### PR TITLE
Use shared object mapper for dynamic provider

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
@@ -11,7 +11,13 @@ interface IDynamicDataProvider {
     private val logger: Logger
         get() = Logger.getInstance(IDynamicDataProvider::class.java)
     val objectMapper: ObjectMapper
-        get() = ObjectMapper(TomlFactory())
+        get() = sharedObjectMapper
+
+    companion object {
+        private val sharedObjectMapper: ObjectMapper by lazy {
+            ObjectMapper(TomlFactory())
+        }
+    }
 
     fun parse(): List<DynamicMethodCall>
 


### PR DESCRIPTION
## Summary
- share the Jackson ObjectMapper across IDynamicDataProvider instances via a lazy singleton so it is configured once and remains thread-safe

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68daf7b9e6b4832e9a018815291fadc2