### PR TITLE
test: cover character literals in interpolated string test

### DIFF
--- a/examples/data/InterpolatedStringTestData.java
+++ b/examples/data/InterpolatedStringTestData.java
@@ -11,5 +11,10 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, " + name + "!");
         System.out.println(name + ", hello!");
         System.out.println(name + ", " + name);
+        System.out.println("Unicode: " + '\u0041');
+        System.out.println("Next: " + (char)('A' + 1));
+        System.out.println("Length: " + args.length);
+        System.out.println("Sum: " + (2 + 3));
+        System.out.println("Upper: " + name.toUpperCase());
     }
 }

--- a/folded/InterpolatedStringTestData-folded.java
+++ b/folded/InterpolatedStringTestData-folded.java
@@ -11,5 +11,10 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, $name!");
         System.out.println("$name, hello!");
         System.out.println("$name, $name");
+        System.out.println("Unicode: ${'\u0041'}");
+        System.out.println("Next: ${(char)('A' + 1)}");
+        System.out.println("Length: ${args.length}");
+        System.out.println("Sum: ${(2 + 3)}");
+        System.out.println("Upper: ${name.toUpperCase()}");
     }
 }

--- a/testData/InterpolatedStringTestData-all.java
+++ b/testData/InterpolatedStringTestData-all.java
@@ -11,5 +11,10 @@ public class InterpolatedStringTestData {
         <fold text='' expand='false'>System.out.</fold>println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
+        <fold text='' expand='false'>System.out.</fold>println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
+        <fold text='' expand='false'>System.out.</fold>println("Next: <fold text='${' expand='false'>" + </fold><fold text='' expand='false'>(char)(</fold>'A' + 1<fold text='' expand='false'>)</fold><fold text='}")' expand='false'>)</fold>;
+        <fold text='' expand='false'>System.out.</fold>println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;
+        <fold text='' expand='false'>System.out.</fold>println("Sum: <fold text='${' expand='false'>" + (</fold>2 + 3<fold text='}")' expand='false'>)</fold>);
+        <fold text='' expand='false'>System.out.</fold>println("Upper: <fold text='${' expand='false'>" + </fold>name.toUpperCase()<fold text='}")' expand='false'>)</fold>;
     }</fold>
 }

--- a/testData/InterpolatedStringTestData.java
+++ b/testData/InterpolatedStringTestData.java
@@ -11,5 +11,10 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
+        System.out.println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
+        System.out.println("Next: <fold text='${' expand='false'>" + </fold>(char)('A' + 1)<fold text='}")' expand='false'>)</fold>;
+        System.out.println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;
+        System.out.println("Sum: <fold text='${' expand='false'>" + </fold>(2 + 3)<fold text='}")' expand='false'>)</fold>;
+        System.out.println("Upper: <fold text='${' expand='false'>" + </fold>name.toUpperCase()<fold text='}")' expand='false'>)</fold>;
     }</fold>
 }


### PR DESCRIPTION
## Summary
- embed character literal examples into existing interpolated string test data
- broaden coverage with array length, numeric, and method call interpolation cases
- update folded and example files for new scenarios

## Testing
- `./gradlew test -x examples:test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68aa411cf904832ebee9bcda3cf20503