### PR TITLE
Optimize Helper char lookups and add tests

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -152,15 +152,17 @@ object Helper {
 
     @JvmStatic
     fun findDot(document: Document, positionStart: Int, direction: Int, includeNewLines: Boolean): Int {
+        val chars = document.charsSequence
+        val length = chars.length
         var position = positionStart
         var offset = 0
-        while (kotlin.math.abs(offset) < 100 && position > 0 && position < document.text.length) {
+        while (kotlin.math.abs(offset) < 100 && position > 0 && position < length) {
             position += direction
             offset += direction
-            if (charAt(document, position) == '.') {
+            if (charAt(chars, position) == '.') {
                 break
             }
-            if (!charAt(document, position).isWhitespace()) {
+            if (!charAt(chars, position).isWhitespace()) {
                 return Int.MAX_VALUE
             }
         }
@@ -169,13 +171,13 @@ object Helper {
             do {
                 position += direction
                 offsetWithNewLine += direction
-                if (direction < 0 && charAt(document, position) == '\n') {
+                if (direction < 0 && charAt(chars, position) == '\n') {
                     offset = offsetWithNewLine
-                } else if (direction > 0 && charAt(document, position).isWhitespace()) {
+                } else if (direction > 0 && charAt(chars, position).isWhitespace()) {
                     offset = offsetWithNewLine
                 }
-            } while (kotlin.math.abs(offsetWithNewLine) < 100 && position > 0 && position < document.text.length &&
-                charAt(document, position).isWhitespace())
+            } while (kotlin.math.abs(offsetWithNewLine) < 100 && position > 0 && position < length &&
+                charAt(chars, position).isWhitespace())
         }
         if (kotlin.math.abs(offset) >= 100) {
             return Int.MAX_VALUE
@@ -183,8 +185,13 @@ object Helper {
         return offset
     }
 
-    fun charAt(document: Document, position: Int): Char {
-        return document.getText(TextRange.create(position, position + 1))[0]
+    fun charAt(document: Document, position: Int): Char = charAt(document.charsSequence, position)
+
+    private fun charAt(chars: CharSequence, position: Int): Char {
+        if (position < 0 || position >= chars.length) {
+            throw IndexOutOfBoundsException("Position $position is out of bounds for document length ${chars.length}")
+        }
+        return chars[position]
     }
 
     fun getSlicePosition(

--- a/test/com/intellij/advancedExpressionFolding/processor/util/HelperTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/util/HelperTest.kt
@@ -1,0 +1,52 @@
+package com.intellij.advancedExpressionFolding.processor.util
+
+import com.intellij.openapi.editor.impl.DocumentImpl
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HelperTest {
+
+    @Test
+    fun findDotSkipsWhitespaceWhenSearchingForward() {
+        val content = "foo   .bar"
+        val document = DocumentImpl(content)
+
+        val startOffset = content.indexOf('o', startIndex = 2)
+        val result = Helper.findDot(document, startOffset, 1, false)
+
+        assertEquals(4, result)
+    }
+
+    @Test
+    fun findDotReturnsOffsetWhenScanningBackward() {
+        val content = "foo.bar"
+        val document = DocumentImpl(content)
+
+        val startOffset = content.indexOf('b')
+        val result = Helper.findDot(document, startOffset, -1, false)
+
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun findDotStopsWhenNonWhitespaceEncountered() {
+        val content = "fooX.bar"
+        val document = DocumentImpl(content)
+
+        val startOffset = content.indexOf('o', startIndex = 2)
+        val result = Helper.findDot(document, startOffset, 1, false)
+
+        assertEquals(Int.MAX_VALUE, result)
+    }
+
+    @Test
+    fun findDotExtendsOffsetWhenIncludingTrailingWhitespace() {
+        val content = "foo.\n  bar"
+        val document = DocumentImpl(content)
+
+        val startOffset = content.indexOf('o', startIndex = 2)
+        val result = Helper.findDot(document, startOffset, 1, true)
+
+        assertEquals(4, result)
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the document character sequence in Helper.findDot to avoid repeated substring extraction
- update Helper.charAt to read directly from the document CharSequence with bounds validation
- add JUnit tests that exercise Helper.findDot in forward, backward, whitespace, and failure scenarios

## Testing
- ./gradlew test --no-daemon --console=plain --no-configuration-cache


------
https://chatgpt.com/codex/tasks/task_e_68ee282173d0832eb91861f7cfbe9eee