### PR TITLE
docs: remove HTML from package summaries

### DIFF
--- a/package-info-gen.main.kts
+++ b/package-info-gen.main.kts
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S kotlinc -script --
+import java.io.File
+import java.util.Locale
+
+val srcDir = File("src")
+
+fun camelToSentence(name: String): String {
+    return name
+        .replace(Regex("([a-z])([A-Z])"), "$1 $2")
+        .toLowerCase(Locale.ROOT)
+}
+
+data class PackageInfo(
+    val classes: MutableList<String> = mutableListOf(),
+    var hasJava: Boolean = false
+)
+
+val packages = mutableMapOf<File, PackageInfo>()
+
+srcDir.walkTopDown()
+    .filter { it.isFile && (it.extension == "java" || it.extension == "kt") && it.name != "package-info.java" && it.name != "package-info.kt" }
+    .forEach { file ->
+        val dir = file.parentFile
+        val info = packages.computeIfAbsent(dir) { PackageInfo() }
+        info.classes.add(file.nameWithoutExtension)
+        if (file.extension == "java") info.hasJava = true
+    }
+
+packages.forEach { (dir, info) ->
+    val pkgName = dir.relativeTo(srcDir).path.replace(File.separatorChar, '.')
+    val sb = StringBuilder()
+    sb.append("/**\n")
+    sb.append(" * Provides classes:\n")
+    info.classes.sorted().forEach { cls ->
+        sb.append(" * - ")
+        sb.append(cls)
+        sb.append(" - ")
+        sb.append(camelToSentence(cls))
+        sb.append("\n")
+    }
+    sb.append(" */\n")
+
+    val ext = if (info.hasJava) "java" else "kt"
+    if (ext == "kt") {
+        sb.append("@file:JvmName(\"package-info\")\n")
+        sb.append("package ")
+        sb.append(pkgName)
+        sb.append("\n")
+        File(dir, "package-info.java").takeIf { it.exists() }?.delete()
+    } else {
+        sb.append("package ")
+        sb.append(pkgName)
+        sb.append(";\n")
+        File(dir, "package-info.kt").takeIf { it.exists() }?.delete()
+    }
+
+    File(dir, "package-info.$ext").writeText(sb.toString())
+    println("Generated package-info.$ext for $pkgName")
+}

--- a/src/com/intellij/advancedExpressionFolding/action/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/package-info.kt
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - FindMethodsWithDefaultParametersAction - find methods with default parameters action
+ * - FoldingOffAction - folding off action
+ * - FoldingOnAction - folding on action
+ * - GlobalToggleFoldingAction - global toggle folding action
+ * - UpdateFoldedTextColorsAction - update folded text colors action
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.action

--- a/src/com/intellij/advancedExpressionFolding/diff/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/diff/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - FolderTagMetadata - folder tag metadata
+ * - FoldingTemporaryEditor - folding temporary editor
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.diff

