### PR TITLE
@PublishedApi refactor: make MethodCallFoldingLoaderService internal

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/MethodCallFoldingLoaderService.kt
+++ b/src/com/intellij/advancedExpressionFolding/MethodCallFoldingLoaderService.kt
@@ -5,16 +5,19 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 
 @Service
-class MethodCallFoldingLoaderService {
+internal class MethodCallFoldingLoaderService {
 
-    val factory by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    @PublishedApi
+    internal val factory by lazy(LazyThreadSafetyMode.PUBLICATION) {
         MethodCallFactory.initialize()
     }
 
     companion object {
-        fun get() = service<MethodCallFoldingLoaderService>()
+        @PublishedApi
+        internal fun get() = service<MethodCallFoldingLoaderService>()
         @JvmStatic
-        fun factory() = get().factory
+        @PublishedApi
+        internal fun factory() = get().factory
     }
 }
 


### PR DESCRIPTION
## Summary
- limit MethodCallFoldingLoaderService visibility to internal
- expose factory through internal property and companion functions annotated with PublishedApi

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d0fcc7d8832eae5f1ed48e9e8558