### PR TITLE
Convert extension getters to properties

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
@@ -37,7 +37,7 @@ object CacheExt : StateDelegate() {
                     element.putUserData(key, newExpression.ofNullable())
                     newExpression
                 }
-                else -> cachedExpression.getOrNull()
+                else -> cachedExpression.orNull
             }
     }
 
@@ -45,9 +45,10 @@ object CacheExt : StateDelegate() {
         override fun toString(): String = "NULL_OBJECT"
     }
     private fun Expression?.ofNullable(): Expression = this ?: NULL_OBJECT
-    private fun Expression?.getOrNull(): Expression? = when {
-        this === NULL_OBJECT -> null
-        else -> this
-    }
+    private val Expression?.orNull: Expression?
+        get() = when {
+            this === NULL_OBJECT -> null
+            else -> this
+        }
 
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt
@@ -4,7 +4,7 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.HideExpression
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
-import com.intellij.advancedExpressionFolding.processor.lombok.MethodBodyInspector.getRethrownException
+import com.intellij.advancedExpressionFolding.processor.lombok.MethodBodyInspector.rethrownException
 import com.intellij.psi.PsiStatement
 import com.intellij.psi.PsiTryStatement
 
@@ -20,7 +20,7 @@ object PsiTryStatementExt : BaseExtension() {
             it.catchBlock?.statements?.singleOrNull() != null
         } ?: return null
 
