### PR TITLE
Remove branch filter from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ name: Build
 on:
   # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g., for dependabot pull requests)
   push:
-    branches: [ main ]
     paths-ignore:
       - '.github/**'
       - 'wiki'


### PR DESCRIPTION
## Summary
- allow build workflow to run on any branch by removing restrictive branches filter

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68aa372b691c832e86157d81a0f6ca16