### PR TITLE
Add badges and descriptions for new and experimental settings - 2

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,8 +273,13 @@ abstract class CheckboxesProvider {
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
         // NEW OPTION
-        registerCheckbox(state::memoryImprovement, "Memory improvements")
+        registerCheckbox(state::memoryImprovement, "Memory improvements") {
+            badge("New", FeatureBadgeStyle.NEW)
+            description("Lowers the plugin's memory footprint by tuning folding caches. Ideal for large projects—observe IDE usage after enabling.")
+        }
         registerCheckbox(state::experimental, "Experimental features") {
+            badge("Experimental", FeatureBadgeStyle.EXPERIMENTAL)
+            description("Unlocks in-progress foldings that may be unstable or change without notice. Expect occasional visual glitches while testing.")
             example("ExperimentalTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#experimental")
         }

--- a/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
@@ -1,32 +1,86 @@
 package com.intellij.advancedExpressionFolding.settings.view
 
+import com.intellij.ui.JBColor
+import java.awt.Color
 import kotlin.reflect.KMutableProperty0
 
 @DslMarker
 annotation class CheckboxDsl
 
-typealias Description = String
+typealias ExampleDescription = String
 typealias UrlSuffix = String
 typealias ExampleFile = String
 
 data class CheckboxDefinition(
     val title: String,
     val property: KMutableProperty0<Boolean>,
-    val exampleLinkMap: Map<ExampleFile, Description?>? = null,
-    val docLink: UrlSuffix? = null
+    val exampleLinkMap: Map<ExampleFile, ExampleDescription?>? = null,
+    val docLink: UrlSuffix? = null,
+    val badge: FeatureBadge? = null,
+    val longDescription: String? = null
 )
+
+data class FeatureBadge(
+    val label: String,
+    val style: FeatureBadgeStyle
+)
+
+enum class FeatureBadgeStyle(
+    private val lightBackground: Int,
+    private val darkBackground: Int,
+    private val lightForeground: Int,
+    private val darkForeground: Int,
+    private val lightBorder: Int,
+    private val darkBorder: Int
+) {
+    NEW(
+        lightBackground = 0xE7F6EC,
+        darkBackground = 0x204029,
+        lightForeground = 0x1B5E20,
+        darkForeground = 0xA5D6A7,
+        lightBorder = 0xA5D6A7,
+        darkBorder = 0x2E7D32
+    ),
+    EXPERIMENTAL(
+        lightBackground = 0xFFF4E5,
+        darkBackground = 0x3D2B1F,
+        lightForeground = 0xBF360C,
+        darkForeground = 0xFFCC80,
+        lightBorder = 0xFFB74D,
+        darkBorder = 0xE65100
+    );
+
+    val background: Color
+        get() = Color(if (JBColor.isBright()) lightBackground else darkBackground)
+
+    val foreground: Color
+        get() = Color(if (JBColor.isBright()) lightForeground else darkForeground)
+
+    val border: Color
+        get() = Color(if (JBColor.isBright()) lightBorder else darkBorder)
+}
 
 @CheckboxDsl
 class CheckboxBuilder {
-    private val examples = mutableMapOf<ExampleFile, Description?>()
+    private val examples = mutableMapOf<ExampleFile, ExampleDescription?>()
     private var docLink: UrlSuffix? = null
+    private var badge: FeatureBadge? = null
+    private var longDescription: String? = null
 
-    fun example(file: ExampleFile, description: Description? = null) {
+    fun example(file: ExampleFile, description: ExampleDescription? = null) {
         examples[file] = description
     }
 
     fun link(documentationLink: UrlSuffix) {
         docLink = documentationLink
+    }
+
+    fun badge(label: String, style: FeatureBadgeStyle) {
+        badge = FeatureBadge(label, style)
+    }
+
+    fun description(details: String) {
+        longDescription = details
     }
 
     internal fun build(
@@ -37,7 +91,9 @@ class CheckboxBuilder {
             title = title,
             property = property,
             exampleLinkMap = if (examples.isEmpty()) null else examples.toMap(),
-            docLink = docLink
+            docLink = docLink,
+            badge = badge,
+            longDescription = longDescription
         )
     }
 


### PR DESCRIPTION

<img width="1094" height="834" alt="Screenshot 2025-10-25 at 19 41 22" src="https://github.com/user-attachments/assets/1e00dced-1c2b-44cb-910c-412d3dca1a08" />


## Summary
- extend the checkbox DSL with feature badges and optional descriptive text
- render status badges and descriptions in the settings UI to spotlight new or risky options
- mark the Memory improvements and Experimental features toggles with clear badges and richer guidance

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68ea78bcfae8832ea6dc3263ac06c67d