### PR TITLE
Integrate folding group language into main plugin - 4

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,6 +10,20 @@
     <resource-bundle>Bundle</resource-bundle>
 
     <extensions defaultExtensionNs="com.intellij">
+        <fileType name="FoldingGroup"
+                  language="FoldingGroupLang"
+                  extensions="group.java;group.sample;group"
+                  fieldName="INSTANCE"
+                  implementationClass="com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupFileType"/>
+        <lang.parserDefinition language="FoldingGroupLang"
+                               implementationClass="com.intellij.advancedExpressionFolding.foldingGroup.parser.FoldingGroupParserDefinition"/>
+        <lang.syntaxHighlighterFactory language="FoldingGroupLang"
+                                       implementationClass="com.intellij.advancedExpressionFolding.foldingGroup.highlighting.FoldingGroupSyntaxHighlighterFactory"/>
+        <annotator language="FoldingGroupLang"
+                   implementationClass="com.intellij.advancedExpressionFolding.foldingGroup.annotator.FoldingGroupAnnotator"/>
+        <lang.braceMatcher language="FoldingGroupLang"
+                            implementationClass="com.intellij.advancedExpressionFolding.foldingGroup.editor.FoldingGroupBraceMatcher"/>
+        <colorSettingsPage implementation="com.intellij.advancedExpressionFolding.foldingGroup.highlighting.FoldingGroupColorSettingsPage"/>
         <!-- Entry point: Java folding builder delegating to expressionBuilder extensions -->
         <lang.foldingBuilder language="JAVA"
                              implementationClass="com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder"/>

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupFile.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupFile.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.foldingGroup
+
+import com.intellij.extapi.psi.PsiFileBase
+import com.intellij.psi.FileViewProvider
+
+class FoldingGroupFile(viewProvider: FileViewProvider) : PsiFileBase(viewProvider, FoldingGroupLanguage) {
+  override fun getFileType() = FoldingGroupFileType
+
+  override fun toString(): String = "FoldingGroupFile"
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupFileType.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupFileType.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.foldingGroup
+
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.vfs.VirtualFile
+import javax.swing.Icon
+
+object FoldingGroupFileType : LanguageFileType(FoldingGroupLanguage) {
+  override fun getName(): String = "FoldingGroup"
+
+  override fun getDescription(): String = "Folding group marker file"
+
+  override fun getDefaultExtension(): String = "group.java"
+
+  override fun getIcon(): Icon? = null
+
+  override fun getCharset(file: VirtualFile, content: ByteArray): String = "UTF-8"
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupLanguage.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/FoldingGroupLanguage.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.foldingGroup
+
+import com.intellij.lang.Language
+
+object FoldingGroupLanguage : Language("FoldingGroupLang") {
+  override fun isCaseSensitive(): Boolean = true
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/annotator/FoldingGroupAnnotator.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/annotator/FoldingGroupAnnotator.kt
@@ -1,0 +1,134 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.annotator
+
+import com.intellij.advancedExpressionFolding.foldingGroup.highlighting.FoldingGroupColors
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupTokenTypes
+import com.intellij.advancedExpressionFolding.foldingGroup.psi.FoldingGroupMarker
+import com.intellij.advancedExpressionFolding.foldingGroup.psi.FoldingGroupText
+import com.intellij.advancedExpressionFolding.foldingGroup.parser.FoldingGroupElementTypes
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+
+class FoldingGroupAnnotator : Annotator {
+  override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    if (element is FoldingGroupMarker) {
+      annotateMarker(element, holder)
+    }
+  }
+
+  private fun annotateMarker(marker: FoldingGroupMarker, holder: AnnotationHolder) {
+    val numberElement = marker.numberElement
+    if (numberElement != null) {
+      val numberText = numberElement.text
+      if (numberText.length > 1 && numberText.startsWith('0')) {
+        holder.newAnnotation(HighlightSeverity.ERROR, "Leading zeros are not allowed")
+          .range(numberElement.textRange)
+          .create()
+      }
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+        .range(numberElement.textRange)
+        .textAttributes(FoldingGroupColors.numberKey(marker.groupId))
+        .create()
+    } else {
+      holder.newAnnotation(HighlightSeverity.ERROR, "Group number expected")
+        .range(marker.textRange)
+        .create()
+    }
+
+    val openQuote = marker.node.findChildByType(FoldingGroupElementTypes.GROUP_QUOTE_OPEN)
+    val closeQuote = marker.node.findChildByType(FoldingGroupElementTypes.GROUP_QUOTE_CLOSE)
+    if (openQuote != null && closeQuote == null) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "Closing quote is missing")
+        .range(marker.textRange)
+        .create()
+    }
+
+    val closeBracket = marker.closingBracket
+    if (closeBracket == null) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "']' expected")
+        .range(marker.textRange)
+        .create()
+    }
+
+    val textElement = marker.quotedTextElement
+    if (textElement != null) {
+      annotateText(marker.groupId, textElement, holder)
+    }
+
+    val message = buildTooltip(marker)
+    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+      .range(marker.textRange)
+      .tooltip(message)
+      .create()
+  }
+
+  private fun annotateText(groupId: Int, textElement: FoldingGroupText, holder: AnnotationHolder) {
+    if (textElement.textLength == 0) {
+      holder.newAnnotation(HighlightSeverity.WARNING, "Empty folding text")
+        .range(textElement.parent.textRange)
+        .create()
+      return
+    }
+
+    holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+      .range(textElement.textRange)
+      .textAttributes(FoldingGroupColors.textKey(groupId))
+      .create()
+
+    val children = textElement.node.getChildren(null)
+    for (child in children) {
+      val elementType = child.elementType
+      if (elementType == FoldingGroupTokenTypes.ESCAPED_SEQUENCE) {
+        continue
+      }
+      if (elementType == FoldingGroupTokenTypes.TEXT_CHUNK) {
+        val chunk = child.text
+        var index = 0
+        while (index < chunk.length) {
+          if (chunk[index] == '\\') {
+            val nextIndex = index + 1
+            if (nextIndex >= chunk.length) {
+              registerUnknownEscape(child.psi, index, index + 1, holder)
+              break
+            }
+            val next = chunk[nextIndex]
+            if (next != '\\' && next != '"' && next != 'n' && next != 't') {
+              registerUnknownEscape(child.psi, index, nextIndex + 1, holder)
+            }
+            index = nextIndex + 1
+          } else {
+            index++
+          }
+        }
+      }
+    }
+  }
+
+  private fun registerUnknownEscape(element: PsiElement, start: Int, end: Int, holder: AnnotationHolder) {
+    val base = element.textRange.startOffset
+    val range = TextRange(base + start, base + end)
+    holder.newAnnotation(HighlightSeverity.WARNING, "Unknown escape sequence")
+      .range(range)
+      .create()
+  }
+
+  private fun buildTooltip(marker: FoldingGroupMarker): String {
+    val id = if (marker.groupId >= 0) marker.groupId.toString() else "?"
+    val raw = marker.rawText
+    val escaped = buildString {
+      for (ch in raw) {
+        when (ch) {
+          '\n' -> append("\\n")
+          '\t' -> append("\\t")
+          '\r' -> { /* skip */ }
+          '"' -> append("\\\"")
+          else -> append(ch)
+        }
+      }
+    }
+    val preview = if (escaped.length > 40) escaped.substring(0, 37) + "…" else escaped
+    return "Group $id • length: ${raw.length} • preview: \"$preview\""
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/editor/FoldingGroupBraceMatcher.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/editor/FoldingGroupBraceMatcher.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.editor
+
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupTokenTypes
+import com.intellij.lang.BracePair
+import com.intellij.lang.PairedBraceMatcher
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IElementType
+
+class FoldingGroupBraceMatcher : PairedBraceMatcher {
+  private val pairs = arrayOf(BracePair(FoldingGroupTokenTypes.LBRACKET, FoldingGroupTokenTypes.RBRACKET, false))
+
+  override fun getPairs(): Array<BracePair> = pairs
+
+  override fun isPairedBracesAllowedBeforeType(lbraceType: IElementType, tokenType: IElementType?): Boolean = true
+
+  override fun getCodeConstructStart(file: PsiFile, openingBraceOffset: Int): Int = openingBraceOffset
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupColorSettingsPage.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupColorSettingsPage.kt
@@ -1,0 +1,30 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.highlighting
+
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.options.colors.ColorDescriptor
+import com.intellij.openapi.options.colors.ColorSettingsPage
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import javax.swing.Icon
+
+class FoldingGroupColorSettingsPage : ColorSettingsPage {
+  private val descriptors = arrayOf(
+    AttributesDescriptor("Brackets", FoldingGroupColors.GROUP_BRACKET),
+    AttributesDescriptor(":", FoldingGroupColors.GROUP_COLON),
+    AttributesDescriptor("Quotes", FoldingGroupColors.GROUP_QUOTE)
+  )
+
+  override fun getDisplayName(): String = "Folding Group Markers"
+
+  override fun getIcon(): Icon? = null
+
+  override fun getHighlighter(): SyntaxHighlighter = FoldingGroupSyntaxHighlighter()
+
+  override fun getAttributeDescriptors(): Array<AttributesDescriptor> = descriptors
+
+  override fun getColorDescriptors(): Array<ColorDescriptor> = ColorDescriptor.EMPTY_ARRAY
+
+  override fun getDemoText(): String = "pre [2:\"demo\"] post"
+
+  override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey>? = null
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupColors.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupColors.kt
@@ -1,0 +1,67 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.highlighting
+
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import java.awt.Color
+
+object FoldingGroupColors {
+  private val PALETTE = intArrayOf(
+    0x6272A4,
+    0xBD93F9,
+    0x50FA7B,
+    0xFF79C6,
+    0x8BE9FD,
+    0xF1FA8C,
+    0xFFB86C,
+    0xFF5555,
+    0xA4FFFF,
+    0xC792EA
+  )
+
+  val GROUP_BRACKET: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+    "FOLDING_GROUP_BRACKET",
+    TextAttributes(Color(0x44475A), null, null, null, 1)
+  )
+
+  val GROUP_COLON: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+    "FOLDING_GROUP_COLON",
+    TextAttributes(Color(0x6272A4), null, null, null, 0)
+  )
+
+  val GROUP_QUOTE: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+    "FOLDING_GROUP_QUOTE",
+    TextAttributes(Color(0x708090), null, null, null, 0)
+  )
+
+  private val numberKeys: Array<TextAttributesKey> = Array(10) { index ->
+    TextAttributesKey.createTextAttributesKey(
+      "FOLDING_GROUP_NUMBER_$index",
+      TextAttributes(Color(PALETTE[index]), null, null, null, 0)
+    )
+  }
+
+  private val textKeys: Array<TextAttributesKey> = Array(10) { index ->
+    val baseColor = Color(PALETTE[index])
+    val background = Color(baseColor.red, baseColor.green, baseColor.blue, if (index == 0) (0.18f * 255).toInt() else 38)
+    TextAttributesKey.createTextAttributesKey(
+      "FOLDING_GROUP_TEXT_$index",
+      TextAttributes(Color(0xF8F8F2), background, null, null, 0)
+    )
+  }
+
+  val DEFAULT_TEXT: TextAttributesKey = TextAttributesKey.createTextAttributesKey(
+    "FOLDING_GROUP_DEFAULT_TEXT",
+    DefaultLanguageHighlighterColors.STRING
+  )
+
+  fun numberKey(groupId: Int): TextAttributesKey = numberKeys[modIndex(groupId)]
+
+  fun textKey(groupId: Int): TextAttributesKey = textKeys[modIndex(groupId)]
+
+  private fun modIndex(groupId: Int): Int {
+    if (groupId < 0) return 0
+    return groupId % 10
+  }
+
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupSyntaxHighlighter.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupSyntaxHighlighter.kt
@@ -1,0 +1,18 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.highlighting
+
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupLexer
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupTokenTypes
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
+import com.intellij.psi.tree.IElementType
+
+class FoldingGroupSyntaxHighlighter : SyntaxHighlighterBase() {
+  override fun getHighlightingLexer() = FoldingGroupLexer()
+
+  override fun getTokenHighlights(tokenType: IElementType): Array<TextAttributesKey> = when (tokenType) {
+    FoldingGroupTokenTypes.LBRACKET, FoldingGroupTokenTypes.RBRACKET -> pack(FoldingGroupColors.GROUP_BRACKET)
+    FoldingGroupTokenTypes.COLON -> pack(FoldingGroupColors.GROUP_COLON)
+    FoldingGroupTokenTypes.QUOTE -> pack(FoldingGroupColors.GROUP_QUOTE)
+    else -> emptyArray()
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupSyntaxHighlighterFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/highlighting/FoldingGroupSyntaxHighlighterFactory.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.highlighting
+
+import com.intellij.openapi.fileTypes.SingleLazyInstanceSyntaxHighlighterFactory
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+class FoldingGroupSyntaxHighlighterFactory : SingleLazyInstanceSyntaxHighlighterFactory() {
+  override fun createHighlighter(): SyntaxHighlighter = FoldingGroupSyntaxHighlighter()
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupLexer.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupLexer.kt
@@ -1,0 +1,241 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.lexer
+
+import com.intellij.lexer.LexerBase
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
+
+private const val STATE_DEFAULT = 0
+private const val STATE_AFTER_LBRACKET = 1
+private const val STATE_AFTER_NUMBER = 2
+private const val STATE_AFTER_COLON = 3
+private const val STATE_IN_TEXT = 4
+private const val STATE_AFTER_QUOTE = 5
+
+class FoldingGroupLexer : LexerBase() {
+  private var buffer: CharSequence = ""
+  private var endOffset: Int = 0
+  private var tokenStart: Int = 0
+  private var tokenEnd: Int = 0
+  private var tokenType: IElementType? = null
+  private var state: Int = STATE_DEFAULT
+
+  override fun getState(): Int = state
+
+  override fun getTokenType(): IElementType? = tokenType
+
+  override fun getTokenStart(): Int = tokenStart
+
+  override fun getTokenEnd(): Int = tokenEnd
+
+  override fun getBufferSequence(): CharSequence = buffer
+
+  override fun getBufferEnd(): Int = endOffset
+
+  override fun start(buffer: CharSequence, startOffset: Int, endOffset: Int, initialState: Int) {
+    this.buffer = buffer
+    this.endOffset = endOffset
+    this.tokenStart = startOffset
+    this.tokenEnd = startOffset
+    this.state = initialState
+    this.tokenType = null
+    advance()
+  }
+
+  override fun advance() {
+    if (tokenEnd >= endOffset) {
+      tokenType = null
+      tokenStart = endOffset
+      return
+    }
+    tokenStart = if (tokenType == null) tokenStart else tokenEnd
+    when (state) {
+      STATE_DEFAULT -> lexDefault()
+      STATE_AFTER_LBRACKET -> lexAfterLBracket()
+      STATE_AFTER_NUMBER -> lexAfterNumber()
+      STATE_AFTER_COLON -> lexAfterColon()
+      STATE_IN_TEXT -> lexInText()
+      STATE_AFTER_QUOTE -> lexAfterQuote()
+      else -> lexDefault()
+    }
+  }
+
+  private fun lexDefault() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c == '[' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.LBRACKET
+        state = STATE_AFTER_LBRACKET
+      }
+      c.isWhitespace() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isWhitespace() }
+        tokenType = TokenType.WHITE_SPACE
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '[' || it.isWhitespace() }
+        tokenType = FoldingGroupTokenTypes.PLAINTEXT
+      }
+    }
+  }
+
+  private fun lexAfterLBracket() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c.isWhitespace() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isWhitespace() }
+        tokenType = TokenType.WHITE_SPACE
+      }
+      c.isDigit() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isDigit() }
+        tokenType = FoldingGroupTokenTypes.GROUP_NUMBER
+        state = STATE_AFTER_NUMBER
+      }
+      c == ':' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.COLON
+        state = STATE_AFTER_COLON
+      }
+      c == '"' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.QUOTE
+        state = STATE_IN_TEXT
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '[' || it.isWhitespace() }
+        tokenType = FoldingGroupTokenTypes.PLAINTEXT
+        state = STATE_DEFAULT
+      }
+    }
+  }
+
+  private fun lexAfterNumber() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c.isWhitespace() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isWhitespace() }
+        tokenType = TokenType.WHITE_SPACE
+      }
+      c == ':' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.COLON
+        state = STATE_AFTER_COLON
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '[' || it.isWhitespace() }
+        tokenType = FoldingGroupTokenTypes.PLAINTEXT
+        state = STATE_DEFAULT
+      }
+    }
+  }
+
+  private fun lexAfterColon() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c.isWhitespace() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isWhitespace() }
+        tokenType = TokenType.WHITE_SPACE
+      }
+      c == '"' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.QUOTE
+        state = STATE_IN_TEXT
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '[' || it.isWhitespace() }
+        tokenType = FoldingGroupTokenTypes.PLAINTEXT
+        state = STATE_DEFAULT
+      }
+    }
+  }
+
+  private fun lexInText() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c == '"' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.QUOTE
+        state = STATE_AFTER_QUOTE
+      }
+      c == '\\' -> {
+        if (tokenStart + 1 < endOffset) {
+          val next = buffer[tokenStart + 1]
+          if (next == '\\' || next == '"' || next == 'n' || next == 't') {
+            tokenEnd = tokenStart + 2
+            tokenType = FoldingGroupTokenTypes.ESCAPED_SEQUENCE
+            return
+          }
+        }
+        tokenEnd = (tokenStart + 2).coerceAtMost(endOffset)
+        tokenType = FoldingGroupTokenTypes.TEXT_CHUNK
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '"' || it == '\\' }
+        tokenType = FoldingGroupTokenTypes.TEXT_CHUNK
+      }
+    }
+  }
+
+  private fun lexAfterQuote() {
+    if (tokenStart >= endOffset) {
+      tokenType = null
+      return
+    }
+    val c = buffer[tokenStart]
+    when {
+      c.isWhitespace() -> {
+        tokenEnd = scanWhile(tokenStart) { it.isWhitespace() }
+        tokenType = TokenType.WHITE_SPACE
+      }
+      c == ']' -> {
+        tokenEnd = tokenStart + 1
+        tokenType = FoldingGroupTokenTypes.RBRACKET
+        state = STATE_DEFAULT
+      }
+      else -> {
+        tokenEnd = scanUntil(tokenStart) { it == '[' || it.isWhitespace() }
+        tokenType = FoldingGroupTokenTypes.PLAINTEXT
+        state = STATE_DEFAULT
+      }
+    }
+  }
+
+  private inline fun scanWhile(start: Int, predicate: (Char) -> Boolean): Int {
+    var index = start
+    while (index < endOffset && predicate(buffer[index])) {
+      index++
+    }
+    return index
+  }
+
+  private inline fun scanUntil(start: Int, stopPredicate: (Char) -> Boolean): Int {
+    var index = start
+    while (index < endOffset && !stopPredicate(buffer[index])) {
+      index++
+    }
+    return index
+  }
+
+  private fun Char.isWhitespace(): Boolean = this == ' ' || this == '\t' || this == '\n' || this == '\r'
+
+  private fun Char.isDigit(): Boolean = this in '0'..'9'
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupTokenType.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupTokenType.kt
@@ -1,0 +1,21 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.lexer
+
+import com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupLanguage
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.TokenType
+
+class FoldingGroupTokenType(debugName: String) : IElementType(debugName, FoldingGroupLanguage) {
+  override fun toString(): String = "FoldingGroupTokenType." + super.toString()
+}
+
+object FoldingGroupTokenTypes {
+  val LBRACKET = FoldingGroupTokenType("LBRACKET")
+  val RBRACKET = FoldingGroupTokenType("RBRACKET")
+  val COLON = FoldingGroupTokenType("COLON")
+  val QUOTE = FoldingGroupTokenType("QUOTE")
+  val GROUP_NUMBER = FoldingGroupTokenType("GROUP_NUMBER")
+  val ESCAPED_SEQUENCE = FoldingGroupTokenType("ESCAPED_SEQUENCE")
+  val TEXT_CHUNK = FoldingGroupTokenType("TEXT_CHUNK")
+  val PLAINTEXT = FoldingGroupTokenType("PLAINTEXT")
+  val BAD_CHARACTER: IElementType = TokenType.BAD_CHARACTER
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupElementType.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupElementType.kt
@@ -1,0 +1,6 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.parser
+
+import com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupLanguage
+import com.intellij.psi.tree.IElementType
+
+class FoldingGroupElementType(debugName: String) : IElementType(debugName, FoldingGroupLanguage)

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupElementTypes.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupElementTypes.kt
@@ -1,0 +1,41 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.parser
+
+import com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupLanguage
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupTokenTypes
+import com.intellij.advancedExpressionFolding.foldingGroup.psi.*
+import com.intellij.lang.ASTNode
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.IFileElementType
+import com.intellij.psi.tree.TokenSet
+
+object FoldingGroupElementTypes {
+  val FILE: IFileElementType = IFileElementType(FoldingGroupLanguage)
+
+  val GROUP_MARKER = FoldingGroupElementType("GROUP_MARKER")
+  val GROUP_OPEN = FoldingGroupElementType("GROUP_OPEN")
+  val GROUP_NUMBER_NODE = FoldingGroupElementType("GROUP_NUMBER_NODE")
+  val GROUP_COLON = FoldingGroupElementType("GROUP_COLON")
+  val GROUP_QUOTE_OPEN = FoldingGroupElementType("GROUP_QUOTE_OPEN")
+  val GROUP_TEXT = FoldingGroupElementType("GROUP_TEXT")
+  val GROUP_QUOTE_CLOSE = FoldingGroupElementType("GROUP_QUOTE_CLOSE")
+  val GROUP_CLOSE = FoldingGroupElementType("GROUP_CLOSE")
+  val PLAIN_TEXT = FoldingGroupElementType("PLAIN_TEXT")
+
+  val WHITE_SPACES: TokenSet = TokenSet.create(TokenType.WHITE_SPACE)
+  val STRINGS: TokenSet = TokenSet.create(FoldingGroupTokenTypes.TEXT_CHUNK, FoldingGroupTokenTypes.ESCAPED_SEQUENCE)
+  val COMMENTS: TokenSet = TokenSet.EMPTY
+
+  fun createElement(node: ASTNode) = when (node.elementType) {
+    GROUP_MARKER -> FoldingGroupMarker(node)
+    GROUP_OPEN -> FoldingGroupLeaf(node)
+    GROUP_NUMBER_NODE -> FoldingGroupNumber(node)
+    GROUP_COLON -> FoldingGroupLeaf(node)
+    GROUP_QUOTE_OPEN -> FoldingGroupLeaf(node)
+    GROUP_TEXT -> FoldingGroupText(node)
+    GROUP_QUOTE_CLOSE -> FoldingGroupLeaf(node)
+    GROUP_CLOSE -> FoldingGroupLeaf(node)
+    PLAIN_TEXT -> FoldingGroupPlainText(node)
+    else -> FoldingGroupPsiElement(node)
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupParser.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupParser.kt
@@ -1,0 +1,125 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.parser
+
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupTokenTypes
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.PsiParser
+import com.intellij.psi.tree.IElementType
+
+class FoldingGroupParser : PsiParser {
+  override fun parse(root: IElementType, builder: PsiBuilder): ASTNode {
+    val rootMarker = builder.mark()
+    while (!builder.eof()) {
+      if (builder.tokenType == FoldingGroupTokenTypes.LBRACKET) {
+        if (!parseMarker(builder)) {
+          parsePlainText(builder)
+        }
+      } else {
+        parsePlainText(builder)
+      }
+    }
+    rootMarker.done(root)
+    return builder.treeBuilt
+  }
+
+  private fun parsePlainText(builder: PsiBuilder) {
+    val marker = builder.mark()
+    var advanced = false
+    while (!builder.eof() && builder.tokenType != FoldingGroupTokenTypes.LBRACKET) {
+      builder.advanceLexer()
+      advanced = true
+    }
+    if (advanced) {
+      marker.done(FoldingGroupElementTypes.PLAIN_TEXT)
+    } else {
+      marker.drop()
+      builder.advanceLexer()
+    }
+  }
+
+  private fun parseMarker(builder: PsiBuilder): Boolean {
+    val marker = builder.mark()
+    if (builder.tokenType != FoldingGroupTokenTypes.LBRACKET) {
+      marker.drop()
+      return false
+    }
+    wrapToken(builder, FoldingGroupElementTypes.GROUP_OPEN)
+
+    skipWhitespace(builder)
+    if (builder.tokenType == FoldingGroupTokenTypes.GROUP_NUMBER) {
+      wrapToken(builder, FoldingGroupElementTypes.GROUP_NUMBER_NODE)
+      skipWhitespace(builder)
+    }
+    if (builder.tokenType == FoldingGroupTokenTypes.COLON) {
+      wrapToken(builder, FoldingGroupElementTypes.GROUP_COLON)
+    } else {
+      builder.error("':' expected")
+    }
+    skipWhitespace(builder)
+    if (builder.tokenType == FoldingGroupTokenTypes.QUOTE) {
+      wrapToken(builder, FoldingGroupElementTypes.GROUP_QUOTE_OPEN)
+    } else {
+      builder.error("Opening quote expected")
+      marker.done(FoldingGroupElementTypes.GROUP_MARKER)
+      return true
+    }
+
+    val textMarker = builder.mark()
+    var hasText = false
+    while (!builder.eof()) {
+      val tokenType = builder.tokenType
+      if (tokenType == FoldingGroupTokenTypes.QUOTE) {
+        break
+      }
+      if (tokenType == FoldingGroupTokenTypes.ESCAPED_SEQUENCE || tokenType == FoldingGroupTokenTypes.TEXT_CHUNK) {
+        builder.advanceLexer()
+        hasText = true
+        continue
+      }
+      if (tokenType == FoldingGroupTokenTypes.RBRACKET) {
+        break
+      }
+      if (tokenType == FoldingGroupTokenTypes.LBRACKET) {
+        break
+      }
+      builder.advanceLexer()
+      hasText = true
+    }
+    if (hasText) {
+      textMarker.done(FoldingGroupElementTypes.GROUP_TEXT)
+    } else {
+      textMarker.done(FoldingGroupElementTypes.GROUP_TEXT)
+    }
+
+    if (builder.tokenType == FoldingGroupTokenTypes.QUOTE) {
+      wrapToken(builder, FoldingGroupElementTypes.GROUP_QUOTE_CLOSE)
+    } else {
+      builder.error("Closing quote expected")
+      marker.done(FoldingGroupElementTypes.GROUP_MARKER)
+      return true
+    }
+
+    skipWhitespace(builder)
+    if (builder.tokenType == FoldingGroupTokenTypes.RBRACKET) {
+      wrapToken(builder, FoldingGroupElementTypes.GROUP_CLOSE)
+    } else {
+      builder.error("']' expected")
+      marker.done(FoldingGroupElementTypes.GROUP_MARKER)
+      return true
+    }
+    marker.done(FoldingGroupElementTypes.GROUP_MARKER)
+    return true
+  }
+
+  private fun skipWhitespace(builder: PsiBuilder) {
+    while (builder.tokenType == com.intellij.psi.TokenType.WHITE_SPACE) {
+      builder.advanceLexer()
+    }
+  }
+
+  private fun wrapToken(builder: PsiBuilder, type: IElementType) {
+    val marker = builder.mark()
+    builder.advanceLexer()
+    marker.done(type)
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupParserDefinition.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupParserDefinition.kt
@@ -1,0 +1,32 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.parser
+
+import com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupFile
+import com.intellij.advancedExpressionFolding.foldingGroup.lexer.FoldingGroupLexer
+import com.intellij.lang.ASTNode
+import com.intellij.lang.ParserDefinition
+import com.intellij.lang.PsiParser
+import com.intellij.openapi.project.Project
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.TokenSet
+
+class FoldingGroupParserDefinition : ParserDefinition {
+  override fun createLexer(project: Project) = FoldingGroupLexer()
+
+  override fun createParser(project: Project): PsiParser = FoldingGroupParser()
+
+  override fun getFileNodeType() = FoldingGroupElementTypes.FILE
+
+  override fun getWhitespaceTokens(): TokenSet = FoldingGroupElementTypes.WHITE_SPACES
+
+  override fun getCommentTokens(): TokenSet = FoldingGroupElementTypes.COMMENTS
+
+  override fun getStringLiteralElements(): TokenSet = FoldingGroupElementTypes.STRINGS
+
+  override fun createFile(viewProvider: FileViewProvider): PsiFile = FoldingGroupFile(viewProvider)
+
+  override fun createElement(node: ASTNode): PsiElement = FoldingGroupElementTypes.createElement(node)
+
+  override fun spaceExistenceTypeBetweenTokens(left: ASTNode, right: ASTNode): ParserDefinition.SpaceRequirements = ParserDefinition.SpaceRequirements.MAY
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupMarker.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupMarker.kt
@@ -1,0 +1,63 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.psi
+
+import com.intellij.advancedExpressionFolding.foldingGroup.parser.FoldingGroupElementTypes
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+class FoldingGroupMarker(node: ASTNode) : FoldingGroupPsiElement(node) {
+  val groupId: Int
+    get() = findChildByClass(FoldingGroupNumber::class.java)?.intValue() ?: -1
+
+  val rawText: String
+    get() {
+      val textNode = findChildByClass(FoldingGroupText::class.java) ?: return ""
+      return buildString {
+        val childNodes = textNode.node.getChildren(null)
+        if (childNodes.isEmpty()) {
+          append(unescapeSegment(textNode.text))
+        } else {
+          childNodes.forEach { node ->
+            append(unescapeSegment(node.text))
+          }
+        }
+      }
+    }
+
+  val quotedTextElement: FoldingGroupText?
+    get() = findChildByClass(FoldingGroupText::class.java)
+
+  val numberElement: FoldingGroupNumber?
+    get() = findChildByClass(FoldingGroupNumber::class.java)
+
+  val openBracket: PsiElement?
+    get() = node.findChildByType(FoldingGroupElementTypes.GROUP_OPEN)?.psi
+
+  val closingBracket: PsiElement?
+    get() = node.findChildByType(FoldingGroupElementTypes.GROUP_CLOSE)?.psi
+
+  private fun unescapeSegment(segment: String): String {
+    val builder = StringBuilder()
+    var index = 0
+    while (index < segment.length) {
+      val c = segment[index]
+      if (c == '\\' && index + 1 < segment.length) {
+        val next = segment[index + 1]
+        when (next) {
+          '\\' -> builder.append('\\')
+          '"' -> builder.append('"')
+          'n' -> builder.append('\n')
+          't' -> builder.append('\t')
+          else -> {
+            builder.append('\\')
+            builder.append(next)
+          }
+        }
+        index += 2
+      } else {
+        builder.append(c)
+        index++
+      }
+    }
+    return builder.toString().replace("\r", "")
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupNumber.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupNumber.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.psi
+
+import com.intellij.lang.ASTNode
+
+class FoldingGroupNumber(node: ASTNode) : FoldingGroupPsiElement(node) {
+  fun intValue(): Int? {
+    val text = text
+    return text.toIntOrNull()
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupPsiElement.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupPsiElement.kt
@@ -1,0 +1,11 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.psi
+
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+
+open class FoldingGroupPsiElement(node: ASTNode) : ASTWrapperPsiElement(node)
+
+class FoldingGroupLeaf(node: ASTNode) : FoldingGroupPsiElement(node)
+
+class FoldingGroupPlainText(node: ASTNode) : FoldingGroupPsiElement(node)

--- a/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupText.kt
+++ b/src/com/intellij/advancedExpressionFolding/foldingGroup/psi/FoldingGroupText.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.psi
+
+import com.intellij.lang.ASTNode
+
+class FoldingGroupText(node: ASTNode) : FoldingGroupPsiElement(node) {
+  fun segments(): List<String> = children.map { it.text }
+}

--- a/test/com/intellij/advancedExpressionFolding/foldingGroup/annotator/FoldingGroupAnnotatorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/foldingGroup/annotator/FoldingGroupAnnotatorTest.kt
@@ -1,0 +1,39 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.annotator
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.advancedExpressionFolding.foldingGroup.highlighting.FoldingGroupColors
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.lang.annotation.HighlightSeverity
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FoldingGroupAnnotatorTest : BaseTest() {
+  @Test
+  fun validMarkersProduceHighlights() {
+    fixture.configureByText("valid.group", """pre [10:"foo"] mid [0:"x + "y""] post""")
+    val infos = fixture.doHighlighting().filterIsInstance<HighlightInfo>()
+    assertTrue(infos.any { it.severity == HighlightSeverity.INFORMATION && it.forcedTextAttributesKey == FoldingGroupColors.numberKey(10) })
+    assertTrue(infos.any { it.toolTip?.contains("Group 10") == true })
+  }
+
+  @Test
+  fun leadingZeroError() {
+    fixture.configureByText("zero.group", """[01:"foo"]""")
+    val infos = fixture.doHighlighting().filterIsInstance<HighlightInfo>()
+    assertTrue(infos.any { it.description?.contains("Leading zeros") == true })
+  }
+
+  @Test
+  fun unknownEscapeWarning() {
+    fixture.configureByText("escape.group", """[1:"foo\xbar"]""")
+    val infos = fixture.doHighlighting().filterIsInstance<HighlightInfo>()
+    assertTrue(infos.any { it.description?.contains("Unknown escape") == true })
+  }
+
+  @Test
+  fun missingQuoteAndBracketErrors() {
+    fixture.configureByText("broken.group", """[2:"foo"""")
+    val infos = fixture.doHighlighting().filterIsInstance<HighlightInfo>()
+    assertTrue(infos.any { it.severity == HighlightSeverity.ERROR })
+  }
+}

--- a/test/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupLexerTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/foldingGroup/lexer/FoldingGroupLexerTest.kt
@@ -1,0 +1,39 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.lexer
+
+import com.intellij.psi.TokenType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldingGroupLexerTest {
+  @Test
+  fun markers() {
+    val text = "pre [2:\"say(\\\"hi\\\")\\nnext\"] post"
+    val lexer = FoldingGroupLexer()
+    lexer.start(text)
+    val tokens = mutableListOf<Pair<Any, String>>()
+    while (lexer.tokenType != null) {
+      tokens += lexer.tokenType!! to text.substring(lexer.tokenStart, lexer.tokenEnd)
+      lexer.advance()
+    }
+    val expected = listOf(
+      FoldingGroupTokenTypes.PLAINTEXT to "pre",
+      TokenType.WHITE_SPACE to " ",
+      FoldingGroupTokenTypes.LBRACKET to "[",
+      FoldingGroupTokenTypes.GROUP_NUMBER to "2",
+      FoldingGroupTokenTypes.COLON to ":",
+      FoldingGroupTokenTypes.QUOTE to "\"",
+      FoldingGroupTokenTypes.TEXT_CHUNK to "say(",
+      FoldingGroupTokenTypes.ESCAPED_SEQUENCE to "\\\"",
+      FoldingGroupTokenTypes.TEXT_CHUNK to "hi",
+      FoldingGroupTokenTypes.ESCAPED_SEQUENCE to "\\\"",
+      FoldingGroupTokenTypes.TEXT_CHUNK to ")",
+      FoldingGroupTokenTypes.ESCAPED_SEQUENCE to "\\n",
+      FoldingGroupTokenTypes.TEXT_CHUNK to "next",
+      FoldingGroupTokenTypes.QUOTE to "\"",
+      FoldingGroupTokenTypes.RBRACKET to "]",
+      TokenType.WHITE_SPACE to " ",
+      FoldingGroupTokenTypes.PLAINTEXT to "post"
+    )
+    assertEquals(expected, tokens)
+  }
+}

--- a/test/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupPsiTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/foldingGroup/parser/FoldingGroupPsiTest.kt
@@ -1,0 +1,25 @@
+package com.intellij.advancedExpressionFolding.foldingGroup.parser
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.advancedExpressionFolding.foldingGroup.FoldingGroupLanguage
+import com.intellij.advancedExpressionFolding.foldingGroup.psi.FoldingGroupMarker
+import com.intellij.openapi.application.runReadAction
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.util.PsiTreeUtil
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldingGroupPsiTest : BaseTest() {
+  @Test
+  fun groupProperties() {
+    val text = "[2:\"say(\\\"hi\\\")\\nnext\"]"
+    val file = runReadAction {
+      PsiFileFactory.getInstance(fixture.project).createFileFromText("sample.group", FoldingGroupLanguage, text)
+    }
+    val marker = runReadAction {
+      PsiTreeUtil.findChildOfType(file, FoldingGroupMarker::class.java)
+    } ?: error("Marker not found")
+    assertEquals(2, marker.groupId)
+    assertEquals("say(\"hi\")\nnext", marker.rawText)
+  }
+}

--- a/testData/foldingGroup/basic.group.java
+++ b/testData/foldingGroup/basic.group.java
@@ -1,0 +1,1 @@
+pre [10:"foo"] mid [0:"x + \"y\""] post


### PR DESCRIPTION
## Summary
- register the Folding Group language directly in the main plugin descriptor with its file type, parser definition, syntax highlighter factory, annotator, brace matcher, and color settings page
- relocate the Folding Group language sources under `com.intellij.advancedExpressionFolding.foldingGroup`, updating the syntax highlighter factory override and improving `FoldingGroupMarker.rawText`
- convert the Folding Group lexer, annotator, and PSI tests to JUnit 5 under the main test sources while exercising the new file type mapping

## Testing
- `./gradlew --console=plain test -Dkotlin.daemon.jvmargs=-Xmx6144m -Dkotlin.compiler.execution.strategy=in-process`

------
https://chatgpt.com/codex/tasks/task_e_68eb73279a20832ea56bdbde3e13205e