### PR TITLE
Use modification stamps for cache invalidation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
@@ -12,11 +12,13 @@ object CacheExt : StateDelegate() {
     fun PsiElement.invalidateExpired(document: Document, synthetic: Boolean): Boolean {
         val versionKey = Keys.getVersionKey(synthetic)
         val lastVersion = getUserData(versionKey)
-        val hashCode = document.text.hashCode()
-        val expired = lastVersion != hashCode
+        val currentStamp = document.modificationStamp
+        val expired = lastVersion != null && lastVersion != currentStamp
         if (expired) {
             Keys.clearAllOnExpire(this)
-            putUserData(versionKey, hashCode)
+        }
+        if (lastVersion != currentStamp) {
+            putUserData(versionKey, currentStamp)
         }
         return expired
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
@@ -25,8 +25,8 @@ object Keys {
 
     private val SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}syn")
     private val NOT_SYNTHETIC_KEY: Key<Expression> = Key.create("${PREFIX}!syn")
-    private val VERSION_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-syn")
-    private val VERSION_NOT_SYNTHETIC_KEY: Key<Int> = Key.create("${PREFIX}ver-!syn")
+    private val VERSION_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-syn")
+    private val VERSION_NOT_SYNTHETIC_KEY: Key<Long> = Key.create("${PREFIX}ver-!syn")
 
     val FULL_CACHE: Key<Array<FoldingDescriptor>> = Key.create("${PREFIX}-full")
 
@@ -57,7 +57,7 @@ object Keys {
             psiElement.putUserData(it, null)
         }
     }
-    fun getVersionKey(synthetic: Boolean): Key<Int> {
+    fun getVersionKey(synthetic: Boolean): Key<Long> {
         return when {
             synthetic -> VERSION_SYNTHETIC_KEY
             else -> VERSION_NOT_SYNTHETIC_KEY

--- a/test/com/intellij/advancedExpressionFolding/CacheExtTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/CacheExtTest.kt
@@ -1,0 +1,72 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.cache.CacheExt
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiBinaryExpression
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.SmartPointerManager
+import com.intellij.psi.SmartPsiElementPointer
+import com.intellij.psi.util.PsiTreeUtil
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class CacheExtTest : BaseTest() {
+
+    @Test
+    fun `document modification stamps preserve cache and invalidate on edit`() {
+        val file = fixture.configureByText(
+            "CacheSample.java",
+            """
+            class CacheSample {
+                int calc(int a, int b) {
+                    return a + b;
+                }
+            }
+            """.trimIndent()
+        )
+        val project = fixture.project
+        val document = fixture.editor.document
+
+        val expressionPointer = runReadAction<SmartPsiElementPointer<PsiBinaryExpression>> {
+            val binaryExpression = PsiTreeUtil.findChildOfType(file, PsiBinaryExpression::class.java)
+                ?: error("Expected binary expression")
+            SmartPointerManager.getInstance(project).createSmartPsiElementPointer(binaryExpression)
+        }
+
+        val first = runReadAction {
+            CacheExt.getExpression(expressionPointer.element!!, document, false)
+        }
+        assertNotNull(first)
+
+        val second = runReadAction {
+            CacheExt.getExpression(expressionPointer.element!!, document, false)
+        }
+        assertSame(first, second)
+
+        runReadAction {
+            CacheExt.getExpression(expressionPointer.element!!, document, true)
+        }
+
+        val third = runReadAction {
+            CacheExt.getExpression(expressionPointer.element!!, document, false)
+        }
+        assertSame(first, third)
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            val offset = document.text.indexOf("a + b")
+            check(offset >= 0) { "binary expression not found" }
+            document.replaceString(offset, offset + "a + b".length, "a - b")
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+        }
+
+        val afterEdit = runReadAction {
+            CacheExt.getExpression(expressionPointer.element!!, document, false)
+        }
+        assertNotNull(afterEdit)
+        assertNotSame(first, afterEdit)
+    }
+}
+


### PR DESCRIPTION
## Summary
- switch cache invalidation to use document modification stamps instead of document text hashes
- store modification stamps per synthetic/non-synthetic key to avoid wiping cached expressions on unrelated accesses
- add a regression test that confirms cache reuse survives synthetic lookups and still invalidates after edits

## Testing
- ./gradlew test --console=plain --no-daemon --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68daf70c0cbc832e80dcb7fa8b506e40