### PR TITLE
refactor: use enum for cache keys

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -6,6 +6,7 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.asInstance
 import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
 import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.openapi.util.Key
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
 import com.intellij.advancedExpressionFolding.settings.IConfig
@@ -50,7 +51,8 @@ class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance
         if (!quick) {
             (element as? PsiJavaFile)?.let { file ->
                 if (!file.invalidateExpired(document, false)) {
-                    return file.getUserData(Keys.FULL_CACHE)
+                    @Suppress("UNCHECKED_CAST")
+                    return file.getUserData(Keys.FULL_CACHE.key as Key<Array<FoldingDescriptor>>)
                 }
             }
         }
@@ -62,7 +64,8 @@ class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance
         foldingDescriptors: Array<FoldingDescriptor>
     ) {
         (element as? PsiJavaFile)?.run {
-            putUserData(Keys.FULL_CACHE, foldingDescriptors)
+            @Suppress("UNCHECKED_CAST")
+            putUserData(Keys.FULL_CACHE.key as Key<Array<FoldingDescriptor>>, foldingDescriptors)
         }
     }
 

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
@@ -4,6 +4,7 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.SimpleExpression
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.cache.Keys.METHOD_TO_PARENT_CLASS_KEY
+import com.intellij.openapi.util.Key
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.openapi.util.removeUserData
 import com.intellij.psi.*
@@ -47,10 +48,14 @@ object SummaryParentOverrideExt : BaseExtension() {
             }
             it.element.exprOnLastChar(overriddenMethodsLabel)
         }?.let {
-            this.putUserData(METHOD_TO_PARENT_CLASS_KEY, methodToParentClass)
+            @Suppress("UNCHECKED_CAST")
+            this.putUserData(
+                METHOD_TO_PARENT_CLASS_KEY.key as Key<MutableMap<MethodSignature, String>>, methodToParentClass
+            )
             return it.exprWrap(this)
         }
-        this.removeUserData(METHOD_TO_PARENT_CLASS_KEY)
+        @Suppress("UNCHECKED_CAST")
+        this.removeUserData(METHOD_TO_PARENT_CLASS_KEY.key as Key<MutableMap<MethodSignature, String>>)
         return null
     }
 
@@ -83,7 +88,10 @@ object SummaryParentOverrideExt : BaseExtension() {
             body.lBrace
         }?.let { brace ->
             val signature = element.getSignature()
-            element.containingClass?.getUserData(METHOD_TO_PARENT_CLASS_KEY)
+            @Suppress("UNCHECKED_CAST")
+            element.containingClass?.getUserData(
+                METHOD_TO_PARENT_CLASS_KEY.key as Key<MutableMap<MethodSignature, String>>
+            )
                 ?.get(signature)?.let {
                     val prefix = if (oneLiner) {
                         '}'

--- a/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
@@ -2,7 +2,7 @@ package com.intellij.advancedExpressionFolding.processor
 
 import com.intellij.advancedExpressionFolding.processor.EModifier.*
 import com.intellij.advancedExpressionFolding.processor.cache.Keys
-import com.intellij.advancedExpressionFolding.processor.cache.Keys.IGNORED
+import com.intellij.openapi.util.Key
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension.Companion.isBoolean
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension.Companion.isInt
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension.Companion.isObject
@@ -35,8 +35,9 @@ val PsiField.initializerType: PsiClass?
 
 inline fun String.filter(predicate: (String) -> Boolean): String? = takeIf(predicate)
 
-fun PsiElement.isIgnored(): Boolean = getUserData(IGNORED) ?: false
-fun PsiElement.markIgnored(value: Boolean = true) = putUserData(IGNORED, value)
+fun PsiElement.isIgnored(): Boolean = getUserData(Keys.ignoredKey) ?: false
+
+fun PsiElement.markIgnored(value: Boolean = true) = putUserData(Keys.ignoredKey, value)
 
 fun PsiExpressionList.filterOutWhiteSpaceAndTokens() = children.filter {
     !it.isIgnorable()
@@ -153,22 +154,29 @@ val PsiClass.methodsNotStatic: Sequence<PsiMethod>
     }
 
 fun PsiElement.setClassType(type: PsiClassExt.ClassType) {
-    putUserData(Keys.CLASS_TYPE_KEY, type)
-    putCopyableUserData(Keys.CLASS_TYPE_KEY, type)
+    @Suppress("UNCHECKED_CAST")
+    putUserData(Keys.CLASS_TYPE_KEY.key as Key<PsiClassExt.ClassType>, type)
+    @Suppress("UNCHECKED_CAST")
+    putCopyableUserData(Keys.CLASS_TYPE_KEY.key as Key<PsiClassExt.ClassType>, type)
 }
 
-fun PsiElement.getClassType(): PsiClassExt.ClassType? = getUserData(Keys.CLASS_TYPE_KEY)
+@Suppress("UNCHECKED_CAST")
+fun PsiElement.getClassType(): PsiClassExt.ClassType? = getUserData(Keys.CLASS_TYPE_KEY.key as Key<PsiClassExt.ClassType>)
 
 var PsiMethod.propertyField: PsiField?
-    get() = getUserData(Keys.FIELD_KEY)
-    set(value) = putUserData(Keys.FIELD_KEY, value)
+    @Suppress("UNCHECKED_CAST")
+    get() = getUserData(Keys.FIELD_KEY.key as Key<PsiField>)
+    @Suppress("UNCHECKED_CAST")
+    set(value) = putUserData(Keys.FIELD_KEY.key as Key<PsiField>, value)
 
 val PsiField.metadata: Keys.FieldMetaData
     get() {
-        var userData = getUserData(Keys.FIELD_META_DATA_KEY)
+        @Suppress("UNCHECKED_CAST")
+        var userData = getUserData(Keys.FIELD_META_DATA_KEY.key as Key<Keys.FieldMetaData>)
         if (userData == null) {
             userData = Keys.FieldMetaData()
-            putUserData(Keys.FIELD_META_DATA_KEY, userData)
+            @Suppress("UNCHECKED_CAST")
+            putUserData(Keys.FIELD_META_DATA_KEY.key as Key<Keys.FieldMetaData>, userData)
         }
         return userData
     }


### PR DESCRIPTION
## Summary
- replace cache key object with enum holding each `Key`
- iterate over enum entries to clear user data
- adjust usages to access typed `Key` instances
- centralize common key prefix in enum constructor
- expose typed `ignoredKey` to remove local casts

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b0d7cdb3bc832e94fe83b41ab58307