### PR TITLE
Improve naming for property expression receivers

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/operation/Get.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/Get.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiElement
 class Get(
     element: PsiElement,
     textRange: TextRange,
-    val `object`: Expression,
+    val receiver: Expression,
     val key: Expression,
     val style: Style
 ) : Expression(element, textRange) {
@@ -18,7 +18,7 @@ class Get(
     enum class Style { NORMAL, FIRST, LAST }
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean {
-        val objectEnd = `object`.textRange.endOffset
+        val objectEnd = receiver.textRange.endOffset
         val keyStart = key.textRange.startOffset
         val keyEnd = key.textRange.endOffset
         val end = textRange.endOffset
@@ -39,7 +39,7 @@ class Get(
         if (style == Style.NORMAL) {
             descriptors += FoldingDescriptor(
                 element.node,
-                TextRange.create(`object`.textRange.endOffset, key.textRange.startOffset),
+                TextRange.create(receiver.textRange.endOffset, key.textRange.startOffset),
                 group,
                 "["
             )
@@ -53,7 +53,7 @@ class Get(
             val placeholder = "." + if (style == Style.FIRST) "getFirst" else "getLast"
             descriptors += FoldingDescriptor(
                 element.node,
-                TextRange.create(`object`.textRange.endOffset, key.textRange.startOffset - 1),
+                TextRange.create(receiver.textRange.endOffset, key.textRange.startOffset - 1),
                 group,
                 placeholder
             )
@@ -64,8 +64,8 @@ class Get(
                 ""
             )
         }
-        if (`object`.supportsFoldRegions(document, this)) {
-            descriptors += `object`.buildFoldRegions(`object`.element, document, this).toList()
+        if (receiver.supportsFoldRegions(document, this)) {
+            descriptors += receiver.buildFoldRegions(receiver.element, document, this).toList()
         }
         if (style == Style.NORMAL && key.supportsFoldRegions(document, this)) {
             descriptors += key.buildFoldRegions(key.element, document, this).toList()

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/collection/ArrayGet.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/collection/ArrayGet.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiElement
 class ArrayGet(
     element: PsiElement,
     textRange: TextRange,
-    val `object`: Expression
+    val receiver: Expression
 ) : Expression(element, textRange) {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
@@ -24,12 +24,12 @@ class ArrayGet(
         val descriptors = mutableListOf<FoldingDescriptor>()
         descriptors += FoldingDescriptor(
             element.node,
-            TextRange.create(`object`.textRange.endOffset, textRange.endOffset),
+            TextRange.create(receiver.textRange.endOffset, textRange.endOffset),
             group,
             ".last()"
         )
-        if (`object`.supportsFoldRegions(document, this)) {
-            descriptors += `object`.buildFoldRegions(`object`.element, document, this).toList()
+        if (receiver.supportsFoldRegions(document, this)) {
+            descriptors += receiver.buildFoldRegions(receiver.element, document, this).toList()
         }
         return descriptors.toTypedArray()
     }

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/collection/Put.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/collection/Put.kt
@@ -10,13 +10,13 @@ import com.intellij.psi.PsiElement
 class Put(
     element: PsiElement,
     textRange: TextRange,
-    val `object`: Expression,
+    val receiver: Expression,
     val key: Expression,
     val value: Expression
 ) : Expression(element, textRange) {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean {
-        return `object`.textRange.endOffset < key.textRange.startOffset
+        return receiver.textRange.endOffset < key.textRange.startOffset
     }
 
     override fun buildFoldRegions(
@@ -28,7 +28,7 @@ class Put(
         val descriptors = mutableListOf<FoldingDescriptor>()
         descriptors += FoldingDescriptor(
             element.node,
-            TextRange.create(`object`.textRange.endOffset, key.textRange.startOffset),
+            TextRange.create(receiver.textRange.endOffset, key.textRange.startOffset),
             group,
             "["
         )
@@ -46,8 +46,8 @@ class Put(
                 ""
             )
         }
-        if (`object`.supportsFoldRegions(document, this)) {
-            descriptors += `object`.buildFoldRegions(`object`.element, document, this).toList()
+        if (receiver.supportsFoldRegions(document, this)) {
+            descriptors += receiver.buildFoldRegions(receiver.element, document, this).toList()
         }
         if (key.supportsFoldRegions(document, this)) {
             descriptors += key.buildFoldRegions(key.element, document, this).toList()

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiElement
 class OptionalNotNullAssertionGet(
     element: PsiElement,
     textRange: TextRange,
-    private val `object`: Expression?
+    private val receiver: Expression?
 ) : Expression(element, TextRange.create(textRange.startOffset - 1, textRange.endOffset + 2)) {
 
     override fun buildFoldRegions(
@@ -26,7 +26,7 @@ class OptionalNotNullAssertionGet(
             FoldingGroup.newGroup(Getter::class.java.name),
             "!!"
         )
-        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
+        receiver?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/Getter.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/Getter.kt
@@ -11,7 +11,7 @@ class Getter(
     element: PsiElement,
     textRange: TextRange,
     override val getterTextRange: TextRange,
-    override val `object`: Expression?,
+    override val receiver: Expression?,
     override val name: String
 ) : Expression(element, textRange), IGetter {
 
@@ -29,7 +29,7 @@ class Getter(
             FoldingGroup.newGroup(Getter::class.java.name),
             name
         )
-        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
+        receiver?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/GetterRecord.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/GetterRecord.kt
@@ -11,7 +11,7 @@ class GetterRecord(
     element: PsiElement,
     textRange: TextRange,
     override val getterTextRange: TextRange,
-    override val `object`: Expression?,
+    override val receiver: Expression?,
     override val name: String
 ) : Expression(element, textRange), IGetter {
     override fun supportsFoldRegions(
@@ -29,7 +29,7 @@ class GetterRecord(
             FoldingGroup.newGroup(GetterRecord::class.java.name),
             name
         )
-        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
+        receiver?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         return descriptors.toTypedArray()

--- a/src/com/intellij/advancedExpressionFolding/expression/property/IGetter.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/IGetter.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 interface IGetter : INameable {
     override val name: String
     val getterTextRange: TextRange
-    val `object`: Expression?
+    val receiver: Expression?
 
     fun buildFoldRegions(element: PsiElement, document: Document, parent: Expression?): Array<FoldingDescriptor>
 }

--- a/src/com/intellij/advancedExpressionFolding/expression/property/Setter.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/property/Setter.kt
@@ -11,7 +11,7 @@ class Setter(
     element: PsiElement,
     textRange: TextRange,
     private val setterTextRange: TextRange,
-    private val `object`: Expression?,
+    private val receiver: Expression?,
     private val name: String,
     private val value: Expression
 ) : Expression(element, textRange) {
@@ -44,7 +44,7 @@ class Setter(
                 )
             }
         }
-        `object`?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
+        receiver?.takeIf { it.supportsFoldRegions(document, this) }?.let { obj ->
             descriptors += obj.buildFoldRegions(obj.element, document, this).toList()
         }
         if (value.supportsFoldRegions(document, this)) {

--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
@@ -139,12 +139,12 @@ object IfNullSafeExt : BaseExtension() {
             }
 
         val iGetter = BuildExpressionExt.getAnyExpression(elementList.first(), document).asInstance<IGetter>()
-        val parentGetter = iGetter?.`object`
+        val parentGetter = iGetter?.receiver
         if (parentGetter != null) {
 
             var parent = parentGetter
             while (true) {
-                val expression = parent.asInstance<IGetter>()?.`object`
+                val expression = parent.asInstance<IGetter>()?.receiver
                 if (expression != null) {
                     parent = expression
                 } else {


### PR DESCRIPTION
## Summary
- rename the ambiguous `object` property in getter and setter expressions to `receiver`
- align collection and optional operation expressions with the new receiver terminology
- update Kotlin null-safe folding logic to rely on the clarified receiver accessor

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ebc206dc98832e87e1601f37c7e130