-        val rethrownException = catchBlock.getRethrownException() ?: return null
+        val rethrownException = catchBlock.rethrownException ?: return null
 
         val tryKeyword = firstChild
         val sneakyThrows = when {

--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
@@ -195,34 +195,36 @@ object IfNullSafeExt : BaseExtension() {
     }
 
 
-    private fun PsiExpression.getOperandReference(): PsiElement? {
-        if (this is PsiReferenceExpression) {
-            return this.resolve()
-        }
-        if (this is PsiMethodCallExpression) {
-            return this.firstChildQualifierExpression()
-        }
-        return null
-    }
-
-    private fun PsiExpression.getOperandParentReference(): PsiElement? {
-        if (this is PsiMethodCallExpression) {
-            val qualifierExpression = firstChildQualifierExpression()
-            if (qualifierExpression is PsiReferenceExpression) {
-                return qualifierExpression.getOperandReference()
-            } else if (qualifierExpression is PsiMethodCallExpression) {
-                return qualifierExpression.getOperandReference()
+    private val PsiExpression.operandReference: PsiElement?
+        get() {
+            if (this is PsiReferenceExpression) {
+                return this.resolve()
             }
+            if (this is PsiMethodCallExpression) {
+                return this.firstChildQualifierExpression()
+            }
+            return null
         }
-        return null
-    }
+
+    private val PsiExpression.operandParentReference: PsiElement?
+        get() {
+            if (this is PsiMethodCallExpression) {
+                val qualifierExpression = firstChildQualifierExpression()
+                if (qualifierExpression is PsiReferenceExpression) {
+                    return qualifierExpression.operandReference
+                } else if (qualifierExpression is PsiMethodCallExpression) {
+                    return qualifierExpression.operandReference
+                }
+            }
+            return null
+        }
 
     private fun isNext(
         prev: PsiExpression,
         curr: PsiExpression
     ): Boolean {
-        val first = prev.getOperandReference().toString()
-        val second = curr.getOperandParentReference().toString()
+        val first = prev.operandReference.toString()
+        val second = curr.operandParentReference.toString()
         return first == second
     }
 

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt
@@ -15,7 +15,7 @@ object LombokConstructorExt : BaseExtension() {
                 val args = mutableListOf<String>()
                 it.modifierAsArgument().run(args::addAll)
                 if (it.modifier() != EModifier.PRIVATE) {
-                    it.body?.getComment()?.text?.run(args::add)
+                    it.body?.comment?.text?.run(args::add)
                 }
                 ClassLevelAnnotation(LOMBOK_NO_ARGS_CONSTRUCTOR, listOf(it), arguments = args)
             } else {

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/MethodBodyInspector.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/MethodBodyInspector.kt
@@ -142,20 +142,21 @@ object MethodBodyInspector {
         !method.isDirtyAssignment(statement, field, param)
     }
 
-    fun PsiCatchSection.getRethrownException(): String? {
-        val param = parameter ?: return null
-        val statement = catchBlock?.statements?.singleOrNull()
+    val PsiCatchSection.rethrownException: String?
+        get() {
+            val param = parameter ?: return null
+            val statement = catchBlock?.statements?.singleOrNull()
 
-        val newExpression = statement.asInstance<PsiThrowStatement>()?.exception.asNewInstance()
-        val referenceName = newExpression?.classReference?.referenceName ?: return null
-        val args = newExpression.argumentList?.expressions
-        val referenceExpression = args?.singleOrNull().asReference()
-        return referenceExpression?.takeIf {
-            referenceExpression.isReferenceTo(param)
-        }?.let {
-            referenceName
+            val newExpression = statement.asInstance<PsiThrowStatement>()?.exception.asNewInstance()
+            val referenceName = newExpression?.classReference?.referenceName ?: return null
+            val args = newExpression.argumentList?.expressions
+            val referenceExpression = args?.singleOrNull().asReference()
+            return referenceExpression?.takeIf {
+                referenceExpression.isReferenceTo(param)
+            }?.let {
+                referenceName
+            }
         }
-    }
 
     fun PsiMethod.asWrapperGetter(field: PsiField): String? {
         val methodCall = body?.statements?.singleOrNull().asReturn()?.returnValue.asMethodCall()

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
@@ -28,7 +28,7 @@ object SummaryParentOverrideExt : BaseExtension() {
                         //TODO: support sharedMethod from GrandparentClass as well here
                         findMethodBySignature(method, false) != null
                     }?.map {
-                        val sig = it.getSignature()
+                        val sig = it.signature
                         methodToParentClass[sig] = className
                         it.name
                     } ?: emptyList()
@@ -82,7 +82,7 @@ object SummaryParentOverrideExt : BaseExtension() {
         } else {
             body.lBrace
         }?.let { brace ->
-            val signature = element.getSignature()
+            val signature = element.signature
             element.containingClass?.getUserData(METHOD_TO_PARENT_CLASS_KEY)
                 ?.get(signature)?.let {
                     val prefix = if (oneLiner) {

--- a/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
@@ -129,7 +129,7 @@ fun PsiClass?.isBuilder(): Boolean {
     if (this == null) {
         return false
     }
-    val userData = getClassType()
+    val userData = classType
     if (userData == null) {
         allMethods.forEach {
             if (it.name == "build") {
@@ -155,7 +155,8 @@ fun PsiElement.setClassType(type: PsiClassExt.ClassType) {
     putCopyableUserData(Keys.CLASS_TYPE_KEY, type)
 }
 
-fun PsiElement.getClassType(): PsiClassExt.ClassType? = getUserData(Keys.CLASS_TYPE_KEY)
+val PsiElement.classType: PsiClassExt.ClassType?
+    get() = getUserData(Keys.CLASS_TYPE_KEY)
 
 var PsiMethod.propertyField: PsiField?
     get() = getUserData(Keys.FIELD_KEY)
@@ -204,11 +205,13 @@ fun PsiCodeBlock.hasComments(): Boolean = children.any {
     it is PsiComment
 }
 
-fun PsiCodeBlock.getComment(): PsiElement? = children.firstOrNull {
-    it is PsiComment
-}
+val PsiCodeBlock.comment: PsiElement?
+    get() = children.firstOrNull {
+        it is PsiComment
+    }
 
-fun PsiMethod.getSignature(): MethodSignature = getSignature(PsiSubstitutor.EMPTY)
+val PsiMethod.signature: MethodSignature
+    get() = getSignature(PsiSubstitutor.EMPTY)
 
 fun VirtualFile.toJavaPsiFile(project: Project): PsiJavaFile? {
     if (!isValid) {


### PR DESCRIPTION
## Summary
- convert getter-style extension functions into extension properties for better Kotlin idioms
- update call sites to use the new properties in Lombok helpers, cache utilities, and Kotlin null-safe processing

## Testing
- ./gradlew test --no-configuration-cache --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ebcc082e58832e81e63d2330d75f3f