### PR TITLE
Align documentation/example links with their checkboxes

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -184,15 +184,17 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         }
         propertyToCheckbox[property] = checkbox
         
+        val definition = builder.build(property, title)
+        val examplePanel =
+            if (definition.exampleLinkMap != null || definition.docLink != null) {
+                createExamplePanel(definition.exampleLinkMap, definition.docLink)
+            } else {
+                null
+            }
+
         row {
             cell(checkbox)
-        }
-        
-        val definition = builder.build(property, title)
-        if (definition.exampleLinkMap != null || definition.docLink != null) {
-            row {
-                cell(createExamplePanel(definition.exampleLinkMap, definition.docLink))
-            }
+            examplePanel?.let { cell(it) }
         }
 
     }


### PR DESCRIPTION
## Summary
- render the documentation and example action links in the same row as their checkbox
- reuse the existing example panel so each checkbox keeps its affordances

## Testing
- ./gradlew test --console=plain *(fails: com.intellij.ide.startup.ServiceNotReadyException in FoldingActionsTest)*

------
https://chatgpt.com/codex/tasks/task_e_68ea7b5cadc0832e9354e05ad059c36c