### PR TITLE
Add badges and descriptions for new and experimental settings

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -272,9 +272,17 @@ abstract class CheckboxesProvider {
             example("PseudoAnnotationsMainTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
-        // NEW OPTION
-        registerCheckbox(state::memoryImprovement, "Memory improvements")
+        registerCheckbox(state::memoryImprovement, "Memory improvements") {
+            status(
+                CheckboxStatus.NEW_FEATURE,
+                "Reduces the plugin's memory footprint by compacting folding caches. Enable when large projects feel memory constrained."
+            )
+        }
         registerCheckbox(state::experimental, "Experimental features") {
+            status(
+                CheckboxStatus.EXPERIMENTAL,
+                "Unlocks folding prototypes that are still under evaluation. Expect occasional misfolds and disable the option if editing becomes unstable."
+            )
             example("ExperimentalTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#experimental")
         }

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -18,12 +18,18 @@ import com.intellij.openapi.vfs.encoding.EncodingProjectManager
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBFont
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
 import java.awt.Color.decode
 import java.awt.FlowLayout
+import java.awt.Font
 import java.net.URI
 import javax.swing.JButton
+import javax.swing.JComponent
 import javax.swing.JPanel
 import kotlin.reflect.KMutableProperty0
 
@@ -176,24 +182,66 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     ) {
         val builder = CheckboxBuilder()
         block?.invoke(builder)
-        
+
+        val definition = builder.build(property, title)
+
         val checkbox = JBCheckBox(title)
         checkbox.isSelected = property.get()
         checkbox.addActionListener {
             pendingChanges[property] = checkbox.isSelected
         }
         propertyToCheckbox[property] = checkbox
-        
+
+        val decoratedCheckbox = definition.status?.let { status ->
+            createCheckboxWithBadge(checkbox, status)
+        } ?: checkbox
+
         row {
-            cell(checkbox)
+            cell(decoratedCheckbox)
         }
-        
-        val definition = builder.build(property, title)
+
+        definition.status?.let { status ->
+            row {
+                cell(createStatusDescriptionLabel(status))
+            }
+        }
+
         if (definition.exampleLinkMap != null || definition.docLink != null) {
             row {
                 cell(createExamplePanel(definition.exampleLinkMap, definition.docLink))
             }
         }
 
+    }
+}
+
+private fun createCheckboxWithBadge(
+    checkbox: JBCheckBox,
+    status: CheckboxStatusDefinition
+): JComponent {
+    val panel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0))
+    panel.isOpaque = false
+    panel.add(checkbox)
+    panel.add(createStatusBadge(status))
+    return panel
+}
+
+private fun createStatusBadge(status: CheckboxStatusDefinition): JBLabel {
+    return JBLabel(status.badgeText).apply {
+        font = JBFont.small()
+        font = font.deriveFont(Font.BOLD)
+        border = JBUI.Borders.empty(2, 8)
+        foreground = status.foreground
+        background = status.background
+        isOpaque = true
+        toolTipText = status.tooltip
+    }
+}
+
+private fun createStatusDescriptionLabel(status: CheckboxStatusDefinition): JBLabel {
+    return JBLabel("<html>${status.description}</html>").apply {
+        font = JBFont.small()
+        foreground = UIUtil.getContextHelpForeground()
+        border = JBUI.Borders.empty(0, JBUI.scale(24), JBUI.scale(8), 0)
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
@@ -1,5 +1,7 @@
 package com.intellij.advancedExpressionFolding.settings.view
 
+import com.intellij.ui.JBColor
+import java.awt.Color
 import kotlin.reflect.KMutableProperty0
 
 @DslMarker
@@ -13,13 +15,49 @@ data class CheckboxDefinition(
     val title: String,
     val property: KMutableProperty0<Boolean>,
     val exampleLinkMap: Map<ExampleFile, Description?>? = null,
-    val docLink: UrlSuffix? = null
+    val docLink: UrlSuffix? = null,
+    val status: CheckboxStatusDefinition? = null
 )
+
+data class CheckboxStatusDefinition(
+    val status: CheckboxStatus,
+    val descriptionOverride: Description?
+) {
+    val badgeText: String get() = status.badgeText
+    val tooltip: String? get() = status.tooltip
+    val background: JBColor get() = status.background
+    val foreground: JBColor get() = status.foreground
+    val description: Description get() = descriptionOverride ?: status.defaultDescription
+}
+
+enum class CheckboxStatus(
+    val badgeText: String,
+    val defaultDescription: Description,
+    val tooltip: String?,
+    val background: JBColor,
+    val foreground: JBColor
+) {
+    NEW_FEATURE(
+        badgeText = "NEW",
+        defaultDescription = "Fresh functionality that is still stabilizing. Keep an eye on IDE performance when the option is enabled.",
+        tooltip = "Recently introduced option",
+        background = JBColor(Color(0xE6F4EA), Color(0x1F3328)),
+        foreground = JBColor(Color(0x0F5132), Color(0xCFECDC))
+    ),
+    EXPERIMENTAL(
+        badgeText = "EXPERIMENTAL",
+        defaultDescription = "Work in progress functionality. Behaviors may change and the option could cause unexpected folding results.",
+        tooltip = "Experimental – use with caution",
+        background = JBColor(Color(0xFFF4E5), Color(0x352711)),
+        foreground = JBColor(Color(0x663C00), Color(0xFFE8C2))
+    )
+}
 
 @CheckboxDsl
 class CheckboxBuilder {
     private val examples = mutableMapOf<ExampleFile, Description?>()
     private var docLink: UrlSuffix? = null
+    private var status: CheckboxStatusDefinition? = null
 
     fun example(file: ExampleFile, description: Description? = null) {
         examples[file] = description
@@ -27,6 +65,10 @@ class CheckboxBuilder {
 
     fun link(documentationLink: UrlSuffix) {
         docLink = documentationLink
+    }
+
+    fun status(status: CheckboxStatus, description: Description? = null) {
+        this.status = CheckboxStatusDefinition(status, description)
     }
 
     internal fun build(
@@ -37,7 +79,8 @@ class CheckboxBuilder {
             title = title,
             property = property,
             exampleLinkMap = if (examples.isEmpty()) null else examples.toMap(),
-            docLink = docLink
+            docLink = docLink,
+            status = status
         )
     }
 


### PR DESCRIPTION

<img width="1094" height="834" alt="Screenshot 2025-10-25 at 19 26 34" src="https://github.com/user-attachments/assets/cd5a2639-5843-4458-ba82-e9c97699df0a" />


## Summary
- extend the checkbox DSL with status metadata so settings can be marked as new or experimental
- decorate the Memory improvements and Experimental features options with badges and explanatory text
- render the new status badges and descriptions in the settings panel so risky options stand out

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ea78bcfae8832ea6dc3263ac06c67d