### PR TITLE
Add integration test for dynamic folding configuration

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.annotations.Nls
+import org.jetbrains.annotations.TestOnly
 
 class AddDynamicMethodFoldingIntention : IntentionAction {
 
@@ -69,6 +70,10 @@ class AddDynamicMethodFoldingIntention : IntentionAction {
     } == true
 
     private fun MethodName.getNewNameFromUser(): String? {
+        testNewMethodName?.let {
+            testNewMethodName = null
+            return it
+        }
         return Messages.showInputDialog(
             "Enter new method name:",
             "Add Dynamic Method Folding",
@@ -81,4 +86,7 @@ class AddDynamicMethodFoldingIntention : IntentionAction {
     private fun MethodName.remove() = ConfigurationParser.remove(this)
 
 }
+
+@TestOnly
+var testNewMethodName: String? = null
 

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt
@@ -5,12 +5,21 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
+import org.jetbrains.annotations.TestOnly
 
 enum class Action {
     RENAME, REMOVE, CANCEL
 }
 
+@TestOnly
+var testRenameDialogResult: Pair<Action, MethodName>? = null
+
 fun MethodName.showRenameDialog(): Pair<Action, MethodName>? {
+    testRenameDialogResult?.let {
+        testRenameDialogResult = null
+        return it
+    }
+
     var selectedAction: Action? = null
     var newMethodName: MethodName? = null
 

--- a/test/com/intellij/advancedExpressionFolding/DynamicMethodFoldingConfigurationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/DynamicMethodFoldingConfigurationTest.kt
@@ -1,0 +1,115 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.Action
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.DynamicMethodCall
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.IDynamicDataProvider
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.testRenameDialogResult
+import com.intellij.codeInsight.folding.CodeFoldingManager
+import com.intellij.util.ui.UIUtil
+import com.intellij.openapi.application.runReadAction
+import com.intellij.testFramework.runInEdtAndWait
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.testNewMethodName
+
+class DynamicMethodFoldingConfigurationTest : BaseTest() {
+
+    @Test
+    fun `adding dynamic method fold updates configuration and refolds`(@TempDir tmpDir: Path) {
+        val oldHome = System.getProperty("user.home")
+        System.setProperty("user.home", tmpDir.toString())
+        try {
+            MethodCallFactory.refreshMethodCallMappings(object : IDynamicDataProvider {
+                override fun parse(): List<DynamicMethodCall> = emptyList()
+            })
+            java.nio.file.Files.createFile(tmpDir.resolve("dynamic-ajf2.toml"))
+            val text = "class A { void t() { normalMethod(); } }"
+            fixture.configureByText("Test.java", text)
+            runInEdtAndWait {
+                fixture.editor.caretModel.moveToOffset(text.indexOf("normalMethod"))
+                CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor)
+            }
+            assertFalse(runReadAction { fixture.editor.foldingModel.allFoldRegions.any { it.placeholderText == "changedNormalMethod" } })
+
+            testNewMethodName = "changedNormalMethod"
+            fixture.launchAction(fixture.findSingleIntention("AJF2: Dynamic method folding"))
+            runInEdtAndWait { UIUtil.dispatchAllInvocationEvents(); CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor) }
+
+            var regions = runReadAction { fixture.editor.foldingModel.allFoldRegions }
+            assertTrue(regions.any { it.placeholderText == "changedNormalMethod" })
+
+            val configFile = tmpDir.resolve("dynamic-ajf2.toml")
+            assertTrue(configFile.exists())
+            val config = configFile.readText()
+            assertTrue(config.contains("normalMethod"))
+            assertTrue(config.contains("changedNormalMethod"))
+
+            fixture.configureByText("Test.java", text)
+            runInEdtAndWait {
+                fixture.editor.caretModel.moveToOffset(text.indexOf("normalMethod"))
+                CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor)
+            }
+            regions = runReadAction { fixture.editor.foldingModel.allFoldRegions }
+            assertTrue(regions.any { it.placeholderText == "changedNormalMethod" })
+        } finally {
+            System.setProperty("user.home", oldHome)
+            MethodCallFactory.refreshMethodCallMappings(object : IDynamicDataProvider {
+                override fun parse(): List<DynamicMethodCall> = emptyList()
+            })
+        }
+    }
+
+    @Test
+    fun `renaming dynamic method fold updates configuration and refolds`(@TempDir tmpDir: Path) {
+        val oldHome = System.getProperty("user.home")
+        System.setProperty("user.home", tmpDir.toString())
+        try {
+            MethodCallFactory.refreshMethodCallMappings(object : IDynamicDataProvider {
+                override fun parse(): List<DynamicMethodCall> = emptyList()
+            })
+            val text = "class A { void t() { normalMethod(); } }"
+            fixture.configureByText("Test.java", text)
+            runInEdtAndWait {
+                fixture.editor.caretModel.moveToOffset(text.indexOf("normalMethod"))
+                CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor)
+            }
+            assertFalse(runReadAction { fixture.editor.foldingModel.allFoldRegions.any { it.placeholderText == "firstName" || it.placeholderText == "secondName" } })
+
+            testNewMethodName = "firstName"
+            fixture.launchAction(fixture.findSingleIntention("AJF2: Dynamic method folding"))
+            runInEdtAndWait { UIUtil.dispatchAllInvocationEvents(); CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor) }
+            var regions = runReadAction { fixture.editor.foldingModel.allFoldRegions }
+            assertTrue(regions.any { it.placeholderText == "firstName" })
+
+            testRenameDialogResult = Action.RENAME to "secondName"
+            fixture.launchAction(fixture.findSingleIntention("AJF2: Dynamic method folding"))
+            runInEdtAndWait { UIUtil.dispatchAllInvocationEvents(); CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor) }
+            regions = runReadAction { fixture.editor.foldingModel.allFoldRegions }
+            assertTrue(regions.any { it.placeholderText == "secondName" })
+
+            val config = tmpDir.resolve("dynamic-ajf2.toml").readText()
+            assertTrue(config.contains("secondName"))
+            assertFalse(config.contains("firstName"))
+
+            fixture.configureByText("Test.java", text)
+            runInEdtAndWait {
+                fixture.editor.caretModel.moveToOffset(text.indexOf("normalMethod"))
+                CodeFoldingManager.getInstance(fixture.project).updateFoldRegions(fixture.editor)
+            }
+            regions = runReadAction { fixture.editor.foldingModel.allFoldRegions }
+            assertTrue(regions.any { it.placeholderText == "secondName" })
+        } finally {
+            testRenameDialogResult = null
+            System.setProperty("user.home", oldHome)
+            MethodCallFactory.refreshMethodCallMappings(object : IDynamicDataProvider {
+                override fun parse(): List<DynamicMethodCall> = emptyList()
+            })
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow tests to supply predetermined method names when adding dynamic folds
- add integration tests ensuring dynamic folding configuration updates and editors re-fold on add and rename

## Testing
- `./gradlew :test --tests com.intellij.advancedExpressionFolding.DynamicMethodFoldingConfigurationTest --no-configuration-cache` *(fails: 2 tests completed, 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1353bdbc0832ebc359db7e5cf213d