### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['java', 'kotlin']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for CodeQL analysis
- configure workflow to run manually and analyze Java and Kotlin separately using a matrix

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68acc32a61b8832e8a0bbc6eab77bd0a