### PR TITLE
ci: simplify release draft dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,7 +235,7 @@ jobs:
   releaseDraft:
     name: Release draft
     if: github.event_name != 'pull_request'
-    needs: [ build, test, inspectCode, verify ]
+    needs: [ build, test ]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- use only build and test jobs before creating release draft

## Testing
- `yamllint .github/workflows/build.yml` *(fails: line length, trailing spaces, bracket spacing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3b7efbb8832e890e272411256e98