### PR TITLE
new performance test framework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,8 @@ dependencies {
         zipSigner()
         testFramework(TestFrameworkType.JUnit5)
         testFramework(TestFrameworkType.Plugin.Java)
+        testFramework(TestFrameworkType.Platform)
+        testFramework(TestFrameworkType.Metrics)
     }
 }
 

--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.platform.testFramework.core.FileComparisonFailedError
-import com.intellij.rt.execution.junit.FileComparisonFailure
+import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.DefaultLightProjectDescriptor
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
 import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
@@ -24,9 +24,9 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
     protected open fun doFoldingTest(testNameArg: String? = null) {
         val testName = testNameArg ?: getTestName(false)
         val fileName = getTestFileName(testName)
-        rewriteFileOnFailure(fileName, testName) {
+        PlatformTestUtil.newBenchmark(testName) {
             fixture.testFoldingWithCollapseStatus(fileName)
-        }
+        }.attempts(100).start()
     }
 
     protected fun doReadOnlyFoldingTest() {


### PR DESCRIPTION
Metric | Value
-- | --
warmup.attempt.mean.ms | 1392
warmup.attempt.median.ms | 1392
warmup.attempt.min.ms | 1392
warmup.attempt.range.ms | 0
warmup.attempt.sum.ms | 1392
warmup.attempt.count | 1
warmup.attempt.standard.deviation | 0
warmup.attempt.mad.ms | 0
warmup.total.test.duration.ms | 1760
attempt.mean.ms | 78
attempt.median.ms | 78
attempt.min.ms | 78
attempt.range.ms | 0
attempt.sum.ms | 78
attempt.count | 1
attempt.standard.deviation | 0
attempt.mad.ms | 0
total.test.duration.ms | 808



[metrics.performance.json](https://github.com/user-attachments/files/19614776/metrics.performance.json)
