### PR TITLE
docs: add threading model javadoc to MethodCallFactory

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
@@ -10,6 +10,30 @@ import com.intellij.advancedExpressionFolding.processor.util.Consts
 typealias MethodName = String
 typealias ClassName = String
 
+/**
+ * Thread-safe singleton factory for method call folding definitions.
+ *
+ * **Threading Model:**
+ * - Uses @Volatile fields for lock-free reads (frequent folding operations)
+ * - Uses synchronized for atomic multi-field updates (rare configuration changes)
+ * - This dual approach optimizes for the read-heavy/write-rare access pattern
+ * - Direct @Volatile field access is faster than AtomicReference.get() for reads
+ *
+ * **Why both @Volatile AND synchronized:**
+ * - @Volatile: Ensures immediate visibility of updates to all reader threads
+ * - synchronized: Ensures atomicity when updating multiple related fields together
+ * - Reader threads (folding builders) never block and always see consistent state
+ * - Writer threads (configuration changes) update all fields atomically
+ *
+ * **Lifecycle:**
+ * 1. Lazy initialization during first PsiMethodCallExpression folding
+ * 2. Background reads during method call folding operations
+ * 3. Runtime updates via AddDynamicMethodFoldingIntention
+ *
+ * **Performance characteristics:**
+ * - Reads: O(1) HashMap lookup, no synchronization overhead
+ * - Writes: O(n) reconstruction of all mappings, synchronized but infrequent
+ */
 object MethodCallFactory : BaseExtension(){
 
     @Volatile


### PR DESCRIPTION
## Summary
- document MethodCallFactory with detailed threading model, lifecycle, and performance notes

## Testing
- `./gradlew test` *(fails: stuck at "Calculating task graph")*

------
https://chatgpt.com/codex/tasks/task_e_68b4238c6d48832e891c3316eed1a6bd