--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Provides classes:
+ * - AbstractControlFlowCodeBlock - abstract control flow code block
+ * - CompactControlFlowExpression - compact control flow expression
+ * - ControlFlowMultiStatementCodeBlockExpression - control flow multi statement code block expression
+ * - ControlFlowSingleStatementCodeBlockExpression - control flow single statement code block expression
+ * - ElvisExpression - elvis expression
+ * - ForEachIndexedStatement - for each indexed statement
+ * - ForEachStatement - for each statement
+ * - ForStatement - for statement
+ * - IfExpression - if expression
+ * - SemicolonExpression - semicolon expression
+ * - ShortElvisExpression - short elvis expression
+ */
+package com.intellij.advancedExpressionFolding.expression.controlflow;

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Provides classes:
+ * - ArrayLiteral - array literal
+ * - CharSequenceLiteral - char sequence literal
+ * - CharacterLiteral - character literal
+ * - InterpolatedString - interpolated string
+ * - ListLiteral - list literal
+ * - LocalDateLiteral - local date literal
+ * - NumberLiteral - number literal
+ * - SetLiteral - set literal
+ * - StringLiteral - string literal
+ */
+package com.intellij.advancedExpressionFolding.expression.literal;

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Provides classes:
+ * - Cbrt - cbrt
+ * - Ceil - ceil
+ * - Exp - exp
+ * - Floor - floor
+ * - Gcd - gcd
+ * - Log - log
+ * - Log10 - log10
+ * - Pow - pow
+ * - Random - random
+ * - Rint - rint
+ * - Round - round
+ * - Sqrt - sqrt
+ * - Ulp - ulp
+ */
+package com.intellij.advancedExpressionFolding.expression.math.advanced;

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Provides classes:
+ * - Abs - abs
+ * - Add - add
+ * - AddAllAssign - add all assign
+ * - AddAssign - add assign
+ * - Divide - divide
+ * - DivideAssign - divide assign
+ * - Max - max
+ * - Min - min
+ * - Multiply - multiply
+ * - MultiplyAssign - multiply assign
+ * - Negate - negate
+ * - Not - not
+ * - NotEqual - not equal
+ * - Signum - signum
+ * - Subtract - subtract
+ * - SubtractAssign - subtract assign
+ */
+package com.intellij.advancedExpressionFolding.expression.math.basic;

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Provides classes:
+ * - And - and
+ * - AndAssign - and assign
+ * - Or - or
+ * - Remainder - remainder
+ * - RemainderAssign - remainder assign
+ * - ShiftLeft - shift left
+ * - ShiftLeftAssign - shift left assign
+ * - ShiftRight - shift right
+ * - ShiftRightAssign - shift right assign
+ * - Xor - xor
+ */
+package com.intellij.advancedExpressionFolding.expression.math.bitwise;

--- a/src/com/intellij/advancedExpressionFolding/expression/math/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Provides classes:
+ * - ArithmeticExpression - arithmetic expression
+ */
+package com.intellij.advancedExpressionFolding.expression.math;

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Provides classes:
+ * - Acos - acos
+ * - Asin - asin
+ * - Atan - atan
+ * - Atan2 - atan2
+ * - Cos - cos
+ * - Cosh - cosh
+ * - Sin - sin
+ * - Sinh - sinh
+ * - Tan - tan
+ * - Tanh - tanh
+ * - ToDegrees - to degrees
+ * - ToRadians - to radians
+ */
+package com.intellij.advancedExpressionFolding.expression.math.trig;

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/basic/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/basic/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - Append - append
+ * - Equal - equal
+ * - Greater - greater
+ * - GreaterEqual - greater equal
+ * - TypeCast - type cast
+ * - Variable - variable
+ */
+package com.intellij.advancedExpressionFolding.expression.operation.basic;

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/collection/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/collection/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Provides classes:
+ * - AddAssignForCollection - add assign for collection
+ * - ArrayGet - array get
+ * - ArrayStream - array stream
+ * - Collect - collect
+ * - Put - put
+ * - Range - range
+ * - Remove - remove
+ * - RemoveAllAssign - remove all assign
+ * - RemoveAssignForCollection - remove assign for collection
+ * - Slice - slice
+ */
+package com.intellij.advancedExpressionFolding.expression.operation.collection;

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Provides classes:
+ * - OptionalMapCall - optional map call
+ * - OptionalMapSafeCall - optional map safe call
+ * - OptionalMapSafeCallParam - optional map safe call param
+ * - OptionalNotNullAssertionGet - optional not null assertion get
+ * - OptionalOf - optional of
+ * - OptionalOfNullable - optional of nullable
+ * - OptionalOrElseElvis - optional or else elvis
+ */
+package com.intellij.advancedExpressionFolding.expression.operation.optional;

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Provides classes:
+ * - FieldShiftMethod - field shift method
+ * - Get - get
+ */
+package com.intellij.advancedExpressionFolding.expression.operation;

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/stream/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/stream/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - StreamExpression - stream expression
+ * - StreamFilterNotNull - stream filter not null
+ * - StreamMapCall - stream map call
+ * - StreamMapCallParam - stream map call param
+ * - StringExpression - string expression
+ * - StringOperation - string operation
+ */
+package com.intellij.advancedExpressionFolding.expression.operation.stream;

