### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify-plugin.yml
+++ b/.github/workflows/verify-plugin.yml
@@ -1,4 +1,6 @@
 name: Verify plugin
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/4](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/4)

To fix the issue, add an explicit `permissions` block to limit the GitHub Actions workflow token (`GITHUB_TOKEN`) to the minimum access required. In this case, since the jobs only need to check out code (read access), you can set `permissions: contents: read` at the workflow (top) level. This will apply to all jobs and steps unless overridden. No change to existing workflow logic or job steps is needed.

**Where to edit:**  
Insert the following directly under the `name: ...` (line 1), before the `on:` key (line 3).

**What's needed:**  
No new methods, definitions, or imports are necessary. Just add the `permissions` block as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
