### PR TITLE
ci: update build workflow paths-ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,19 +17,23 @@ on:
   # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g., for dependabot pull requests)
   push:
     paths-ignore:
-      - '.github/**'
       - 'wiki'
       - 'wiki/**'
       - '**/*.md'
       - 'pages/**'
+      - 'complete-project-documentation.yaml'
+      - '**/*.sh'
+      - '**/*.main.kts'
   # Trigger the workflow on any pull request
   pull_request:
     paths-ignore:
-      - '.github/**'
       - 'wiki'
       - 'wiki/**'
       - '**/*.md'
       - 'pages/**'
+      - 'complete-project-documentation.yaml'
+      - '**/*.sh'
+      - '**/*.main.kts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- avoid skipping build workflow when only CI files change by ignoring only markdown, wiki, and page paths
- also ignore `complete-project-documentation.yaml`, shell scripts, and `*.main.kts` scripts

## Testing
- `python - <<'PY'
import yaml, pathlib
p=pathlib.Path('.github/workflows/build.yml')
with p.open() as f:
    yaml.safe_load(f)
print('YAML OK')
PY`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d9617418832eab7af4e439dbc73f