### PR TITLE
Add IntelliJ IDEA 2025.3 EAP compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+
 ## [4.2.0] - 2025-09-20
 
 - [Add setting to prevent collapsing Java text blocks in log folding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/338)

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 4.2.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 252.*
+pluginUntilBuild = 253.*
 
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension


### PR DESCRIPTION
## Summary
- raise the plugin compatibility ceiling to IntelliJ build 253.*
- note the expanded compatibility in the changelog

## Reason
- keep the plugin working on IntelliJ IDEA 2025.3 EAP (253.20558.43)

## Testing
- `./gradlew test --no-daemon --console=plain -Dkotlin.daemon.jvm.options=-Xmx2048m`


------
https://chatgpt.com/codex/tasks/task_e_68e95b8a594c832e956fef7f4d184fde