### PR TITLE
Add performance tests for MethodCallFactory mappings

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/MethodCallFactoryPerformanceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/MethodCallFactoryPerformanceTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 
 @EnabledIfEnvironmentVariable(named = "performance-mode", matches = "1")
-class MethodCallFactoryPerformanceTest {
+class MethodCallFactoryPerformanceTest : BaseTest() {
 
     companion object {
         private const val WARMUP_ITERATIONS = 2
@@ -62,8 +62,8 @@ class MethodCallFactoryPerformanceTest {
         override fun parse(): List<DynamicMethodCall> {
             invocation++
             return (1..size).map { index ->
-                val method = "m${'$'}{invocation}_${'$'}index"
-                DynamicMethodCall(DynamicMethodCallData(mapOf("method" to method, "newName" to "n${'$'}index")))
+                val method = $$"m${invocation}_$index"
+                DynamicMethodCall(DynamicMethodCallData(mapOf("method" to method, "newName" to $$"n$index")))
             }
         }
     }


### PR DESCRIPTION
## Summary
- benchmark MethodCallFactory.initialize and refreshMethodCallMappings with large dynamic data
- gate MethodCallFactory performance tests behind performance-mode env flag
- reduce benchmark repetition counts to 2 for faster test runs
- extract benchmark parameters into named constants

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c1363d1c80832ea824fd2d43f0bfb2