--- a/src/com/intellij/advancedExpressionFolding/expression/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Provides classes:
+ * - Expression - expression
+ * - Function - function
+ * - Operation - operation
+ * - SyntheticExpressionImpl - synthetic expression impl
+ * - VariableDeclarationImpl - variable declaration impl
+ */
+package com.intellij.advancedExpressionFolding.expression;

--- a/src/com/intellij/advancedExpressionFolding/expression/property/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Provides classes:
+ * - Getter - getter
+ * - GetterRecord - getter record
+ * - IGetter - igetter
+ * - INameable - inameable
+ * - Setter - setter
+ */
+package com.intellij.advancedExpressionFolding.expression.property;

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/kotlin/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/kotlin/package-info.kt
@@ -1,0 +1,12 @@
+/**
+ * Provides classes:
+ * - CheckNotNullExpression - check not null expression
+ * - DestructuringExpression - destructuring expression
+ * - ElvisReturnNull - elvis return null
+ * - FieldConstExpression - field const expression
+ * - IfNullSafeExpression - if null safe expression
+ * - LetReturnIt - let return it
+ * - PrintlnExpression - println expression
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.expression.semantic.kotlin

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/logging/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/logging/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - LoggerBracketExpression - logger bracket expression
+ * - LoggerBracketParentExpression - logger bracket parent expression
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.expression.semantic.logging

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/package-info.kt
@@ -1,0 +1,9 @@
+/**
+ * Provides classes:
+ * - ClassAnnotationExpression - class annotation expression
+ * - FieldAnnotationExpression - field annotation expression
+ * - InterfacePropertiesExpression - interface properties expression
+ * - NullAnnotationExpression - null annotation expression
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.expression.semantic.lombok

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/package-info.kt
@@ -1,0 +1,14 @@
+/**
+ * Provides classes:
+ * - AbstractMultiExpression - abstract multi expression
+ * - AbstractSingleChildExpression - abstract single child expression
+ * - BuilderShiftExpression - builder shift expression
+ * - DynamicExpression - dynamic expression
+ * - FastExpression - fast expression
+ * - HideExpression - hide expression
+ * - SimpleExpression - simple expression
+ * - WrapAroundExpression - wrap around expression
+ * - WrapperExpression - wrapper expression
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.expression.semantic

--- a/src/com/intellij/advancedExpressionFolding/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Provides classes:
+ * - AdvancedExpressionFoldingBuilder - advanced expression folding builder
+ * - EmptyStorage - empty storage
+ * - FoldingEditorCreatedListener - folding editor created listener
+ * - FoldingService - folding service
+ * - MainAnnotationCompletionContributor - main annotation completion contributor
+ * - MethodCallFoldingLoaderService - method call folding loader service
+ * - PluginUnloadingListener - plugin unloading listener
+ */
+package com.intellij.advancedExpressionFolding;

--- a/src/com/intellij/advancedExpressionFolding/processor/cache/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - CacheExt - cache ext
+ * - Keys - keys
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.cache

--- a/src/com/intellij/advancedExpressionFolding/processor/controlflow/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/controlflow/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides classes:
+ * - ForStatementExpressionExt - for statement expression ext
+ * - IfExt - if ext
+ * - LoopExt - loop ext
+ * - PsiTryStatementExt - psi try statement ext
+ */
+package com.intellij.advancedExpressionFolding.processor.controlflow;

--- a/src/com/intellij/advancedExpressionFolding/processor/core/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides classes:
+ * - BaseExtension - base extension
+ * - BuildExpressionExt - build expression ext
+ * - ExpressionBuilderManager - expression builder manager
+ * - buildExpression - build expression
+ */
+package com.intellij.advancedExpressionFolding.processor.core;

