### PR TITLE
Simplify CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Automatically assign all pull requests to @AntoniRokitnicki. Update this file if ownership changes.
+* @AntoniRokitnicki


### PR DESCRIPTION
## Summary
- shrink the CODEOWNERS file to a minimal header and default owner entry for @AntoniRokitnicki

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ee5c513388832e8de306677e384159