### PR TITLE
perf: read text from document

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/Expression.java
+++ b/src/com/intellij/advancedExpressionFolding/expression/Expression.java
@@ -26,7 +26,8 @@ public abstract class Expression {
 
     @Override
     public String toString() {
-        return element.getText(); // TODO: Use document.getText(textRange)
+        Document document = element.getContainingFile().getViewProvider().getDocument();
+        return document != null ? document.getText(textRange) : element.getText();
     }
 
     public boolean supportsFoldRegions(@NotNull Document document,


### PR DESCRIPTION
## Summary
- avoid PsiElement#getText in Expression.toString by using Document API for text retrieval

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ab46d123f4832ea89c6efacf7fbff3