### PR TITLE
Add primitive varargs completion test

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt
@@ -134,6 +134,27 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
                     }
                 """.trimIndent()
             )),
+
+            Arguments.of(TestCase(
+                name = "Primitive Varargs",
+                input = """
+                    public class Test {
+                        @<caret>
+                        public void numbers(int... values) {
+                        }
+                    }
+                """.trimIndent(),
+                expected = """
+                    public class Test {
+                        public static void main(String[] args) {
+                            int[] values = new int[]{};
+                            new Test().numbers(values);
+                        }
+                        public void numbers(int... values) {
+                        }
+                    }
+                """.trimIndent()
+            )),
             
             Arguments.of(TestCase(
                 name = "Existing Main Method",


### PR DESCRIPTION
## Summary
- add a parameterized test case that covers primitive varargs completion suggestions
- ensure the generated main method passes an int array to the new numbers varargs method

## Testing
- ./gradlew test *(fails: missing JetBrains Java 17 toolchain provision in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da22094538832e9931acc3555a4423