### PR TITLE
Convert trivial getters to extension properties

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt
@@ -15,7 +15,7 @@ object LombokConstructorExt : BaseExtension() {
                 val args = mutableListOf<String>()
                 it.modifierAsArgument().run(args::addAll)
                 if (it.modifier() != EModifier.PRIVATE) {
-                    it.body?.getComment()?.text?.run(args::add)
+                    it.body?.comment?.text?.run(args::add)
                 }
                 ClassLevelAnnotation(LOMBOK_NO_ARGS_CONSTRUCTOR, listOf(it), arguments = args)
             } else {

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
@@ -28,7 +28,7 @@ object SummaryParentOverrideExt : BaseExtension() {
                         //TODO: support sharedMethod from GrandparentClass as well here
                         findMethodBySignature(method, false) != null
                     }?.map {
-                        val sig = it.getSignature()
+                        val sig = it.signature
                         methodToParentClass[sig] = className
                         it.name
                     } ?: emptyList()
@@ -82,7 +82,7 @@ object SummaryParentOverrideExt : BaseExtension() {
         } else {
             body.lBrace
         }?.let { brace ->
-            val signature = element.getSignature()
+            val signature = element.signature
             element.containingClass?.getUserData(METHOD_TO_PARENT_CLASS_KEY)
                 ?.get(signature)?.let {
                     val prefix = if (oneLiner) {

--- a/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
@@ -129,7 +129,7 @@ fun PsiClass?.isBuilder(): Boolean {
     if (this == null) {
         return false
     }
-    val userData = getClassType()
+    val userData = classType
     if (userData == null) {
         allMethods.forEach {
             if (it.name == "build") {
@@ -155,7 +155,8 @@ fun PsiElement.setClassType(type: PsiClassExt.ClassType) {
     putCopyableUserData(Keys.CLASS_TYPE_KEY, type)
 }
 
-fun PsiElement.getClassType(): PsiClassExt.ClassType? = getUserData(Keys.CLASS_TYPE_KEY)
+val PsiElement.classType: PsiClassExt.ClassType?
+    get() = getUserData(Keys.CLASS_TYPE_KEY)
 
 var PsiMethod.propertyField: PsiField?
     get() = getUserData(Keys.FIELD_KEY)
@@ -204,11 +205,13 @@ fun PsiCodeBlock.hasComments(): Boolean = children.any {
     it is PsiComment
 }
 
-fun PsiCodeBlock.getComment(): PsiElement? = children.firstOrNull {
-    it is PsiComment
-}
+val PsiCodeBlock.comment: PsiElement?
+    get() = children.firstOrNull {
+        it is PsiComment
+    }
 
-fun PsiMethod.getSignature(): MethodSignature = getSignature(PsiSubstitutor.EMPTY)
+val PsiMethod.signature: MethodSignature
+    get() = getSignature(PsiSubstitutor.EMPTY)
 
 fun VirtualFile.toJavaPsiFile(project: Project): PsiJavaFile? {
     if (!isValid) {


### PR DESCRIPTION
## Summary
- convert reusable getter helpers into Kotlin extension properties
- update Lombok helpers to use the new properties in their call sites

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ebcc082e58832e81e63d2330d75f3f