### PR TITLE
Add settings checkbox filtering

### DIFF
--- a/docs/manual-qa/settings-filtering.md
+++ b/docs/manual-qa/settings-filtering.md
@@ -1,0 +1,22 @@
+# Settings search filter QA
+
+## Preconditions
+- IntelliJ IDEA with the Advanced Expression Folding plugin installed.
+- A project opened so the settings page can show example checkout actions.
+
+## Steps
+1. Open **Settings/Preferences → Editor → Advanced Expression Folding 2**.
+2. Type `lombok` in the filter field.
+   - Only Lombok-related options remain visible and their example/doc rows are hidden when the checkbox row is hidden.
+3. Clear the filter by removing the query.
+   - All folding options return and the example/doc rows reappear for the affected entries.
+4. Enable **Getters and setters as properties** while the list is unfiltered and do not apply yet.
+5. Type `stream` into the filter to hide the previously toggled checkbox.
+6. Toggle **Display stream operations as Groovy's spread operator** while the filter is active and press **Apply**.
+7. Clear the filter and verify that **Getters and setters as properties** remains enabled even though it was hidden during the apply.
+8. Press **OK**, reopen the settings page, and confirm that both toggles persist.
+
+## Expected results
+- The filter immediately hides checkboxes (and their associated example/doc rows) that do not match the query text.
+- Clearing the filter restores the full list without losing any selections.
+- Applying settings while some options are hidden preserves the hidden selections.

--- a/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
@@ -13,13 +13,15 @@ data class CheckboxDefinition(
     val title: String,
     val property: KMutableProperty0<Boolean>,
     val exampleLinkMap: Map<ExampleFile, Description?>? = null,
-    val docLink: UrlSuffix? = null
+    val docLink: UrlSuffix? = null,
+    val keywords: Set<String> = emptySet()
 )
 
 @CheckboxDsl
 class CheckboxBuilder {
     private val examples = mutableMapOf<ExampleFile, Description?>()
     private var docLink: UrlSuffix? = null
+    private val keywords = mutableSetOf<String>()
 
     fun example(file: ExampleFile, description: Description? = null) {
         examples[file] = description
@@ -27,6 +29,12 @@ class CheckboxBuilder {
 
     fun link(documentationLink: UrlSuffix) {
         docLink = documentationLink
+    }
+
+    fun keywords(vararg keywords: String) {
+        this.keywords += keywords
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
     }
 
     internal fun build(
@@ -37,7 +45,8 @@ class CheckboxBuilder {
             title = title,
             property = property,
             exampleLinkMap = if (examples.isEmpty()) null else examples.toMap(),
-            docLink = docLink
+            docLink = docLink,
+            keywords = keywords.toSet()
         )
     }
 


### PR DESCRIPTION
## Summary
- add a search field to the settings panel that filters option rows using checkbox metadata
- persist checkbox keywords in the DSL so filtering can include optional aliases
- document a manual QA checklist covering the filtering and apply scenarios

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1aedc6390832e90930fcd2b2f132c