### PR TITLE
refactor: use Kotlin firstOrNull

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
@@ -4,7 +4,7 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.psi.*
-import com.jetbrains.rd.util.firstOrNull
+import kotlin.collections.firstOrNull
 
 object MethodDefaultParameterExt : BaseExtension(){
 


### PR DESCRIPTION
## Summary
- remove rd-util firstOrNull import in MethodDefaultParameterExt
- rely on Kotlin collections firstOrNull implementation

## Testing
- `./gradlew test` *(attempted: build began downloading IntelliJ dependencies and was terminated due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68b14809b088832eac14d97f80e2a846