### PR TITLE
Skip invalid dynamic method configuration entries

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
@@ -8,7 +8,8 @@ import kotlin.io.path.readText
 
 object ConfigurationParser : IDynamicDataProvider {
 
-    private val filePath: Path = Paths.get(System.getProperty("user.home"), "dynamic-ajf2.toml")
+    private val filePath: Path
+        get() = Paths.get(System.getProperty("user.home"), "dynamic-ajf2.toml")
 
     override fun parse(): List<DynamicMethodCall> {
         if (!Files.exists(filePath)) {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
@@ -17,8 +17,16 @@ interface IDynamicDataProvider {
 
     fun parseToml(text: String): List<DynamicMethodCall> {
         val listOfMaps = objectMapper.parseTomlValues(text)
-        return listOfMaps?.map {
-            DynamicMethodCall(DynamicMethodCallData(it))
+        return listOfMaps?.mapNotNull { entry ->
+            val method = entry["method"]
+            val newName = entry["newName"]
+
+            if (method.isNullOrBlank() || newName.isNullOrBlank()) {
+                logger.warn("Skipping dynamic method entry missing required keys: $entry")
+                null
+            } else {
+                DynamicMethodCall(DynamicMethodCallData(entry))
+            }
         } ?: emptyList()
     }
 

--- a/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
@@ -1,0 +1,46 @@
+package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
+
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+
+class ConfigurationParserTest {
+
+    @Test
+    fun parseSkipsEntriesMissingRequiredKeys() {
+        val originalUserHome = System.getProperty("user.home")
+        val temporaryHome = Files.createTempDirectory("dynamic-ajf2-test")
+
+        try {
+            System.setProperty("user.home", temporaryHome.toString())
+
+            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+            configPath.parent?.createDirectories()
+            configPath.writeText(
+                """
+                [missingNewName]
+                method = "sourceMethod"
+                """.trimIndent()
+            )
+
+            val parsed = ConfigurationParser.parse()
+            assertTrue(parsed.isEmpty(), "Expected entries without required keys to be skipped")
+
+            assertDoesNotThrow {
+                MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+            }
+        } finally {
+            Files.deleteIfExists(temporaryHome.resolve("dynamic-ajf2.toml"))
+            Files.deleteIfExists(temporaryHome)
+            if (originalUserHome != null) {
+                System.setProperty("user.home", originalUserHome)
+            } else {
+                System.clearProperty("user.home")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- require dynamic method entries to provide non-empty `method` and `newName` values before building `DynamicMethodCall`
- keep `ConfigurationParser` resolving its config path from the current `user.home`
- add a regression test ensuring the parser skips invalid records and that `MethodCallFactory.refreshMethodCallMappings` handles them

## Testing
- `./gradlew test` *(fails: JetBrains JDK vendor-specific toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da22316680832e8cd1a8c0d8f57839