### PR TITLE
refactor: categorize settings flags via annotations

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -5,11 +5,9 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import org.jetbrains.annotations.NotNull
-import kotlin.reflect.KClass
-import kotlin.reflect.KMutableProperty
-import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.javaType
 
 @State(name = "AdvancedExpressionFoldingSettings", storages = [Storage("editor.codeinsight.xml")])
 class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpressionFoldingSettings.State> {
@@ -21,52 +19,95 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
     }
 
     data class State(
+        @FoldingFlag(main = true)
         override var concatenationExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var slicingExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var comparingExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var comparingLocalDatesCollapse: Boolean = true,
+        @FoldingFlag
         override var localDateLiteralCollapse: Boolean = false,
+        @FoldingFlag
         override var localDateLiteralPostfixCollapse: Boolean = false,
+        @FoldingFlag(main = true)
         override var getExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var rangeExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var checkExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var castExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var varExpressionsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var getSetExpressionsCollapse: Boolean = true,
+        @FoldingFlag
         override var controlFlowSingleStatementCodeBlockCollapse: Boolean = false,
+        @FoldingFlag(main = true)
         override var compactControlFlowSyntaxCollapse: Boolean = false,
+        @FoldingFlag
         override var controlFlowMultiStatementCodeBlockCollapse: Boolean = false,
+        @FoldingFlag
         override var semicolonsCollapse: Boolean = false,
+        @FoldingFlag(main = true)
         override var assertsCollapse: Boolean = true,
+        @FoldingFlag(main = true)
         override var optional: Boolean = true,
+        @FoldingFlag(main = true)
         override var streamSpread: Boolean = true,
+        @FoldingFlag(main = true)
         override var lombok: Boolean = true,
+        @FoldingFlag(main = true)
         override var fieldShift: Boolean = true,
+        @FoldingFlag(main = true)
         override var kotlinQuickReturn: Boolean = true,
+        @FoldingFlag(main = true)
         override var ifNullSafe: Boolean = true,
+        @FoldingFlag(main = true)
         override var logFolding: Boolean = true,
+        @FoldingFlag
         override var destructuring: Boolean = false,
+        @FoldingFlag(main = true)
         override var println: Boolean = true,
+        @FoldingFlag(main = true)
         override var const: Boolean = true,
+        @FoldingFlag(main = true)
         override var nullable: Boolean = false,
+        @FoldingFlag
         override var finalRemoval: Boolean = false,
+        @FoldingFlag
         @Deprecated("too specific")
         override var finalEmoji: Boolean = false,
+        @FoldingFlag
         override var lombokDirtyOff: Boolean = false,
+        @FoldingFlag
         override var expressionFunc: Boolean = true,
+        @FoldingFlag
         override var dynamic: Boolean = true,
+        @FoldingFlag
         @Deprecated("to be removed")
         override var arithmeticExpressions: Boolean = false,
+        @FoldingFlag
         @Deprecated("it generates too many foldings")
         override var emojify: Boolean = false,
+        @FoldingFlag
         override var interfaceExtensionProperties: Boolean = true,
+        @FoldingFlag
         override var patternMatchingInstanceof: Boolean = true,
+        @FoldingFlag
         override var summaryParentOverride: Boolean = false,
+        @FoldingFlag
         override var constructorReferenceNotation: Boolean = true,
+        @FoldingFlag
         override var methodDefaultParameters: Boolean = true,
         override var lombokPatternOff: String? = null,
+        @FoldingFlag
         override var overrideHide: Boolean = true,
+        @FoldingFlag
         override var suppressWarningsHide: Boolean = true,
+        @FoldingFlag
         override var pseudoAnnotations: Boolean = true,
         // NEW OPTION VAR
 
@@ -77,25 +118,20 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
 
         ) : IState, IConfig
 
