### PR TITLE
Refactor builder pipeline to use contextual Document state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -49,8 +49,17 @@ class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance
     ): Array<FoldingDescriptor>? {
         if (!quick) {
             (element as? PsiJavaFile)?.let { file ->
-                if (!file.invalidateExpired(document, false)) {
-                    return file.getUserData(Keys.FULL_CACHE)
+                val cached = with(document) {
+                    with(false) {
+                        if (!file.invalidateExpired()) {
+                            file.getUserData(Keys.FULL_CACHE)
+                        } else {
+                            null
+                        }
+                    }
+                }
+                if (cached != null) {
+                    return cached
                 }
             }
         }

--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
@@ -59,6 +59,10 @@ object PsiFieldExt : BaseExtension() {
         return list.exprWrap(field)
     }
 
+    context(doc: Document)
+    fun createExpression(field: PsiField): Expression? =
+        createExpression(field = field, document = doc)
+
     fun createExpression(psiRecordComponent: PsiRecordComponent): NullAnnotationExpression? {
         return fieldAnnotationExpression(psiRecordComponent.annotations, psiRecordComponent.typeElement, true)
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt
@@ -56,6 +56,10 @@ object PsiMethodExt : BaseExtension() {
         return list.exprWrap(method)
     }
 
+    context(doc: Document)
+    fun createExpression(method: PsiMethod): Expression? =
+        createExpression(method = method, document = doc)
+
     fun createExpression(parameter: PsiParameter, document: Document): Expression? {
         if (interfaceExtensionProperties && InterfacePropertiesExt.ignoreFoldingParameter(parameter)) {
             return null
@@ -69,4 +73,8 @@ object PsiMethodExt : BaseExtension() {
         )
         return list.exprWrap(parameter)
     }
+
+    context(doc: Document)
+    fun createExpression(parameter: PsiParameter): Expression? =
+        createExpression(parameter = parameter, document = doc)
 }


### PR DESCRIPTION
## Summary
- propagate the Document and synthetic flags through the expression builder hierarchy via Kotlin context receivers while keeping compatibility overloads
- update the cache helpers to operate with the new contextual receivers and preserve the existing threaded entry points
- add contextual overloads for PsiMethodExt and adopt them when reading the builder cache

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68cef476db78832eaeb2fb60b4f324c4