### PR TITLE
Group low-value badges in README into collapsible section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Release](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/actions/workflows/release.yml/badge.svg)](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/actions/workflows/release.yml)
 [![Canary Release](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/actions/workflows/release-canary.yml/badge.svg)](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/actions/workflows/release-canary.yml)
 [![Snyk](https://snyk.io/test/github/antonirokitnicki/AdvancedExpressionFolding/badge.svg)](https://app.snyk.io/org/antonirokitnicki/project/cb199e96-f9b6-471e-a7f2-befcd26d62ca)
-![GitHub License](https://img.shields.io/github/license/AntoniRokitnicki/AdvancedExpressionFolding)
 
 [![Java](https://img.shields.io/badge/java-17-blue.svg)](https://plugins.jetbrains.com/docs/intellij/setting-up-theme-environment.html#add-jdk-and-intellij-platform-plugin-sdk)
 [![Kotlin](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FAntoniRokitnicki%2FAdvancedExpressionFolding%2Fmain%2Fgradle%2Flibs.versions.toml&query=%24.versions.kotlin&label=kotlin)](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib)
@@ -24,13 +23,19 @@
 [![Release Version](https://img.shields.io/github/v/release/AntoniRokitnicki/AdvancedExpressionFolding)](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/releases)
 [![Marketplace Version](https://img.shields.io/jetbrains/plugin/v/com.github.advanced-java-folding2.svg)](https://plugins.jetbrains.com/plugin/23659-advanced-java-folding-2-fork-)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.github.advanced-java-folding2.svg)](https://plugins.jetbrains.com/plugin/23659-advanced-java-folding-2-fork-)
-![GitHub Release Date](https://img.shields.io/github/release-date/AntoniRokitnicki/AdvancedExpressionFolding)
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/AntoniRokitnicki/AdvancedExpressionFolding/latest)](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/compare/v3.8.0...main)
 <!-- https://plugins.jetbrains.com/api/plugins/23659/updates?channel=&size=8 -->
 
-![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/AntoniRokitnicki/AdvancedExpressionFolding)
-![GitHub repo size](https://img.shields.io/github/repo-size/AntoniRokitnicki/AdvancedExpressionFolding)
-![Lines of Code Badge](https://raw.githubusercontent.com/AntoniRokitnicki/AdvancedExpressionFolding/lines-of-code-badge/badge.svg)
+<details>
+  <summary>More badges</summary>
+
+  ![GitHub License](https://img.shields.io/github/license/AntoniRokitnicki/AdvancedExpressionFolding)
+  ![GitHub Release Date](https://img.shields.io/github/release-date/AntoniRokitnicki/AdvancedExpressionFolding)
+  ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/AntoniRokitnicki/AdvancedExpressionFolding)
+  ![GitHub repo size](https://img.shields.io/github/repo-size/AntoniRokitnicki/AdvancedExpressionFolding)
+  ![Lines of Code Badge](https://raw.githubusercontent.com/AntoniRokitnicki/AdvancedExpressionFolding/lines-of-code-badge/badge.svg)
+
+</details>
 
 <!-- Plugin description -->
 <p>Modern JVM languages such as Kotlin, Groovy, Scala and some others offer many language features that let you


### PR DESCRIPTION
## Summary
- remove the low-value badges from the main README header block
- tuck the license, release date, size, and line-count badges into a collapsible details group to keep the content above the fold

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ed2c36c148832eaa2d159f19781404