### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,8 @@ jobs:
         !contains(github.event.pull_request.body  || '', '[skip ci]')
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/3](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/security/code-scanning/3)

To fix this issue, you should add a `permissions` block to the "test" job, restricting the GITHUB_TOKEN to only the permissions necessary for the steps performed. Since the steps are all standard build and test activities (actions/checkout, actions/setup-java, codecov code coverage upload, artifact uploading) and do not require write access to repository content, the minimal permissions block would be `contents: read`. Place this block directly under the `runs-on` key of the "test" job (after line 116 and before `steps:`), which will override any repository/org defaults and restrict the permissions for this job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