--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - PsiClassExt - psi class ext
+ * - PsiCodeBlockExt - psi code block ext
+ * - PsiDeclarationStatementExt - psi declaration statement ext
+ * - PsiFieldExt - psi field ext
+ * - PsiMethodExt - psi method ext
+ * - PsiVariableExt - psi variable ext
+ */
+package com.intellij.advancedExpressionFolding.processor.declaration;

--- a/src/com/intellij/advancedExpressionFolding/processor/expression/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - AssignmentExpressionExt - assignment expression ext
+ * - BinaryExpressionExt - binary expression ext
+ * - LiteralExpressionExt - literal expression ext
+ * - PrefixExpressionExt - prefix expression ext
+ * - PsiArrayAccessExpressionExt - psi array access expression ext
+ * - PsiTypeCastExpressionExt - psi type cast expression ext
+ */
+package com.intellij.advancedExpressionFolding.processor.expression;

--- a/src/com/intellij/advancedExpressionFolding/processor/language/java/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/java/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - ConstructorReferenceExt - constructor reference ext
+ * - PatternMatchingExt - pattern matching ext
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.language.java

--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/package-info.kt
@@ -1,0 +1,12 @@
+/**
+ * Provides classes:
+ * - ConstExt - const ext
+ * - IfNullSafeExt - if null safe ext
+ * - LetReturnExt - let return ext
+ * - MethodDefaultParameterExt - method default parameter ext
+ * - NullableExt - nullable ext
+ * - PrintlnExt - println ext
+ * - SingleExpressionFunctionExt - single expression function ext
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.language.kotlin

--- a/src/com/intellij/advancedExpressionFolding/processor/language/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - ExperimentalExt - experimental ext
+ * - FieldShiftExt - field shift ext
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.language

--- a/src/com/intellij/advancedExpressionFolding/processor/logger/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/package-info.kt
@@ -1,0 +1,9 @@
+/**
+ * Provides classes:
+ * - LoggerBracketsExt - logger brackets ext
+ * - LoggerBracketsExtensionBase - logger brackets extension base
+ * - MarkerLoggerBracketsExtension - marker logger brackets extension
+ * - StringFormattedLoggerBracketsExtension - string formatted logger brackets extension
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.logger

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/package-info.kt
@@ -1,0 +1,16 @@
+/**
+ * Provides classes:
+ * - AnnotationExt - annotation ext
+ * - FieldLevelAnnotation - field level annotation
+ * - InterfacePropertiesExt - interface properties ext
+ * - LombokConstructorExt - lombok constructor ext
+ * - LombokExt - lombok ext
+ * - LombokFieldExt - lombok field ext
+ * - LombokFoldingAnnotation - lombok folding annotation
+ * - LombokMethodExt - lombok method ext
+ * - MethodBodyInspector - method body inspector
+ * - MethodType - method type
+ * - SummaryParentOverrideExt - summary parent override ext
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.lombok

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/package-info.kt
@@ -1,0 +1,27 @@
+/**
+ * Provides classes:
+ * - AbstractArithmeticMethodCall - abstract arithmetic method call
+ * - ArithmeticAbsMethodCall - arithmetic abs method call
+ * - ArithmeticAddMethodCall - arithmetic add method call
+ * - ArithmeticAndMethodCall - arithmetic and method call
+ * - ArithmeticAndNotMethodCall - arithmetic and not method call
+ * - ArithmeticAtan2MethodCall - arithmetic atan2method call
+ * - ArithmeticDivideMethodCall - arithmetic divide method call
+ * - ArithmeticGcdMethodCall - arithmetic gcd method call
+ * - ArithmeticMaxMethodCall - arithmetic max method call
+ * - ArithmeticMinMethodCall - arithmetic min method call
+ * - ArithmeticMultiplyMethodCall - arithmetic multiply method call
+ * - ArithmeticNegateMethodCall - arithmetic negate method call
+ * - ArithmeticNotMethodCall - arithmetic not method call
+ * - ArithmeticOrMethodCall - arithmetic or method call
+ * - ArithmeticPlusMethodCall - arithmetic plus method call
+ * - ArithmeticPowMethodCall - arithmetic pow method call
+ * - ArithmeticRemainderMethodCall - arithmetic remainder method call
+ * - ArithmeticShiftLeftMethodCall - arithmetic shift left method call
+ * - ArithmeticShiftRightMethodCall - arithmetic shift right method call
+ * - ArithmeticSignumMethodCall - arithmetic signum method call
+ * - ArithmeticSubtractMethodCall - arithmetic subtract method call
+ * - ArithmeticXorMethodCall - arithmetic xor method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/package-info.kt
@@ -1,0 +1,12 @@
+/**
+ * Provides classes:
+ * - AppendMethodCall - append method call
+ * - CharAtMethodCall - char at method call
+ * - EqualsMethodCall - equals method call
+ * - PrintlnMethodCall - println method call
+ * - SubstringOrSubListMethodCall - substring or sub list method call
+ * - ToStringMethodCall - to string method call
+ * - ValueOfMethodCall - value of method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.basic

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/package-info.kt
@@ -1,0 +1,16 @@
+/**
+ * Provides classes:
+ * - AbstractCollectionMethodCall - abstract collection method call
+ * - ArraysListMethodCall - arrays list method call
+ * - CollectionAddAllMethodCall - collection add all method call
+ * - CollectionAddMethodCall - collection add method call
+ * - CollectionGetMethodCall - collection get method call
+ * - CollectionRemoveAllMethodCall - collection remove all method call
+ * - CollectionRemoveMethodCall - collection remove method call
+ * - CollectionStreamMethodCall - collection stream method call
+ * - CollectionsUnmodifiableListMethodCall - collections unmodifiable list method call
+ * - CollectionsUnmodifiableSetMethodCall - collections unmodifiable set method call
+ * - MapPutMethodCall - map put method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.collection

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/package-info.kt
@@ -1,0 +1,8 @@
+/**
+ * Provides classes:
+ * - AfterDateMethodCall - after date method call
+ * - BeforeDateMethodCall - before date method call
+ * - CreateDateFactoryMethodCall - create date factory method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.date

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/package-info.kt
@@ -1,0 +1,12 @@
+/**
+ * Provides classes:
+ * - AddDynamicMethodFoldingIntention - add dynamic method folding intention
+ * - ConfigurationParser - configuration parser
+ * - DynamicDialog - dynamic dialog
+ * - DynamicExt - dynamic ext
+ * - DynamicMethodCall - dynamic method call
+ * - DynamicMethodCallData - dynamic method call data
+ * - IDynamicDataProvider - idynamic data provider
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/package-info.kt
@@ -1,0 +1,32 @@
+/**
+ * Provides classes:
+ * - AbstractMathMethodCall - abstract math method call
+ * - MathAbsMethodCall - math abs method call
+ * - MathAcosMethodCall - math acos method call
+ * - MathAsinMethodCall - math asin method call
+ * - MathAtanMethodCall - math atan method call
+ * - MathCbrtMethodCall - math cbrt method call
+ * - MathCeilMethodCall - math ceil method call
+ * - MathCosMethodCall - math cos method call
+ * - MathCoshMethodCall - math cosh method call
+ * - MathExpMethodCall - math exp method call
+ * - MathFloorMethodCall - math floor method call
+ * - MathLog10MethodCall - math log10method call
+ * - MathLogMethodCall - math log method call
+ * - MathMaxMethodCall - math max method call
+ * - MathMinMethodCall - math min method call
+ * - MathPowMethodCall - math pow method call
+ * - MathRandomMethodCall - math random method call
+ * - MathRintMethodCall - math rint method call
+ * - MathRoundMethodCall - math round method call
+ * - MathSinMethodCall - math sin method call
+ * - MathSinhMethodCall - math sinh method call
+ * - MathSqrtMethodCall - math sqrt method call
+ * - MathTanMethodCall - math tan method call
+ * - MathTanhMethodCall - math tanh method call
+ * - MathToDegreesMethodCall - math to degrees method call
+ * - MathToRadiansMethodCall - math to radians method call
+ * - MathUlpMethodCall - math ulp method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.math

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/package-info.kt
@@ -1,0 +1,6 @@
+/**
+ * Provides classes:
+ * - CheckNotNullMethodCall - check not null method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.nullable

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/package-info.kt
@@ -1,0 +1,11 @@
+/**
+ * Provides classes:
+ * - AbstractOptionalMethodCall - abstract optional method call
+ * - OptionalGetMethodCall - optional get method call
+ * - OptionalMapMethodCall - optional map method call
+ * - OptionalOfMethodCall - optional of method call
+ * - OptionalOfNullableMethodCall - optional of nullable method call
+ * - OptionalOrElseMethodCall - optional or else method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.optional

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - AbstractMethodCall - abstract method call
+ * - Context - context
+ * - MethodCallExpressionExt - method call expression ext
+ * - MethodCallFactory - method call factory
+ * - MethodCallManager - method call manager
+ * - NeedsQualifier - needs qualifier
+ */
+package com.intellij.advancedExpressionFolding.processor.methodcall;

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/package-info.kt
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - AbstractStreamMethodCall - abstract stream method call
+ * - StreamCollectMethodCall - stream collect method call
+ * - StreamFilterMethodCall - stream filter method call
+ * - StreamMapMethodCall - stream map method call
+ * - StreamMethodCall - stream method call
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.methodcall.stream

