### PR TITLE
Add coverage for property name edge cases

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/PropertyUtilTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/PropertyUtilTest.kt
@@ -8,6 +8,9 @@ class PropertyUtilTest {
     @Test
     fun checkGuessPropertyName() {
         assertEquals("", guessPropertyName(""))
+        assertEquals("", guessPropertyName("get"))
+        assertEquals("", guessPropertyName("set"))
+        assertEquals("", guessPropertyName("is"))
         assertEquals("length", guessPropertyName("length"))
         assertEquals("name", guessPropertyName("getName"))
         assertEquals("name", guessPropertyName("setName"))


### PR DESCRIPTION
## Summary
- add regression coverage for `guessPropertyName` to ensure bare accessor prefixes resolve to an empty property name

## Testing
- `./gradlew test --console=plain` *(fails: NoClassDefFoundError when running FoldingTest because JetBrains JDK 17 toolchain isn't available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da22546e24832e8a470c594585bedb