### PR TITLE
ci: update build workflow paths-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,16 @@ on:
       - '.github/**'
       - 'wiki'
       - 'wiki/**'
-      - 'build-version.gradle.kts'
-      - '*.md'
+      - '**/*.md'
       - 'pages/**'
   # Trigger the workflow on any pull request
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'wiki'
+      - 'wiki/**'
+      - '**/*.md'
+      - 'pages/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- ensure build workflow ignores markdown and wiki changes on push and pull_request

## Testing
- `python - <<'PY'
import yaml, pathlib
p=pathlib.Path('.github/workflows/build.yml')
with p.open() as f:
    yaml.safe_load(f)
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0bd51a608832eb8cdd6cbefb7e27a