### PR TITLE
refactor: safely access catch section parentheses

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/core/buildExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/buildExpression.kt
@@ -84,11 +84,14 @@ class CatchSectionBuilder : BuildExpression<PsiCatchSection>(PsiCatchSection::cl
                 element.lParenth != null &&
                 element.rParenth != null
 
-    override fun buildExpression(element: PsiCatchSection, document: Document, synthetic: Boolean) =
-        CompactControlFlowExpression(
+    override fun buildExpression(element: PsiCatchSection, document: Document, synthetic: Boolean): Expression? {
+        val l = element.lParenth ?: return null
+        val r = element.rParenth ?: return null
+        return CompactControlFlowExpression(
             element,
-            TextRange.create(element.lParenth!!.textRange.startOffset, element.rParenth!!.textRange.endOffset)
+            TextRange.create(l.textRange.startOffset, r.textRange.endOffset)
         )
+    }
 }
 
 class DoWhileStatementBuilder : BuildExpression<PsiDoWhileStatement>(PsiDoWhileStatement::class.java) {


### PR DESCRIPTION
## Summary
- avoid `!!` when accessing catch section parentheses

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b14876f250832e884e59a4b87cbdc6