### PR TITLE
Add option tree model with tri-state logic

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/tree/OptionDescriptor.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/tree/OptionDescriptor.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+/**
+ * Describes single configurable option.
+ */
+data class OptionDescriptor(
+    val id: String,
+    val label: String,
+    val description: String,
+    val defaultValue: Boolean,
+    var currentValue: Boolean,
+    val categoryPath: List<String>
+)

--- a/src/com/intellij/advancedExpressionFolding/settings/tree/OptionModel.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/tree/OptionModel.kt
@@ -1,0 +1,44 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+/**
+ * Model storing tree of options and providing operations for toggling nodes.
+ */
+class OptionModel(descriptors: List<OptionDescriptor>) {
+    val root: OptionTreeNode.ParentNode = TreeBuilder().build(descriptors)
+
+    private val leafById: Map<String, OptionTreeNode.LeafNode> = buildLeafIndex()
+
+    init {
+        root.computeTriState()
+    }
+
+    private fun buildLeafIndex(): Map<String, OptionTreeNode.LeafNode> {
+        val map = mutableMapOf<String, OptionTreeNode.LeafNode>()
+        fun collect(node: OptionTreeNode) {
+            when (node) {
+                is OptionTreeNode.LeafNode -> map[node.descriptor.id] = node
+                is OptionTreeNode.ParentNode -> node.children.forEach { collect(it) }
+            }
+        }
+        collect(root)
+        return map
+    }
+
+    fun toggleLeaf(id: String) {
+        leafById[id]?.toggle()
+    }
+
+    fun toggleParent(path: List<String>) {
+        findParent(path)?.toggle()
+    }
+
+    fun findParent(path: List<String>): OptionTreeNode.ParentNode? {
+        var current: OptionTreeNode.ParentNode = root
+        for (segment in path) {
+            val child = current.children.find { it is OptionTreeNode.ParentNode && it.name == segment } as OptionTreeNode.ParentNode?
+                ?: return null
+            current = child
+        }
+        return current
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/tree/OptionTreeNode.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/tree/OptionTreeNode.kt
@@ -1,0 +1,59 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+/**
+ * Node of option tree representing either a parent category or a leaf option.
+ */
+sealed class OptionTreeNode(val name: String) {
+    var parent: ParentNode? = null
+
+    open fun computeTriState(): TriState = TriState.UNCHECKED
+
+    class ParentNode(name: String) : OptionTreeNode(name) {
+        val children: MutableList<OptionTreeNode> = mutableListOf()
+        var triState: TriState = TriState.UNCHECKED
+
+        override fun computeTriState(): TriState {
+            val childStates = children.map { it.computeTriState() }
+            triState = when {
+                childStates.isEmpty() -> TriState.UNCHECKED
+                childStates.all { it == TriState.CHECKED } -> TriState.CHECKED
+                childStates.all { it == TriState.UNCHECKED } -> TriState.UNCHECKED
+                else -> TriState.PARTIAL
+            }
+            return triState
+        }
+
+        fun toggle() {
+            val check = triState != TriState.CHECKED
+            children.forEach { setCheckedRecursively(it, check) }
+            computeTriStateUpwards()
+        }
+
+        private fun setCheckedRecursively(node: OptionTreeNode, checked: Boolean) {
+            when (node) {
+                is LeafNode -> node.selected = checked
+                is ParentNode -> {
+                    node.children.forEach { setCheckedRecursively(it, checked) }
+                    node.triState = if (checked) TriState.CHECKED else TriState.UNCHECKED
+                }
+            }
+        }
+
+        fun computeTriStateUpwards() {
+            computeTriState()
+            parent?.computeTriStateUpwards()
+        }
+    }
+
+    class LeafNode(val descriptor: OptionDescriptor) : OptionTreeNode(descriptor.id) {
+        var selected: Boolean = descriptor.currentValue
+
+        override fun computeTriState(): TriState = if (selected) TriState.CHECKED else TriState.UNCHECKED
+
+        fun toggle() {
+            selected = !selected
+            descriptor.currentValue = selected
+            parent?.computeTriStateUpwards()
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/tree/TreeBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/tree/TreeBuilder.kt
@@ -1,0 +1,25 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+/**
+ * Builds [OptionTreeNode] hierarchy from flat descriptors.
+ */
+class TreeBuilder {
+    fun build(descriptors: List<OptionDescriptor>): OptionTreeNode.ParentNode {
+        val root = OptionTreeNode.ParentNode("root")
+        for (descriptor in descriptors) {
+            var current = root
+            for (category in descriptor.categoryPath) {
+                val child = current.children.find { it is OptionTreeNode.ParentNode && it.name == category }
+                val parent = if (child is OptionTreeNode.ParentNode) child else OptionTreeNode.ParentNode(category).also {
+                    it.parent = current
+                    current.children.add(it)
+                }
+                current = parent
+            }
+            val leaf = OptionTreeNode.LeafNode(descriptor)
+            leaf.parent = current
+            current.children.add(leaf)
+        }
+        return root
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/tree/TriState.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/tree/TriState.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+/**
+ * Tri-state for parent nodes.
+ */
+enum class TriState {
+    CHECKED,
+    UNCHECKED,
+    PARTIAL
+}

--- a/test/com/intellij/advancedExpressionFolding/settings/tree/OptionModelTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/tree/OptionModelTest.kt
@@ -1,0 +1,50 @@
+package com.intellij.advancedExpressionFolding.settings.tree
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OptionModelTest {
+
+    private fun createModel(): OptionModel {
+        val descriptors = listOf(
+            OptionDescriptor("a", "A", "", false, false, listOf("Cat")),
+            OptionDescriptor("b", "B", "", false, false, listOf("Cat"))
+        )
+        return OptionModel(descriptors)
+    }
+
+    @Test
+    fun `toggling parent updates children`() {
+        val model = createModel()
+        val path = listOf("Cat")
+
+        model.toggleParent(path)
+        val parent = model.findParent(path)!!
+        val statesAfterCheck = parent.children.map { (it as OptionTreeNode.LeafNode).selected }
+        assertEquals(listOf(true, true), statesAfterCheck)
+        assertEquals(TriState.CHECKED, parent.triState)
+
+        model.toggleParent(path)
+        val statesAfterUncheck = parent.children.map { (it as OptionTreeNode.LeafNode).selected }
+        assertEquals(listOf(false, false), statesAfterUncheck)
+        assertEquals(TriState.UNCHECKED, parent.triState)
+    }
+
+    @Test
+    fun `toggling leaf propagates to parent`() {
+        val model = createModel()
+        val path = listOf("Cat")
+        val parent = model.findParent(path)!!
+        val leafA = parent.children[0] as OptionTreeNode.LeafNode
+        val leafB = parent.children[1] as OptionTreeNode.LeafNode
+
+        leafA.toggle()
+        assertEquals(TriState.PARTIAL, parent.triState)
+
+        leafB.toggle()
+        assertEquals(TriState.CHECKED, parent.triState)
+
+        leafA.toggle()
+        assertEquals(TriState.PARTIAL, parent.triState)
+    }
+}


### PR DESCRIPTION
## Summary
- define `OptionDescriptor` for describing configurable options with category paths
- implement `OptionTreeNode` hierarchy and tri-state propagation
- add `OptionModel` and builder to create and manage option trees
- cover tri-state behavior with unit tests

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e18bea4832ebe0128b96a348fff