### PR TITLE
refactor: use delegates for settings tracking

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -5,11 +5,14 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import org.jetbrains.annotations.NotNull
+import kotlin.properties.Delegates
+import kotlin.properties.PropertyDelegateProvider
+import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty
 import kotlin.reflect.KMutableProperty0
+import kotlin.reflect.KProperty
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.javaType
 
 @State(name = "AdvancedExpressionFoldingSettings", storages = [Storage("editor.codeinsight.xml")])
 class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpressionFoldingSettings.State> {
@@ -20,74 +23,101 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
         myState = state.copy()
     }
 
-    data class State(
-        override var concatenationExpressionsCollapse: Boolean = true,
-        override var slicingExpressionsCollapse: Boolean = true,
-        override var comparingExpressionsCollapse: Boolean = true,
-        override var comparingLocalDatesCollapse: Boolean = true,
-        override var localDateLiteralCollapse: Boolean = false,
-        override var localDateLiteralPostfixCollapse: Boolean = false,
-        override var getExpressionsCollapse: Boolean = true,
-        override var rangeExpressionsCollapse: Boolean = true,
-        override var checkExpressionsCollapse: Boolean = true,
-        override var castExpressionsCollapse: Boolean = true,
-        override var varExpressionsCollapse: Boolean = true,
-        override var getSetExpressionsCollapse: Boolean = true,
-        override var controlFlowSingleStatementCodeBlockCollapse: Boolean = false,
-        override var compactControlFlowSyntaxCollapse: Boolean = false,
-        override var controlFlowMultiStatementCodeBlockCollapse: Boolean = false,
-        override var semicolonsCollapse: Boolean = false,
-        override var assertsCollapse: Boolean = true,
-        override var optional: Boolean = true,
-        override var streamSpread: Boolean = true,
-        override var lombok: Boolean = true,
-        override var fieldShift: Boolean = true,
-        override var kotlinQuickReturn: Boolean = true,
-        override var ifNullSafe: Boolean = true,
-        override var logFolding: Boolean = true,
-        override var destructuring: Boolean = false,
-        override var println: Boolean = true,
-        override var const: Boolean = true,
-        override var nullable: Boolean = false,
-        override var finalRemoval: Boolean = false,
+    class State : IState, IConfig {
+        internal val delegatedProperties = mutableMapOf<String, BooleanDelegate>()
+        internal val changedProperties = mutableSetOf<String>()
+
+        private fun boolean(default: Boolean): PropertyDelegateProvider<State, BooleanDelegate> =
+            PropertyDelegateProvider { thisRef, property ->
+                BooleanDelegate(property.name, default, thisRef.changedProperties)
+                    .also { thisRef.delegatedProperties[property.name] = it }
+            }
+
+        override var concatenationExpressionsCollapse: Boolean by boolean(true)
+        override var slicingExpressionsCollapse: Boolean by boolean(true)
+        override var comparingExpressionsCollapse: Boolean by boolean(true)
+        override var comparingLocalDatesCollapse: Boolean by boolean(true)
+        override var localDateLiteralCollapse: Boolean by boolean(false)
+        override var localDateLiteralPostfixCollapse: Boolean by boolean(false)
+        override var getExpressionsCollapse: Boolean by boolean(true)
+        override var rangeExpressionsCollapse: Boolean by boolean(true)
+        override var checkExpressionsCollapse: Boolean by boolean(true)
+        override var castExpressionsCollapse: Boolean by boolean(true)
+        override var varExpressionsCollapse: Boolean by boolean(true)
+        override var getSetExpressionsCollapse: Boolean by boolean(true)
+        override var controlFlowSingleStatementCodeBlockCollapse: Boolean by boolean(false)
+        override var compactControlFlowSyntaxCollapse: Boolean by boolean(false)
+        override var controlFlowMultiStatementCodeBlockCollapse: Boolean by boolean(false)
+        override var semicolonsCollapse: Boolean by boolean(false)
+        override var assertsCollapse: Boolean by boolean(true)
+        override var optional: Boolean by boolean(true)
+        override var streamSpread: Boolean by boolean(true)
+        override var lombok: Boolean by boolean(true)
+        override var fieldShift: Boolean by boolean(true)
+        override var kotlinQuickReturn: Boolean by boolean(true)
+        override var ifNullSafe: Boolean by boolean(true)
+        override var logFolding: Boolean by boolean(true)
+        override var destructuring: Boolean by boolean(false)
+        override var println: Boolean by boolean(true)
+        override var const: Boolean by boolean(true)
+        override var nullable: Boolean by boolean(false)
+        override var finalRemoval: Boolean by boolean(false)
         @Deprecated("too specific")
-        override var finalEmoji: Boolean = false,
-        override var lombokDirtyOff: Boolean = false,
-        override var expressionFunc: Boolean = true,
-        override var dynamic: Boolean = true,
+        override var finalEmoji: Boolean by boolean(false)
+        override var lombokDirtyOff: Boolean by boolean(false)
+        override var expressionFunc: Boolean by boolean(true)
+        override var dynamic: Boolean by boolean(true)
         @Deprecated("to be removed")
-        override var arithmeticExpressions: Boolean = false,
+        override var arithmeticExpressions: Boolean by boolean(false)
         @Deprecated("it generates too many foldings")
-        override var emojify: Boolean = false,
-        override var interfaceExtensionProperties: Boolean = true,
-        override var patternMatchingInstanceof: Boolean = true,
-        override var summaryParentOverride: Boolean = false,
-        override var constructorReferenceNotation: Boolean = true,
-        override var methodDefaultParameters: Boolean = true,
-        override var lombokPatternOff: String? = null,
-        override var overrideHide: Boolean = true,
-        override var suppressWarningsHide: Boolean = true,
-        override var pseudoAnnotations: Boolean = true,
+        override var emojify: Boolean by boolean(false)
+        override var interfaceExtensionProperties: Boolean by boolean(true)
+        override var patternMatchingInstanceof: Boolean by boolean(true)
+        override var summaryParentOverride: Boolean by boolean(false)
+        override var constructorReferenceNotation: Boolean by boolean(true)
+        override var methodDefaultParameters: Boolean by boolean(true)
+        override var lombokPatternOff: String? = null
+        override var overrideHide: Boolean by boolean(true)
+        override var suppressWarningsHide: Boolean by boolean(true)
+        override var pseudoAnnotations: Boolean by boolean(true)
         // NEW OPTION VAR
 
-        override var memoryImprovement: Boolean = true,
-        override var experimental: Boolean = false,
+        override var memoryImprovement: Boolean by boolean(true)
+        override var experimental: Boolean by boolean(false)
 
-        override var globalOn: Boolean = true,
+        override var globalOn: Boolean by boolean(true)
 
-        ) : IState, IConfig
+        fun copy(): State {
+            val copy = State()
+            copy.lombokPatternOff = this.lombokPatternOff
+            delegatedProperties.forEach { (name, delegate) ->
+                copy.delegatedProperties[name]?.value = delegate.value
+            }
+            return copy
+        }
 
-    private fun updateAllState(value: Boolean, vararg excludeProperties: KMutableProperty<Boolean>) {
-        val excluded = excludeProperties.map { it.toString() }
-        with(myState) {
-            allProperties()
-                .filter {
-                    !excluded.contains(it.toString())
-                }.forEach {
-                    if (it.setter.parameters.getOrNull(1)?.type?.javaType?.typeName == "boolean") {
-                        it.setter.call(this, value)
-                    }
-                }
+        internal class BooleanDelegate(
+            private val name: String,
+            initial: Boolean,
+            private val changed: MutableSet<String>
+        ) : ReadWriteProperty<State, Boolean> {
+            var value: Boolean by Delegates.observable(initial) { _, old, new ->
+                if (old != new) changed += name
+            }
+
+            override fun getValue(thisRef: State, property: KProperty<*>) = value
+            override fun setValue(thisRef: State, property: KProperty<*>, value: Boolean) {
+                this.value = value
+            }
+        }
+    }
+
+    private fun updateAllState(value: Boolean, vararg excludeProperties: KMutableProperty0<Boolean>) {
+        val excluded = (excludeProperties.map { it.name } + IConfig::class.memberProperties.map { it.name }).toSet()
+        myState.delegatedProperties.forEach { (name, delegate) ->
+            if (name !in excluded) {
+                delegate.value = value
+            }
         }
     }
 
@@ -119,3 +149,4 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
         ) = !kClass.memberProperties.map { it.name }.contains(property.name)
     }
 }
+


### PR DESCRIPTION
## Summary
- track settings changes via delegated properties
- drop reflection-based bulk state updates in favor of delegate iteration
- ignore config flags when applying bulk state toggles so global toggle remains intact

## Testing
- `./gradlew test --rerun-tasks`

------
https://chatgpt.com/codex/tasks/task_e_68b0d7d2df90832eb6b5aebf2ce1255d