-    private fun updateAllState(value: Boolean, vararg excludeProperties: KMutableProperty<Boolean>) {
-        val excluded = excludeProperties.map { it.toString() }
+    private fun updateAllState(value: Boolean, vararg excludeProperties: KMutableProperty1<State, Boolean>) {
+        val excluded = excludeProperties.toSet()
         with(myState) {
-            allProperties()
-                .filter {
-                    !excluded.contains(it.toString())
-                }.forEach {
-                    if (it.setter.parameters.getOrNull(1)?.type?.javaType?.typeName == "boolean") {
-                        it.setter.call(this, value)
-                    }
-                }
+            configurableFlags()
+                .filterNot { excluded.contains(it) }
+                .forEach { it.set(this, value) }
         }
     }
 
     fun disableAll() = updateAllState(false)
-    fun enableAll(vararg excludeProperties: KMutableProperty0<Boolean>) = updateAllState(true, *excludeProperties)
+    fun enableAll(vararg excludeProperties: KMutableProperty1<State, Boolean>) = updateAllState(true, *excludeProperties)
 
     // used in integrationStubs
-    fun enableEverything() = updateAllState(true, state::emojify, state::finalEmoji)
+    fun enableEverything() = updateAllState(true, State::emojify, State::finalEmoji)
 
     companion object {
         @JvmStatic
@@ -103,19 +139,27 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
         fun getInstance(): AdvancedExpressionFoldingSettings =
             ApplicationManager.getApplication().getService(AdvancedExpressionFoldingSettings::class.java)
 
-        fun allProperties() = State::class.memberProperties
-            .filterIsInstance<KMutableProperty<Boolean>>()
-            .filter { property ->
-                exclude(IConfig::class, property)
-            }
-
-        fun allMainProperties() = allProperties().filter { property ->
-            exclude(ILessImportantState::class, property)
-        }
-
-        private fun exclude(
-            kClass: KClass<*>,
-            property: KMutableProperty<*>
-        ) = !kClass.memberProperties.map { it.name }.contains(property.name)
+        fun allMainProperties(): List<KMutableProperty1<State, Boolean>> =
+            getInstance().state.mainFlags()
     }
 }
+
+private fun AdvancedExpressionFoldingSettings.State.configurableFlags(): List<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>> =
+    this::class.memberProperties
+        .mapNotNull { prop ->
+            prop.findAnnotation<FoldingFlag>()?.let {
+                prop as? KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>
+            }
+        }
+
+private fun AdvancedExpressionFoldingSettings.State.mainFlags(): List<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>> =
+    this::class.memberProperties
+        .mapNotNull { prop ->
+            prop.findAnnotation<FoldingFlag>()?.takeIf { it.main }?.let {
+                prop as? KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>
+            }
+        }
+
+@Target(AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.RUNTIME)
+private annotation class FoldingFlag(val main: Boolean = false)

--- a/test/com/intellij/advancedExpressionFolding/CrazyFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/CrazyFoldingTest.kt
@@ -1,9 +1,8 @@
 package com.intellij.advancedExpressionFolding
 
 import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.allMainProperties
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import junit.framework.ComparisonFailure
 import org.junit.AssumptionViolatedException
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -16,7 +15,7 @@ import java.io.FileOutputStream
 import java.util.*
 import java.util.stream.Stream
 import kotlin.math.pow
-import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KMutableProperty1
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -24,10 +23,6 @@ import kotlin.time.toDuration
 class CrazyFoldingTest : BaseTest() {
 
     class TooComplexException : AssumptionViolatedException("TOO COMPLEX FOLDING")
-
-    private val state: State by lazy {
-        getInstance().state
-    }
 
     private fun File.saveCounterAndFilename(counter: Long, filename: String) {
         val properties = Properties()
@@ -70,9 +65,13 @@ class CrazyFoldingTest : BaseTest() {
 
     @ParameterizedTest
     @MethodSource("permutations")
-    fun testLombokTestData(booleans: BooleanArray, props: List<KMutableProperty<*>>) {
+    fun testLombokTestData(
+        booleans: BooleanArray,
+        props: List<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>>
+    ) {
+        val state = AdvancedExpressionFoldingSettings.getInstance().state
         val message = props.zip(booleans.toList()).map { (prop, value) ->
-            prop.setter.call(state, value)
+            prop.set(state, value)
             if (value) {
                 prop.name
             } else {
@@ -93,7 +92,7 @@ class CrazyFoldingTest : BaseTest() {
             CONFIG_FILE.readCounterAndFilename()?.let { (count: Long, _: String) ->
                 counter = count
             }
-            val props: List<KMutableProperty<*>> = allMainProperties()
+            val props: List<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>> = allMainProperties()
             val numBooleans = props.size
             return Stream.iterate(BooleanArray(numBooleans)) { prev ->
                 val next = prev.clone()

--- a/test/com/intellij/advancedExpressionFolding/FullFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FullFoldingTest.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding
 
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
@@ -9,7 +10,8 @@ import kotlin.reflect.KMutableProperty0
 class FullFoldingTest : FoldingTest() {
 
     @Suppress("DEPRECATION")
-    override fun assignState(turnOnProperties: Array<out KMutableProperty0<Boolean>>) = getInstance().enableAll(state::emojify, state::finalEmoji, state::arithmeticExpressions)
+    override fun assignState(turnOnProperties: Array<out KMutableProperty0<Boolean>>) =
+        getInstance().enableAll(State::emojify, State::finalEmoji, State::arithmeticExpressions)
 
     override fun getTestFileName(testName: String): String {
         val baseFile = super.getTestFileName(testName)


### PR DESCRIPTION
## Summary
- mark settings flags with a runtime `@FoldingFlag` annotation to derive configurable and main flag lists
- update tests to use `KMutableProperty1` references with the annotated flags
- adjust full folding test to pass unbound state property references

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d84f2a0c832ea69b41e0ed4d9cb5