### PR TITLE
feat: add DSL marker for checkbox builders

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -15,6 +15,7 @@ import kotlin.reflect.KMutableProperty0
 abstract class CheckboxesProvider {
 
     @Suppress("DEPRECATION")
+    @CheckboxDsl
     fun Panel.initialize(state: State) {
         registerCheckbox(state::getSetExpressionsCollapse, "Getters and setters as properties") {
             example("GetterSetterTestData.java")
@@ -276,6 +277,7 @@ abstract class CheckboxesProvider {
         }
     }
 
+    @CheckboxDsl
     abstract fun Panel.registerCheckbox(
         property: KMutableProperty0<Boolean>,
         title: String,

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -168,6 +168,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         private const val EXAMPLE_DIR = "data"
     }
     
+    @CheckboxDsl
     override fun Panel.registerCheckbox(
         property: KMutableProperty0<Boolean>,
         title: String,

--- a/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
@@ -2,6 +2,9 @@ package com.intellij.advancedExpressionFolding.settings.view
 
 import kotlin.reflect.KMutableProperty0
 
+@DslMarker
+annotation class CheckboxDsl
+
 typealias Description = String
 typealias UrlSuffix = String
 typealias ExampleFile = String
@@ -13,6 +16,7 @@ data class CheckboxDefinition(
     val docLink: UrlSuffix? = null
 )
 
+@CheckboxDsl
 class CheckboxBuilder {
     private val examples = mutableMapOf<ExampleFile, Description?>()
     private var docLink: UrlSuffix? = null


### PR DESCRIPTION
## Summary
- add CheckboxDsl marker and annotate checkbox builders
- scope checkbox registration to prevent nested DSL misuse

## Testing
- `./gradlew test`
- `./gradlew -q compileTestKotlin` (expected failure when nesting DSL)


------
https://chatgpt.com/codex/tasks/task_e_68b0d8521f70832ea183dce628c7aa66