--- a/src/com/intellij/advancedExpressionFolding/processor/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/package-info.kt
@@ -1,0 +1,11 @@
+/**
+ * Provides classes:
+ * - collectionExtensions - collection extensions
+ * - extensions - extensions
+ * - psiElementExtensions - psi element extensions
+ * - psiElementSimplifier - psi element simplifier
+ * - psiElementToExpressionExtensions - psi element to expression extensions
+ * - textRangeExtensions - text range extensions
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor

--- a/src/com/intellij/advancedExpressionFolding/processor/reference/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/reference/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - MethodReferenceExt - method reference ext
+ * - NewExpressionExt - new expression ext
+ * - ReferenceExpressionExt - reference expression ext
+ */
+package com.intellij.advancedExpressionFolding.processor.reference;

--- a/src/com/intellij/advancedExpressionFolding/processor/token/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/token/package-info.kt
@@ -1,0 +1,7 @@
+/**
+ * Provides classes:
+ * - PsiJavaTokenExt - psi java token ext
+ * - PsiKeywordExt - psi keyword ext
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.processor.token

--- a/src/com/intellij/advancedExpressionFolding/processor/util/package-info.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Provides classes:
+ * - CodeGenerationUtil - code generation util
+ * - Consts - consts
+ * - GenericCallback - generic callback
+ * - Helper - helper
+ * - PropertyUtil - property util
+ */
+package com.intellij.advancedExpressionFolding.processor.util;

--- a/src/com/intellij/advancedExpressionFolding/settings/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/package-info.kt
@@ -1,0 +1,10 @@
+/**
+ * Provides classes:
+ * - AdvancedExpressionFoldingSettings - advanced expression folding settings
+ * - IConfig - iconfig
+ * - ILessImportantState - iless important state
+ * - IState - istate
+ * - StateDelegate - state delegate
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.settings

--- a/src/com/intellij/advancedExpressionFolding/settings/view/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/package-info.kt
@@ -1,0 +1,8 @@
+/**
+ * Provides classes:
+ * - CheckboxesProvider - checkboxes provider
+ * - SettingsConfigurable - settings configurable
+ * - checkboxDsl - checkbox dsl
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.settings.view

--- a/src/com/intellij/advancedExpressionFolding/view/package-info.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/package-info.kt
@@ -1,0 +1,6 @@
+/**
+ * Provides classes:
+ * - FindUsageCustomView - find usage custom view
+ */
+@file:JvmName("package-info")
+package com.intellij.advancedExpressionFolding.view


### PR DESCRIPTION
## Summary
- strip HTML from package-level summaries
- generate Kotlin `package-info.kt` files for packages without Java classes

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68acc289af4c832eb7ab2473d11fac95