### PR TITLE
Add unit tests for utilities and view helpers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.junit.pioneer)
     testImplementation(libs.junit.vintage.engine)
+    testImplementation(libs.mockk)
     implementation(libs.kodein.di.conf)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ qodana = "2024.3.4"
 lombok-plugin = "8.14.2"
 commons-lang3 = "3.18.0"
 slf4j = "2.0.17"
+mockk = "1.13.13"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
@@ -30,6 +31,7 @@ kodein-di-conf = { group = "org.kodein.di", name = "kodein-di-conf-jvm", version
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+mockk = { group = "io.mockk", name = "mockk-jvm", version.ref = "mockk" }
 
 
 [plugins]

--- a/test/com/intellij/advancedExpressionFolding/CodeGenerationUtilTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/CodeGenerationUtilTest.kt
@@ -1,0 +1,34 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.util.CodeGenerationUtil
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiFileFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class CodeGenerationUtilTest {
+    @Test
+    fun codeStringToPsiElementUsesPsiFileFactory() {
+        val project = mockk<com.intellij.openapi.project.Project>()
+        val psiClass = mockk<PsiClass> { every { getProject() } returns project }
+        val psiElement = mockk<PsiElement>()
+        val psiFile = mockk<PsiFile> { every { firstChild } returns psiElement }
+        val factory = mockk<PsiFileFactory> {
+            every { createFileFromText("temp.java", JavaFileType.INSTANCE, any<String>()) } returns psiFile
+        }
+        mockkStatic(PsiFileFactory::class)
+        every { PsiFileFactory.getInstance(project) } returns factory
+        val method = CodeGenerationUtil::class.java.getDeclaredMethod(
+            "codeStringToPsiElement", PsiClass::class.java, String::class.java
+        )
+        method.isAccessible = true
+        val result = method.invoke(CodeGenerationUtil, psiClass, "class B {}") as PsiElement
+        assertSame(psiElement, result)
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/FindUsageCustomViewTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FindUsageCustomViewTest.kt
@@ -1,0 +1,26 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.view.FindUsageCustomView
+import com.intellij.openapi.project.Project
+import com.intellij.usages.UsageViewManager
+import com.intellij.usages.Usage
+import com.intellij.usages.UsageTarget
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class FindUsageCustomViewTest {
+    @Test
+    fun createsUsageViewOnInit() {
+        val project = mockk<Project>()
+        val manager = mockk<UsageViewManager>()
+        val usageView = mockk<com.intellij.usages.impl.UsageViewImpl>(relaxed = true)
+        every { manager.showUsages(any<Array<UsageTarget>>(), any<Array<Usage>>(), any(), any()) } returns usageView
+        mockkStatic(UsageViewManager::class)
+        every { UsageViewManager.getInstance(project) } returns manager
+        FindUsageCustomView(project, "title")
+        verify { UsageViewManager.getInstance(project) }
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/HelperTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/HelperTest.kt
@@ -1,0 +1,18 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.util.Helper
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class HelperTest {
+    @Test
+    fun startsWithHandlesNullAndPrefix() {
+        assertTrue(Helper.startsWith("sample", "sam"))
+        assertFalse(Helper.startsWith(null, "sam"))
+    }
+
+    @Test
+    fun eraseGenericsRemovesGenericParts() {
+        assertEquals("java.util.List", Helper.eraseGenerics("java.util.List<String>"))
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/SettingsConfigurableTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/SettingsConfigurableTest.kt
@@ -1,0 +1,46 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.view.SettingsConfigurable
+import com.intellij.mock.MockApplication
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.panel
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KMutableProperty0
+
+class SettingsConfigurableTest {
+    @Test
+    fun checkboxTracksPendingChanges() {
+        val disposable = Disposer.newDisposable()
+        val app = MockApplication(disposable)
+        val settings = AdvancedExpressionFoldingSettings()
+        app.registerService(AdvancedExpressionFoldingSettings::class.java, settings)
+        ApplicationManager.setApplication(app, disposable)
+
+        class Holder(var option: Boolean)
+        val holder = Holder(false)
+        val configurable = SettingsConfigurable()
+        with(configurable) {
+            panel { registerCheckbox(holder::option, "option", null) }
+        }
+
+        val panelField = SettingsConfigurable::class.java.getDeclaredField("panel")
+        panelField.isAccessible = true
+        panelField.set(configurable, panel { })
+
+        val field = SettingsConfigurable::class.java.getDeclaredField("propertyToCheckbox")
+        field.isAccessible = true
+        val map = field.get(configurable) as MutableMap<KMutableProperty0<Boolean>, JBCheckBox>
+        val checkbox = map[holder::option]!!
+        assertFalse(configurable.isModified())
+        checkbox.doClick()
+        assertTrue(configurable.isModified())
+        configurable.apply()
+        assertTrue(holder.option)
+
+        Disposer.dispose(disposable)
+    }
+}


### PR DESCRIPTION
## Summary
- add mock-based tests for CodeGenerationUtil and Helper utility logic
- cover initialization behaviors in FindUsageCustomView and SettingsConfigurable
- include MockK for test mocking support

## Testing
- `./gradlew test` *(fails: There were failing tests)*
- `./gradlew test --tests "com.intellij.advancedExpressionFolding.CodeGenerationUtilTest" --tests "com.intellij.advancedExpressionFolding.HelperTest" --tests "com.intellij.advancedExpressionFolding.FindUsageCustomViewTest" --tests "com.intellij.advancedExpressionFolding.SettingsConfigurableTest" -x examples:test`


------
https://chatgpt.com/codex/tasks/task_e_68c1341ca7e0832eb4cb6fafd347aa0a