### PR TITLE
Move performance tests into dedicated package

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.performance
 
+import com.intellij.advancedExpressionFolding.BaseTest
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.DynamicMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.DynamicMethodCallData

--- a/test/com/intellij/advancedExpressionFolding/performance/PerformanceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/performance/PerformanceTest.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.performance
 
+import com.intellij.advancedExpressionFolding.FoldingTest
 import com.intellij.platform.testFramework.core.FileComparisonFailedError
 import com.intellij.testFramework.PlatformTestUtil
 import org.junit.jupiter.api.AfterAll
@@ -54,8 +55,9 @@ class PerformanceTest : FoldingTest() {
                 }
             }
             val content = """
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.performance
 
+import com.intellij.advancedExpressionFolding.FoldingTest
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import kotlin.reflect.KFunction0
 
@@ -80,7 +82,7 @@ $results
 
 }
 """.trimIndent()
-            File("test/com/intellij/advancedExpressionFolding/performanceResult.kt").writeText(content)
+            File("test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt").writeText(content)
         }
     }
 

--- a/test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt
+++ b/test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.performance
 
+import com.intellij.advancedExpressionFolding.FoldingTest
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import kotlin.reflect.KFunction0
 


### PR DESCRIPTION
## Summary
- move performance-related tests into the com.intellij.advancedExpressionFolding.performance package
- update generated PerformanceResult file path and imports for the new package structure
- adjust MethodCallFactoryPerformanceTest imports after relocating the file

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ebc44c4188832eaa59f03a98a4c08c