### PR TITLE
Use project coroutine scope for folding clean-up

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/FoldingService.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingService.kt
@@ -11,8 +11,6 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiRecursiveElementVisitor
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Service
@@ -45,7 +43,8 @@ class FoldingService {
             !it.isDisposed
         }
 
-        CoroutineScope(Dispatchers.Default).launch {
+        val coroutineScope = project.service<FoldingServiceCoroutineScope>()
+        coroutineScope.launch {
             editors.forEach { editor ->
                 clearAllKeys(editor)
             }

--- a/src/com/intellij/advancedExpressionFolding/FoldingServiceCoroutineScope.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingServiceCoroutineScope.kt
@@ -1,0 +1,20 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
+
+@Service(Service.Level.PROJECT)
+class FoldingServiceCoroutineScope(project: Project) : CoroutineScope, Disposable {
+    private val job = SupervisorJob()
+
+    override val coroutineContext: CoroutineContext = job + Dispatchers.Default
+
+    override fun dispose() {
+        job.cancel()
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/FoldingServiceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingServiceTest.kt
@@ -1,0 +1,61 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.testFramework.LoggedErrorProcessor
+import com.intellij.util.ThrowableRunnable
+import com.intellij.util.ui.UIUtil
+import com.intellij.openapi.application.WriteIntentReadAction
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class FoldingServiceTest : BaseTest() {
+
+    @Test
+    fun clearAllKeysAfterDisposingEditorsDoesNotLogWarnings() {
+        val psiFile = fixture.configureByText("Foo.java", "class Foo {}")
+        val virtualFile = psiFile.virtualFile
+        val warnings = mutableListOf<String>()
+        val project = fixture.project
+        val foldingService = FoldingService.get()
+        val scope = project.service<FoldingServiceCoroutineScope>()
+        val scopeJob = scope.coroutineContext.job
+
+        val processor = object : LoggedErrorProcessor() {
+            override fun processWarn(
+                category: String,
+                message: String,
+                t: Throwable?,
+            ): Boolean {
+                synchronized(warnings) {
+                    warnings.add("$category: $message")
+                }
+                return true
+            }
+        }
+
+        LoggedErrorProcessor.executeWith(processor, ThrowableRunnable<RuntimeException> {
+            foldingService.clearAllKeys(project)
+            UIUtil.invokeAndWaitIfNeeded {
+                WriteIntentReadAction.run {
+                    FileEditorManager.getInstance(project).closeFile(virtualFile)
+                }
+            }
+            runBlocking {
+                while (true) {
+                    val children = scopeJob.children.toList()
+                    if (children.isEmpty()) {
+                        break
+                    }
+                    children.forEach { it.join() }
+                }
+            }
+        })
+
+        assertTrue(warnings.isEmpty()) {
+            "Warnings were logged after disposing editors: ${warnings.joinToString()}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- launch FoldingService key clearing work on a project-scoped coroutine to ensure it is cancelled on project disposal
- add a dedicated FoldingServiceCoroutineScope project service to provide a cancellable scope
- add a regression test covering clearAllKeys after editors are disposed

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68daf7b0d340832e85b55d04dee6d469