### PR TITLE
fix(ci): use Java 17 for integration tests

### DIFF
--- a/.github/workflows/todo-integration-test.yml
+++ b/.github/workflows/todo-integration-test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 21
+          java-version: 17
 
       - name: Build plugin
         shell: bash


### PR DESCRIPTION
## Summary
- align integration test workflow with project JDK 17

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68acc357b9f0832e91f8dccdfd55e77f