### PR TITLE
test: add Set.of folding example

### DIFF
--- a/examples/data/GetSetPutTestData.java
+++ b/examples/data/GetSetPutTestData.java
@@ -33,6 +33,8 @@ public class GetSetPutTestData {
             }
         });
         System.out.println(copyOfSet);
+        Set<String> literal = Set.of("one", "two");
+        System.out.println(literal);
         String[] strings = new String[] {"one", "two"};
         System.out.println(Arrays.toString(strings));
         System.out.println(System.getProperty("user.dir"));

--- a/folded/GetSetPutTestData-folded.java
+++ b/folded/GetSetPutTestData-folded.java
@@ -23,6 +23,8 @@ public class GetSetPutTestData {
         System.out.println(set);
         Set<String> copyOfSet = ["one", "two"];
         System.out.println(copyOfSet);
+        Set<String> literal = ["one", "two"];
+        System.out.println(literal);
         String[] strings = ["one", "two"];
         System.out.println(Arrays.toString(strings));
         System.out.println(System["user.dir"]);

--- a/testData/GetSetPutTestData-all.java
+++ b/testData/GetSetPutTestData-all.java
@@ -33,6 +33,8 @@ public class GetSetPutTestData {
             }</fold></fold><fold text='' expand='false'>
         </fold><fold text=']' expand='false'>}</fold></fold><fold text='' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println(copyOfSet);
+        <fold text='val' expand='false'>Set<String></fold> literal = Set.of("one", "two");
+        <fold text='' expand='false'>System.out.</fold>println(literal);
         <fold text='val' expand='false'>String[]</fold> strings = <fold text='[' expand='false'>new String[] {</fold>"one", "two"<fold text=']' expand='false'>}</fold>;
         <fold text='' expand='false'>System.out.</fold>println(Arrays.toString(strings));
         <fold text='' expand='false'>System.out.</fold>println(System<fold text='[' expand='false'>.getProperty(</fold>"user.dir"<fold text=']' expand='false'>)</fold>);

--- a/testData/GetSetPutTestData.java
+++ b/testData/GetSetPutTestData.java
@@ -33,6 +33,8 @@ public class GetSetPutTestData {
             }</fold></fold><fold text='' expand='false'>
         </fold><fold text=']' expand='false'>}</fold><fold text='' expand='false'></fold>)</fold>;
         System.out.println(copyOfSet);
+        Set<String> literal = <fold text='[' expand='false'>Set.of(</fold>"one", "two"<fold text=']' expand='false'>)</fold>;
+        System.out.println(literal);
         String[] strings = <fold text='[' expand='false'>new String[] {</fold>"one", "two"<fold text=']' expand='false'>}</fold>;
         System.out.println(Arrays.toString(strings));
         System.out.println(System<fold text='[' expand='false'>.getProperty(</fold>"user.dir"<fold text=']' expand='false'>)</fold>);


### PR DESCRIPTION
## Summary
- move Set.of usage into existing Get/Set/Put test data
- drop standalone SetLiteral test and update folded expectations
- add matching Set.of example in the examples project

## Testing
- `./gradlew test --tests com.intellij.advancedExpressionFolding.FoldingTest.getSetPutTestData -x examples:test` *(fails: Cannot find a Java installation matching JetBrains JDK 17)*
- `./gradlew examples:compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68aa411a9118832e8894c24f2869a2fa