### PR TITLE
Track PSI modification stamps in expression cache

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
@@ -5,6 +5,7 @@ import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.
 import com.intellij.advancedExpressionFolding.settings.StateDelegate
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiModificationTracker
 import org.jetbrains.annotations.Contract
 
 object CacheExt : StateDelegate() {
@@ -12,11 +13,12 @@ object CacheExt : StateDelegate() {
     fun PsiElement.invalidateExpired(document: Document, synthetic: Boolean): Boolean {
         val versionKey = Keys.getVersionKey(synthetic)
         val lastVersion = getUserData(versionKey)
-        val hashCode = document.text.hashCode()
-        val expired = lastVersion != hashCode
+        val currentVersion = containingFile?.modificationStamp
+            ?: PsiModificationTracker.getInstance(project).modificationCount
+        val expired = lastVersion != currentVersion
         if (expired) {
             Keys.clearAllOnExpire(this)
-            putUserData(versionKey, hashCode)
+            putUserData(versionKey, currentVersion)
         }
         return expired
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
@@ -25,8 +25,8 @@ object Keys {
 
     private val SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}syn")
     private val NOT_SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}!syn")
-    private val VERSION_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-syn")
-    private val VERSION_NOT_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-!syn")
+    private val VERSION_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-syn")
+    private val VERSION_NOT_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-!syn")
 
     val FULL_CACHE: Key<Array<FoldingDescriptor>> = Key.create("${PREFIX}-full")
 
@@ -57,7 +57,7 @@ object Keys {
             psiElement.putUserData(it, null)
         }
     }
-    fun getVersionKey(synthetic: Boolean): Key<Int> {
+    fun getVersionKey(synthetic: Boolean): Key<Long> {
         return when {
             synthetic -> VERSION_SYNTHETIC_KEY
             else -> VERSION_NOT_SYNTHETIC_KEY


### PR DESCRIPTION
## Summary
- replace document hash invalidation with PSI modification tracking for expression cache
- expand cache version keys to store long modification counters

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ea4f78b750832ead0581fd48061202