### PR TITLE
fix: correct typos in class names

### DIFF
--- a/examples/data/ConstTestData.java
+++ b/examples/data/ConstTestData.java
@@ -71,7 +71,7 @@ public class ConstTestData {
     static final int VERSION_REF = VERSION;
 
     @SuppressWarnings("ALL")
-    class ConstsWithAnnotaiton {
+    class ConstsWithAnnotation {
         @Deprecated
         static final Pattern PATTERN = Pattern.compile(".*");
 

--- a/folded/ConstTestData-folded.java
+++ b/folded/ConstTestData-folded.java
@@ -71,7 +71,7 @@ public class ConstTestData {
     default const VERSION_REF = VERSION;
 
     @SuppressWarnings("ALL")
-    class ConstsWithAnnotaiton {
+    class ConstsWithAnnotation {
         @Deprecated
         default const PATTERN = Pattern.compile(".*");
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -202,7 +202,7 @@
         <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.TryStatementBuilder"/>
         <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.CatchSectionBuilder"/>
         <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ForStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ForeachStatementBuilder"/>
+        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ForEachStatementBuilder"/>
         <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.WhileStatementBuilder"/>
         <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.DoWhileStatementBuilder"/>
 

--- a/src/com/intellij/advancedExpressionFolding/processor/controlflow/LoopExt.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/controlflow/LoopExt.java
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiForeachStatement;
 import com.intellij.psi.PsiWhileStatement;
 
 public class LoopExt {
-    public static Expression getForeachStatementExpression(PsiForeachStatement element) {
+    public static Expression getForEachStatementExpression(PsiForeachStatement element) {
         AdvancedExpressionFoldingSettings settings = AdvancedExpressionFoldingSettings.getInstance();
         if (element.getIteratedValue() != null && element.getRParenth() != null &&
                 settings.getState().getCompactControlFlowSyntaxCollapse()) {

--- a/src/com/intellij/advancedExpressionFolding/processor/core/buildExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/buildExpression.kt
@@ -41,9 +41,9 @@ class ForStatementBuilder : BuildExpression<PsiForStatement>(PsiForStatement::cl
         ForStatementExpressionExt.getForStatementExpression(element, document)
 }
 
-class ForeachStatementBuilder : BuildExpression<PsiForeachStatement>(PsiForeachStatement::class.java) {
+class ForEachStatementBuilder : BuildExpression<PsiForeachStatement>(PsiForeachStatement::class.java) {
     override fun buildExpression(element: PsiForeachStatement, document: Document, synthetic: Boolean): Expression? =
-        LoopExt.getForeachStatementExpression(element)
+        LoopExt.getForEachStatementExpression(element)
 }
 
 class IfStatementBuilder : BuildExpression<PsiIfStatement>(PsiIfStatement::class.java) {

--- a/testData/ConstTestData-all.java
+++ b/testData/ConstTestData-all.java
@@ -71,7 +71,7 @@ public class ConstTestData {
     <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>int</fold> VERSION_REF = VERSION;
 
     @SuppressWarnings("ALL")
-    class ConstsWithAnnotaiton <fold text='{...}' expand='true'>{
+    class ConstsWithAnnotation <fold text='{...}' expand='true'>{
         @Deprecated
         <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>Pattern</fold> PATTERN = Pattern.compile(".*");
 

--- a/testData/ConstTestData.java
+++ b/testData/ConstTestData.java
@@ -71,7 +71,7 @@ public class ConstTestData {
     <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>int</fold> VERSION_REF = VERSION;
 
     @SuppressWarnings("ALL")
-    class ConstsWithAnnotaiton <fold text='{...}' expand='true'>{
+    class ConstsWithAnnotation <fold text='{...}' expand='true'>{
         @Deprecated
         <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>Pattern</fold> PATTERN = Pattern.compile(".*");
 


### PR DESCRIPTION
## Summary
- rename ForeachStatementBuilder to ForEachStatementBuilder and update loader
- fix misspelled ConstsWithAnnotation class across examples and test data

## Testing
- `./gradlew test` *(fails: execution timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68aabaf882e8832ebec9e6ed936f3736