### PR TITLE
Add tests for folding service and editor listener

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/FoldingListenerTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingListenerTest.kt
@@ -1,0 +1,27 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FoldingListenerTest : BaseTest() {
+
+    @Test
+    fun `editorReleased clears keys`() {
+        fixture.configureByText("T.java", "class T {}")
+        val element = fixture.file.firstChild
+        with(Keys) {
+            IGNORED.turnOn(element)
+            assertTrue(IGNORED.isOn(element))
+        }
+        val event = EditorFactoryEvent(EditorFactory.getInstance(), fixture.editor)
+        FoldingEditorCreatedListener().editorReleased(event)
+        with(Keys) {
+            assertFalse(IGNORED.isOn(element))
+        }
+    }
+}
+

--- a/test/com/intellij/advancedExpressionFolding/FoldingServiceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingServiceTest.kt
@@ -1,0 +1,70 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.testFramework.runInEdtAndWait
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.FoldRegion
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FoldingServiceTest : BaseTest() {
+
+    @Test
+    fun `fold toggles only plugin regions`() {
+        val text = "class T {\n  void m(){}\n}\n"
+        fixture.configureByText("T.java", text)
+        val editor = fixture.editor
+        val model = editor.foldingModel as com.intellij.openapi.editor.ex.FoldingModelEx
+        lateinit var pluginRegion: FoldRegion
+        lateinit var otherRegion: FoldRegion
+        val mid = text.indexOf('{') + 1
+        runInEdtAndWait {
+            runWriteAction {
+                model.runBatchFoldingOperation {
+                    pluginRegion = model.createFoldRegion(
+                        0,
+                        mid,
+                        "...",
+                        FoldingGroup.newGroup("com.intellij.advancedExpressionFolding.test"),
+                        false
+                    )!!
+                    otherRegion = model.createFoldRegion(
+                        mid,
+                        text.length,
+                        "...",
+                        FoldingGroup.newGroup("other"),
+                        false
+                    )!!
+                    pluginRegion.isExpanded = true
+                    otherRegion.isExpanded = true
+                }
+            }
+        }
+        val service = FoldingService()
+        runInEdtAndWait { runReadAction { service.fold(editor, true) } }
+        assertFalse(pluginRegion.isExpanded)
+        assertTrue(otherRegion.isExpanded)
+        runInEdtAndWait { runReadAction { service.fold(editor, false) } }
+        assertTrue(pluginRegion.isExpanded)
+        assertTrue(otherRegion.isExpanded)
+    }
+
+    @Test
+    fun `clearAllKeys removes user data`() {
+        fixture.configureByText("T.java", "class T {}")
+        val element = fixture.file.firstChild
+        with(Keys) {
+            IGNORED.turnOn(element)
+            assertTrue(IGNORED.isOn(element))
+        }
+        FoldingService().clearAllKeys(fixture.editor)
+        with(Keys) {
+            assertFalse(IGNORED.isOn(element))
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- cover FoldingService.fold toggling of plugin groups
- ensure clearAllKeys removes key data
- verify editor release listener clears cached keys

## Testing
- `./gradlew :test --no-daemon --tests "com.intellij.advancedExpressionFolding.Folding*Test"`


------
https://chatgpt.com/codex/tasks/task_e_68c133edb67c832eac5b7dbf4a2c517f