### PR TITLE
Use PSI modification stamps for cache invalidation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
@@ -12,11 +12,11 @@ object CacheExt : StateDelegate() {
     fun PsiElement.invalidateExpired(document: Document, synthetic: Boolean): Boolean {
         val versionKey = Keys.getVersionKey(synthetic)
         val lastVersion = getUserData(versionKey)
-        val hashCode = document.text.hashCode()
-        val expired = lastVersion != hashCode
+        val currentVersion = containingFile?.modificationStamp ?: document.modificationStamp
+        val expired = lastVersion != currentVersion
         if (expired) {
             Keys.clearAllOnExpire(this)
-            putUserData(versionKey, hashCode)
+            putUserData(versionKey, currentVersion)
         }
         return expired
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
@@ -25,8 +25,8 @@ object Keys {
 
     private val SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}syn")
     private val NOT_SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}!syn")
-    private val VERSION_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-syn")
-    private val VERSION_NOT_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-!syn")
+    private val VERSION_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-syn")
+    private val VERSION_NOT_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-!syn")
 
     val FULL_CACHE: Key<Array<FoldingDescriptor>> = Key.create("${PREFIX}-full")
 
@@ -57,7 +57,7 @@ object Keys {
             psiElement.putUserData(it, null)
         }
     }
-    fun getVersionKey(synthetic: Boolean): Key<Int> {
+    fun getVersionKey(synthetic: Boolean): Key<Long> {
         return when {
             synthetic -> VERSION_SYNTHETIC_KEY
             else -> VERSION_NOT_SYNTHETIC_KEY


### PR DESCRIPTION
## Summary
- replace document text hashing with PSI modification stamps when checking cache staleness
- store modification stamps in cache keys so expression data survives unrelated edits

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ea4f78b750832ead0581fd48061202