### PR TITLE
refactor: simplify visible code extraction

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/diff/FoldingTemporaryEditor.kt
+++ b/src/com/intellij/advancedExpressionFolding/diff/FoldingTemporaryEditor.kt
@@ -30,22 +30,22 @@ object FoldingTemporaryEditor {
 
     private fun getVisibleCode(editor: EditorEx): FoldedCode {
         val document = editor.document
-        val foldedText = StringBuilder(document.textLength)
         var offset = 0
-        for (region in editor.foldingModel.allFoldRegions) {
-            if (region.isValid && region.isExpanded) {
-                val foldStart = region.startOffset
-                try {
-                    foldedText.append(document.getText(TextRange(offset, foldStart)))
-                    foldedText.append(region.placeholderText)
-                    offset = region.endOffset
-                } catch (_: IllegalArgumentException) {
-                    //ignore text that has already been folded
+        return buildString(document.textLength) {
+            for (region in editor.foldingModel.allFoldRegions) {
+                if (region.isValid && region.isExpanded) {
+                    val foldStart = region.startOffset
+                    try {
+                        append(document.getText(TextRange(offset, foldStart)))
+                        append(region.placeholderText)
+                        offset = region.endOffset
+                    } catch (_: IllegalArgumentException) {
+                        //ignore text that has already been folded
+                    }
                 }
             }
+            append(document.getText(TextRange(offset, document.textLength)))
         }
-        foldedText.append(document.getText(TextRange(offset, document.textLength)))
-        return foldedText.toString()
     }
 
     private const val FOLD = "fold"


### PR DESCRIPTION
## Summary
- refactor FoldingTemporaryEditor#getVisibleCode to use `buildString`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d7bc0e78832eb1ca4246d4732212