### PR TITLE
fix: add GlobalToggleFoldingAction to Code menu

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,7 +49,9 @@
         </group>
 
         <action id="com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"
-                class="com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"/>
+                class="com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction">
+            <add-to-group group-id="CodeMenu" anchor="last"/>
+        </action>
 
         <action id="com.intellij.advancedExpressionFolding.action.FoldingOnAction"
                 class="com.intellij.advancedExpressionFolding.action.FoldingOnAction"


### PR DESCRIPTION
Fixes #278 

## Summary
- add GlobalToggleFoldingAction to Code menu in plugin configuration

## Testing
- `./gradlew test` *(fails: command did not complete within the time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68b14766347c832e95ec007ae0078f0b