### PR TITLE
refactor: simplify Kotlin string concatenations

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
@@ -49,7 +49,7 @@ object MethodDefaultParameterExt : BaseExtension(){
             params.map.forEach { (paramNr, value) ->
                 val paramWithValue = method.parameterList.parameters.getOrNull(paramNr)
                 val paramNextElement = paramWithValue?.nextSibling
-                list += paramNextElement?.expr(" = $value" + paramNextElement.text, group = group)
+                list += paramNextElement?.expr(" = $value${paramNextElement.text}", group = group)
             }
             if (params.map.isNotEmpty()) {
                 list += duplicatedMethod.exprHide(group = group)

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -181,7 +181,7 @@ abstract class CheckboxesProvider {
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalremoval")
         }
 
-        registerCheckbox(state::finalEmoji, "Replace the 'final' modifier with " + Emoji.FINAL_LOCK) {
+        registerCheckbox(state::finalEmoji, "Replace the 'final' modifier with ${Emoji.FINAL_LOCK}") {
             example("FinalEmojiTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalemoji")
         }


### PR DESCRIPTION
## Summary
- Use string interpolation for final modifier checkbox description
- Use string interpolation when building default parameter expressions

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b148071a3c832ebf21486b2a8fa568