### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/todo-integration-test.yml
+++ b/.github/workflows/todo-integration-test.yml
@@ -1,4 +1,6 @@
 name: TODO Run Integration Tests
+permissions:
+  contents: read
 
 on: [workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/2](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/2)

To fix this issue, you should add an explicit `permissions` block to the workflow file. Since the workflow only appears to check out code and run build steps, it does not need write access to repository contents, issues, or pull requests. The least privilege is most likely `contents: read`. To implement this, add the following block right after the `name:` block, before the `on:`/`jobs:` keys:

```yaml
permissions:
  contents: read
```

This change should be made at the root of the workflow `.github/workflows/todo-integration-test.yml`. No method definitions or imports are needed; just add or edit the YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
