### PR TITLE
Add extension properties for method call arguments

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt
@@ -8,6 +8,8 @@ import com.intellij.advancedExpressionFolding.expression.controlflow.ForStatemen
 import com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
 import com.intellij.advancedExpressionFolding.expression.operation.basic.Variable
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.getAnyExpression
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
+import com.intellij.advancedExpressionFolding.processor.argumentCount
 import com.intellij.advancedExpressionFolding.processor.util.Helper
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.openapi.editor.Document
@@ -185,9 +187,9 @@ object ForStatementExpressionExt {
                 }
             }
         } else if (initializer is PsiMethodCallExpression &&
-            initializer.argumentList.expressions.size == 1 &&
-            initializer.argumentList.expressions[0] is PsiReferenceExpression &&
-            (initializer.argumentList.expressions[0] as PsiReferenceExpression).isReferenceTo(conditionVariable) &&
+            initializer.argumentCount == 1 &&
+            initializer.argumentExpressions[0] is PsiReferenceExpression &&
+            (initializer.argumentExpressions[0] as PsiReferenceExpression).isReferenceTo(conditionVariable) &&
             conditionROperand is PsiMethodCallExpression &&
             conditionROperand.methodExpression.qualifierExpression is PsiReferenceExpression &&
             initializer.methodExpression.qualifierExpression is PsiReferenceExpression &&

--- a/src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt
@@ -9,6 +9,7 @@ import com.intellij.advancedExpressionFolding.expression.literal.InterpolatedStr
 import com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
 import com.intellij.advancedExpressionFolding.expression.math.basic.Add
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.BinaryExpressionExt
 import com.intellij.advancedExpressionFolding.processor.language.kotlin.IfNullSafeExt
@@ -71,7 +72,7 @@ object IfExt {
                         is PsiReferenceExpression -> true
                         is PsiMethodCallExpression ->
                             Helper.startsWith(qualifierElement.methodExpression.referenceName, "get") &&
-                                qualifierElement.argumentList.expressions.isEmpty()
+                                qualifierElement.argumentExpressions.isEmpty()
                         else -> false
                     }
                     if (isSupportedQualifier) {
@@ -109,7 +110,7 @@ object IfExt {
                     is PsiReferenceExpression -> true
                     is PsiMethodCallExpression ->
                         Helper.startsWith(qualifierElement.methodExpression.referenceName, "get") &&
-                            qualifierElement.argumentList.expressions.isEmpty()
+                            qualifierElement.argumentExpressions.isEmpty()
                     else -> false
                 }
                 if (isSupportedQualifier) {

--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt
@@ -7,6 +7,7 @@ import com.intellij.advancedExpressionFolding.processor.asInstance
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.realNextSibling
+import com.intellij.advancedExpressionFolding.processor.singleArgument
 import com.intellij.advancedExpressionFolding.processor.start
 import com.intellij.advancedExpressionFolding.processor.util.Helper
 import com.intellij.psi.*
@@ -213,7 +214,7 @@ object PsiDeclarationStatementExt : BaseExtension() {
     private fun PsiExpression.index(): Int? = when (this) {
         is PsiArrayAccessExpression -> indexExpression.asInstance<PsiLiteralExpression>()?.value.asInstance<Int>()
 
-        is PsiMethodCallExpression -> argumentList.expressions.singleOrNull()
+        is PsiMethodCallExpression -> singleArgument
             .asInstance<PsiLiteralExpression>()?.value.asInstance<Int>()
 
         else -> null

--- a/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
@@ -12,6 +12,8 @@ import com.intellij.advancedExpressionFolding.expression.operation.basic.Greater
 import com.intellij.advancedExpressionFolding.expression.operation.basic.GreaterEqual
 import com.intellij.advancedExpressionFolding.expression.operation.collection.Range
 import com.intellij.advancedExpressionFolding.processor.util.Consts
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
+import com.intellij.advancedExpressionFolding.processor.argumentCount
 import com.intellij.advancedExpressionFolding.processor.util.Helper.eraseGenerics
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.openapi.editor.Document
@@ -72,7 +74,7 @@ object BinaryExpressionExt {
             return null
         }
         val qualifier = getQualifierExpression(methodCall, document) ?: return null
-        val argument = com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.getAnyExpression(methodCall.argumentList.expressions[0], document)
+        val argument = com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.getAnyExpression(methodCall.argumentExpressions[0], document)
         val operationSign = element.operationSign.text
         val expressionValue = literal!!.text.toInt()
         var lessOperation = "<"
@@ -108,7 +110,7 @@ object BinaryExpressionExt {
             return false
         }
         val identifier = methodCall.methodExpression.children.firstOrNull { it is PsiIdentifier } as? PsiIdentifier
-        return identifier != null && identifier.text == "compareTo" && methodCall.argumentList.expressions.size == 1
+        return identifier != null && identifier.text == "compareTo" && methodCall.argumentCount == 1
     }
 
     private fun isSupportedCompareToMethod(method: PsiMethod?): Boolean {

--- a/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
@@ -5,6 +5,7 @@ import com.intellij.advancedExpressionFolding.expression.math.basic.Negate
 import com.intellij.advancedExpressionFolding.expression.math.basic.NotEqual
 import com.intellij.advancedExpressionFolding.expression.operation.basic.Append
 import com.intellij.advancedExpressionFolding.expression.operation.basic.Equal
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.expression.operation.basic.GreaterEqual
 import com.intellij.advancedExpressionFolding.processor.util.Helper
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
@@ -76,7 +77,7 @@ object PrefixExpressionExt {
     ) {
         fun getFoldedArgument(index: Int): Expression {
             return com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.getAnyExpression(
-                element.argumentList.expressions[index],
+                element.argumentExpressions[index],
                 document
             )
         }

--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
@@ -2,6 +2,7 @@ package com.intellij.advancedExpressionFolding.processor.logger
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.asInstance
+import com.intellij.advancedExpressionFolding.processor.firstArgument
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.on
 import com.intellij.openapi.editor.Document
@@ -22,7 +23,7 @@ object LoggerBracketsExt : BaseExtension() {
 
         val extensionConstructor: (PsiMethodCallExpression, Document) -> LoggerBracketsExtensionBase = when {
             methodName == "formatted" -> ::StringFormattedLoggerBracketsExtension
-            element.argumentList.expressions.firstOrNull()?.isLogMarker() == true -> ::MarkerLoggerBracketsExtension
+            element.firstArgument?.isLogMarker() == true -> ::MarkerLoggerBracketsExtension
             else -> ::LoggerBracketsExtensionBase
         }
         return extensionConstructor(element, document).processExpression()

--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
@@ -5,6 +5,7 @@ import com.intellij.advancedExpressionFolding.expression.operation.basic.Variabl
 import com.intellij.advancedExpressionFolding.expression.semantic.logging.LoggerBracketExpression
 import com.intellij.advancedExpressionFolding.expression.semantic.logging.LoggerBracketParentExpression
 import com.intellij.advancedExpressionFolding.processor.asInstance
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.start
@@ -22,14 +23,14 @@ open class LoggerBracketsExtensionBase(
 ) : BaseExtension(){
 
     fun processExpression(): Expression? {
-        val logLiteral = element.argumentList.expressions.takeIf {
+        val logLiteral = element.argumentExpressions.takeIf {
             it.hasEnoughElements()
         }?.extractLiteral() ?: return null
         if (!logFoldingTextBlocks && logLiteral.isTextBlock) return null
         val logText = logLiteral.text ?: return null
         val split = logText.splitTextPattern() ?: return null
 
-        val arguments = element.argumentList.expressions.toMutableList().prepareArguments()
+        val arguments = element.argumentExpressions.toMutableList().prepareArguments()
         var nextStringAddon = ""
         val hasTooManyArguments = split.size <= arguments.size
         var hasLast = false

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
@@ -2,6 +2,7 @@ package com.intellij.advancedExpressionFolding.processor.methodcall
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
@@ -23,7 +24,7 @@ abstract class AbstractMethodCall : BaseExtension() {
         if (classNames.isNotEmpty() && !classNames.contains(context.className)) {
             return null
         }
-        val expressions = element.argumentList.expressions
+        val expressions = element.argumentExpressions
         return onAnyArguments(element, context, expressions)
     }
 

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt
@@ -6,6 +6,8 @@ import com.intellij.advancedExpressionFolding.expression.property.Getter
 import com.intellij.advancedExpressionFolding.expression.property.GetterRecord
 import com.intellij.advancedExpressionFolding.expression.property.Setter
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
+import com.intellij.advancedExpressionFolding.processor.argumentCount
 import com.intellij.advancedExpressionFolding.processor.language.FieldShiftExt
 import com.intellij.advancedExpressionFolding.processor.logger.LoggerBracketsExt
 import com.intellij.advancedExpressionFolding.processor.util.Helper
@@ -72,7 +74,7 @@ object MethodCallExpressionExt {
         val factory = MethodCallFoldingLoaderService.factory()
         val methodCalls = factory.findByMethodName(methodName) ?: return null
         for (methodCall in methodCalls) {
-            val args = element.argumentList.expressions.map { BuildExpressionExt.getAnyExpression(it, document) }
+            val args = element.argumentExpressions.map { BuildExpressionExt.getAnyExpression(it, document) }
             val context = Context(methodName, className, qualifierExpression, method, document, identifier, args)
             val expression = methodCall.execute(element, context)
             if (expression != null) {
@@ -110,7 +112,7 @@ object MethodCallExpressionExt {
         qualifier: PsiExpression?,
         identifier: PsiElement
     ): Expression? {
-        if (psiClass != null && psiClass.isRecord && element.argumentList.expressionCount == 0) {
+        if (psiClass != null && psiClass.isRecord && element.argumentCount == 0) {
             if (settings.state.getSetExpressionsCollapse) {
                 val expression = qualifier?.let { BuildExpressionExt.getAnyExpression(it, document) }
                 return GetterRecord(
@@ -144,7 +146,7 @@ object MethodCallExpressionExt {
         val text = identifier.text
         if (isSimpleSetter(text, element, qualifier)) {
             val qualifierExpression = qualifier?.let { BuildExpressionExt.getAnyExpression(it, document) }
-            val paramExpression = BuildExpressionExt.getAnyExpression(element.argumentList.expressions[0], document)
+            val paramExpression = BuildExpressionExt.getAnyExpression(element.argumentExpressions[0], document)
             val propertyName = guessPropertyName(text)
             return Setter(
                 element,
@@ -166,7 +168,7 @@ object MethodCallExpressionExt {
         if (!Helper.isSetter(text)) {
             return false
         }
-        if (element.argumentList.expressions.size != 1) {
+        if (element.argumentCount != 1) {
             return false
         }
         if (element.parent !is PsiStatement) {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding.processor.methodcall.date
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.literal.LocalDateLiteral
 import com.intellij.advancedExpressionFolding.processor.methodcall.AbstractMethodCall
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiLiteralExpression
@@ -20,7 +21,7 @@ class CreateDateFactoryMethodCall : AbstractMethodCall() {
         context: Context,
         expressions: Array<PsiExpression>
     ): Expression? {
-        val literals = element.argumentList.expressions.takeIf {
+        val literals = element.argumentExpressions.takeIf {
             it.size == 3
         }?.let { array ->
             array.mapNotNull {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt
@@ -6,6 +6,7 @@ import com.intellij.advancedExpressionFolding.expression.operation.basic.Variabl
 import com.intellij.advancedExpressionFolding.expression.property.INameable
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.CheckNotNullExpression
 import com.intellij.advancedExpressionFolding.processor.asInstance
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.methodcall.AbstractMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
@@ -54,8 +55,8 @@ class CheckNotNullMethodCall : AbstractMethodCall() {
         }?.takeIf {
             argumentExpression is Variable
         } != null
-        val preFirstArgumentRange = TextRange(element.start(), element.argumentList.expressions.first().start())
-        val postFirstArgumentRange = TextRange(element.argumentList.expressions.first().end(), element.end())
+        val preFirstArgumentRange = TextRange(element.start(), element.argumentExpressions.first().start())
+        val postFirstArgumentRange = TextRange(element.argumentExpressions.first().end(), element.end())
         val postFirstArgumentSuffix = CheckNotNullExpression(element, postFirstArgumentRange, "!!", argumentExpression)
         return CheckNotNullExpression(
             element,

--- a/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/psiElementExtensions.kt
@@ -44,6 +44,16 @@ fun PsiElement.isIgnorable() = this is PsiJavaToken || isWhitespace()
 
 fun PsiElement.isWhitespace() = this is PsiWhiteSpace
 
+
+val PsiCall.argumentExpressions: Array<PsiExpression>
+    get() = argumentList?.expressions ?: PsiExpression.EMPTY_ARRAY
+
+val PsiCall.firstArgument: PsiExpression?
+    get() = argumentExpressions.firstOrNull()
+
+val PsiCall.singleArgument: PsiExpression?
+    get() = argumentExpressions.singleOrNull()
+
 val PsiElement.prevRealSibling: PsiElement?
     get() {
         return generateSequence(this.prevSibling) { it.prevSibling }

--- a/src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt
@@ -7,6 +7,8 @@ import com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
 import com.intellij.advancedExpressionFolding.expression.literal.SetLiteral
 import com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
+import com.intellij.advancedExpressionFolding.processor.argumentCount
 import com.intellij.advancedExpressionFolding.processor.expression.LiteralExpressionExt
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallExpressionExt
 import com.intellij.advancedExpressionFolding.processor.util.Consts
@@ -151,10 +153,10 @@ object NewExpressionExt {
         for (statement in statements) {
             if (statement is PsiExpressionStatement && statement.expression is PsiMethodCallExpression) {
                 val methodCall = statement.expression as PsiMethodCallExpression
-                if (methodCall.methodExpression.text == "add" && methodCall.argumentList.expressions.size == 1) {
+                if (methodCall.methodExpression.text == "add" && methodCall.argumentCount == 1) {
                     val method = methodCall.methodExpression.resolve() as? PsiMethod
                     if (method != null && method.containingClass?.qualifiedName == "java.util.HashSet") {
-                        arguments.add(methodCall.argumentList.expressions[0])
+                        arguments.add(methodCall.argumentExpressions[0])
                         continue
                     }
                 }

--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding.processor.util
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
@@ -242,7 +243,7 @@ object Helper {
     }
 
     fun isGetter(element: PsiElement, expression: PsiMethodCallExpression): Boolean {
-        return expression.argumentList.expressions.isEmpty() && isGetter(element.text)
+        return expression.argumentExpressions.isEmpty() && isGetter(element.text)
     }
 
     fun isGetter(name: String): Boolean = isGetterAux(name, "get") || isGetterAux(name, "is")


### PR DESCRIPTION
## Summary
- add `PsiCall` extension properties for reusable access to method call arguments
- refactor call-site processors to use the shared extensions for argument lookup

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ebcb9063d4832e8961c318ff8bfaa2