### PR TITLE
Use safe call operators in folding helpers

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -102,9 +102,9 @@ class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance
         try {
             val element = astNode.psi
             val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
-            if (document != null) {
-                val expression = BuildExpressionExt.getNonSyntheticExpression(element, document)
-                return expression != null && expression.isCollapsedByDefault()
+            document?.let {
+                val expression = BuildExpressionExt.getNonSyntheticExpression(element, it)
+                return expression?.isCollapsedByDefault() == true
             }
         } catch (_: IndexNotReadyException) {
             return false

--- a/src/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributor.kt
@@ -60,7 +60,11 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
 
     private fun findTopLevelClass(psiClass: PsiClass): PsiClass {
         var current = psiClass
-        while (current.containingClass != null) current = current.containingClass!!
+        while (true) {
+            current.containingClass?.let {
+                current = it
+            } ?: break
+        }
         return current
     }
 

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/NumberLiteral.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/NumberLiteral.kt
@@ -24,8 +24,7 @@ class NumberLiteral(
         parent: Expression?
     ): Array<FoldingDescriptor> {
         val descriptors = mutableListOf<FoldingDescriptor>()
-        val highlightedRange = numberTextRange
-        if (highlightedRange != null) {
+        numberTextRange?.let { highlightedRange ->
             val group = FoldingGroup.newGroup(NumberLiteral::class.java.name + HIGHLIGHTED_GROUP_POSTFIX)
             if (textRange.startOffset < highlightedRange.startOffset) {
                 descriptors += FoldingDescriptor(

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Variable.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Variable.kt
@@ -25,8 +25,7 @@ class Variable(
         parent: Expression?
     ): Array<FoldingDescriptor> {
         val descriptors = mutableListOf<FoldingDescriptor>()
-        val highlightedRange = variableTextRange
-        if (highlightedRange != null) {
+        variableTextRange?.let { highlightedRange ->
             val group = FoldingGroup.newGroup(Variable::class.java.name + Expression.HIGHLIGHTED_GROUP_POSTFIX)
             if (textRange.startOffset < highlightedRange.startOffset) {
                 descriptors += FoldingDescriptor(

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt
@@ -26,8 +26,7 @@ class OptionalNotNullAssertionGet(
             FoldingGroup.newGroup(Getter::class.java.name),
             "!!"
         )
-        val obj = `object`
-        if (obj != null && obj.supportsFoldRegions(document, this)) {
+        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/Getter.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/Getter.kt
@@ -29,8 +29,7 @@ class Getter(
             FoldingGroup.newGroup(Getter::class.java.name),
             name
         )
-        val obj = `object`
-        if (obj != null && obj.supportsFoldRegions(document, this)) {
+        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/GetterRecord.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/GetterRecord.kt
@@ -29,8 +29,7 @@ class GetterRecord(
             FoldingGroup.newGroup(GetterRecord::class.java.name),
             name
         )
-        val obj = `object`
-        if (obj != null && obj.supportsFoldRegions(document, this)) {
+        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/Setter.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/Setter.kt
@@ -44,8 +44,7 @@ class Setter(
                 )
             }
         }
-        val obj = `object`
-        if (obj != null && obj.supportsFoldRegions(document, this)) {
+        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         if (value.supportsFoldRegions(document, this)) {

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/AbstractMultiExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/AbstractMultiExpression.kt
@@ -41,9 +41,9 @@ abstract class AbstractMultiExpression(
         }
 
         children.forEach { child ->
-            if (child != null) {
-                assignGroupOnNotFound(child, parentGroup)
-                list += child.buildFoldRegions(child.element, document, this)
+            child?.let {
+                assignGroupOnNotFound(it, parentGroup)
+                list += it.buildFoldRegions(it.element, document, this)
             }
         }
         return list.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/AbstractSingleChildExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/AbstractSingleChildExpression.kt
@@ -54,11 +54,9 @@ abstract class AbstractSingleChildExpression(
             text,
         )
         val array = arrayOf(folding)
-        return if (child != null && child.supportsFoldRegions(document, this)) {
-            array + child.buildFoldRegions(child.element, document, this)
-        } else {
-            array
-        }
+        return child?.takeIf { it.supportsFoldRegions(document, this) }
+            ?.let { array + it.buildFoldRegions(it.element, document, this) }
+            ?: array
     }
 
     fun group(): FoldingGroup = this::class.group()


### PR DESCRIPTION
## Summary
- replace manual null checks with Kotlin safe calls across folding expression helpers
- streamline optional property handling in property getter/setter fold builders
- simplify collapse state lookup by using safe-call idioms in the folding builder

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ebbc6ba09c832ea4d561af904da04e