### PR TITLE
ci: expose plugin artifacts

### DIFF
--- a/.github/workflows/build-jar.yml
+++ b/.github/workflows/build-jar.yml
@@ -1,0 +1,43 @@
+# Workflow for building the plugin JAR and exposing the distribution artifacts
+name: Build Jar
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      zip: ${{ steps.build.outputs.zip }}
+      jar: ${{ steps.build.outputs.jar }}
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Build plugin
+        id: build
+        uses: ./.github/actions/build-plugin
+
+      - name: Upload plugin jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jar
+          path: ${{ steps.build.outputs.jar }}
+
+      - name: Show distribution paths
+        run: |
+          echo "ZIP located at ${{ steps.build.outputs.zip }}"
+          echo "JAR located at ${{ steps.build.outputs.jar }}"


### PR DESCRIPTION
## Summary
- add workflow that builds the plugin and exposes ZIP and JAR artifact paths
- upload built plugin JAR as an artifact
- rename workflow to build jar

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d8c57d88832e836bb9ae60c1f672