### PR TITLE
mockk - Add tests for plugin listeners and actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,6 +88,12 @@ dependencies {
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.junit.pioneer)
     testImplementation(libs.junit.vintage.engine)
+    testImplementation("io.mockk:mockk:1.13.11") {
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-jdk8")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-debug")
+    }
     implementation(libs.kodein.di.conf)
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html

--- a/test/com/intellij/advancedExpressionFolding/PluginComponentsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/PluginComponentsTest.kt
@@ -1,0 +1,92 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.action.FoldingOffAction
+import com.intellij.advancedExpressionFolding.action.FoldingOnAction
+import com.intellij.advancedExpressionFolding.settings.IConfig
+import com.intellij.ide.plugins.DynamicPluginListener
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PluginComponentsTest {
+
+    @Test
+    fun pluginUnloadingClearsCache() {
+        mockkObject(FoldingService.Companion)
+        val service = mockk<FoldingService>(relaxed = true)
+        every { FoldingService.get() } returns service
+
+        val clazz = Class.forName("com.intellij.advancedExpressionFolding.PluginUnloadingListener")
+        val ctor = clazz.getDeclaredConstructor().apply { isAccessible = true }
+        val listener = ctor.newInstance() as DynamicPluginListener
+        val descriptor = mockk<IdeaPluginDescriptor>()
+
+        listener.beforePluginUnload(descriptor, false)
+        listener.pluginUnloaded(descriptor, false)
+
+        verify(exactly = 2) { service.clearAllKeys() }
+        unmockkAll()
+    }
+
+    @Test
+    fun editorListenerClearsOnRelease() {
+        mockkObject(FoldingService.Companion)
+        val service = mockk<FoldingService>(relaxed = true)
+        every { FoldingService.get() } returns service
+
+        val editor = mockk<Editor>()
+        val event = mockk<EditorFactoryEvent> { every { this@mockk.editor } returns editor }
+
+        val listener = FoldingEditorCreatedListener()
+        listener.editorReleased(event)
+        verify { service.clearAllKeys(editor) }
+        unmockkAll()
+    }
+
+    private class TestConfig(override var globalOn: Boolean = false) : IConfig {
+        override val memoryImprovement: Boolean = false
+    }
+
+    private fun createEvent(editor: Editor?): AnActionEvent = mockk {
+        every { getData(CommonDataKeys.EDITOR) } returns editor
+    }
+
+    @Test
+    fun foldingOnActionFoldsAndEnablesGlobalFlag() {
+        mockkObject(FoldingService.Companion)
+        val service = mockk<FoldingService>(relaxed = true)
+        every { FoldingService.get() } returns service
+
+        val config = TestConfig(false)
+        val action = FoldingOnAction(config)
+        val editor = mockk<Editor>()
+        val event = createEvent(editor)
+
+        action.actionPerformed(event)
+
+        assertTrue(config.globalOn)
+        verify { service.fold(editor, true) }
+        unmockkAll()
+    }
+
+    @Test
+    fun foldingOffActionFoldsEditorOff() {
+        mockkObject(FoldingService.Companion)
+        val service = mockk<FoldingService>(relaxed = true)
+        every { FoldingService.get() } returns service
+
+        val action = FoldingOffAction()
+        val editor = mockk<Editor>()
+        val event = createEvent(editor)
+
+        action.actionPerformed(event)
+
+        verify { service.fold(editor, false) }
+        unmockkAll()
+    }
+}


### PR DESCRIPTION
## Summary
- add MockK dependency for testing
- verify FoldingService is invoked by plugin listeners and actions

## Testing
- `./gradlew test --tests com.intellij.advancedExpressionFolding.PluginComponentsTest -x examples:test`


------
https://chatgpt.com/codex/tasks/task_e_68c13410f248832ebfe02ab0525a9187