### PR TITLE
Fix append fold region check

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Append.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Append.java
@@ -45,7 +45,7 @@ public class Append extends Operation {
 
     @Override
     public boolean supportsFoldRegions(@NotNull Document document, @Nullable Expression parent) {
-        return super.supportsFoldRegions(document, parent) & operands.size() > 0;
+        return operands.size() > 0 && super.supportsFoldRegions(document, parent);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Avoid accessing operation fold checks when append has no operands

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_68aa10710910832eb6d618906d9326cd