### PR TITLE
Add integration test covering folding cache clearing

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/FoldingIntegrationTestBridge.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/FoldingIntegrationTestBridge.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.integration
 
+import com.intellij.advancedExpressionFolding.FoldingService
 import com.intellij.advancedExpressionFolding.processor.cache.Keys
 import com.intellij.codeInsight.folding.CodeFoldingManager
 import com.intellij.lang.folding.FoldingDescriptor
@@ -54,7 +55,7 @@ object FoldingIntegrationTestBridge {
         application.invokeAndWait {
             application.runWriteAction {
                 if (!editor.isDisposed) {
-                    FoldingService.get().fold(editor, collapse)
+                    FoldingService.Companion.get().fold(editor, collapse)
                 }
             }
         }

--- a/test/com/intellij/advancedExpressionFolding/IntegrationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/IntegrationTest.kt
@@ -25,11 +25,7 @@ import com.intellij.ide.starter.runner.IDECommandLine
 import com.intellij.ide.starter.runner.Starter
 import com.intellij.ide.starter.screenRecorder.IDEScreenRecorder
 import com.intellij.tools.ide.performanceTesting.commands.*
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.api.fail
@@ -201,8 +197,8 @@ class IntegrationTest {
                 execute { it.openFile(file) }
             }
 
-            val foldingBridge = service<FoldingTestBridgeStub>()
-            val foldingService = service<FoldingServiceStub>()
+            val foldingBridge = utility<FoldingTestBridgeStub>()
+            val foldingService = utility<FoldingServiceStub>()
 
             foldingBridge.updateFoldRegions(filesToCheck)
             wait()

--- a/test/com/intellij/advancedExpressionFolding/integrationStubs.kt
+++ b/test/com/intellij/advancedExpressionFolding/integrationStubs.kt
@@ -1,5 +1,6 @@
 package com.intellij.advancedExpressionFolding
 
+import com.intellij.advancedExpressionFolding.integration.FoldingSnapshot
 import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.driver.client.Remote
@@ -23,7 +24,7 @@ interface FoldingServiceStub {
     fun clearAllKeys()
 }
 
-@Remote("com.intellij.advancedExpressionFolding.FoldingIntegrationTestBridge", plugin = "com.github.advanced-java-folding2")
+@Remote("com.intellij.advancedExpressionFolding.integration.FoldingIntegrationTestBridge", plugin = "com.github.advanced-java-folding2")
 interface FoldingTestBridgeStub {
     fun snapshot(filePaths: List<String>): List<FoldingSnapshot>
     fun updateFoldRegions(filePaths: List<String>)


### PR DESCRIPTION
## Summary
- add a FoldingIntegrationTestBridge utility to snapshot fold regions, cached descriptors, and toggle folding from the IDE driver
- extend driver stubs so tests can invoke FoldingService.clearAllKeys and the new bridge helper
- add an integration test that opens multiple files, clears folding keys, waits for cache eviction, and verifies fold regions are recomputed after collapsing/expanding

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cef924db00832ea90785c2367f2724