### PR TITLE
Enable experimental Kotlin features in builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,17 @@ kotlin {
         @Suppress("UnstableApiUsage")
         vendor = JvmVendorSpec.JETBRAINS
     }
+    compilerOptions {
+        // Enables Kotlin Context Parameters (Kotlin 2.2+ preview).
+        // Lets functions and properties declare implicit dependencies
+        // so we don’t need to pass them explicitly everywhere.
+        freeCompilerArgs.add("-Xcontext-parameters")
+
+        // Enables Nested Type Aliases (Kotlin preview).
+        // Lets us define type aliases inside other types (e.g. inside classes or objects),
+        // improving readability and encapsulation.
+        freeCompilerArgs.add("-Xnested-type-aliases")
+    }
 }
 
 idea {


### PR DESCRIPTION
## Summary
- revert the folding persistence helper refactor so AdvancedExpressionFoldingBuilder again delegates directly to `store.store`
- keep the build script enabling the required Kotlin preview flags for context parameters and nested type aliases

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cc442ddc58832e93ac6ccee1bd9171