### PR TITLE
Disable method default parameter folding during debugging

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
@@ -3,12 +3,17 @@ package com.intellij.advancedExpressionFolding.processor.language.kotlin
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
+import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.jetbrains.rd.util.firstOrNull
+import com.intellij.xdebugger.XDebuggerManager
 
 object MethodDefaultParameterExt : BaseExtension(){
 
     fun enhanceMethodsWithDefaultParams(clazz: PsiClass): Expression? {
+        if (clazz.project.isDebugSessionRunning()) {
+            return null
+        }
         val defaultParamMethods = findMethodsWithDefaultParams(clazz)
         return buildExpressions(defaultParamMethods, clazz)
     }
@@ -114,6 +119,13 @@ object MethodDefaultParameterExt : BaseExtension(){
 
     @JvmInline
     private value class DefaultParameterMap(val map: Map<ParameterIndex, ParameterDefaultValueAsString>)
+
+    private fun Project.isDebugSessionRunning(): Boolean {
+        if (isDisposed || isDefault) {
+            return false
+        }
+        return XDebuggerManager.getInstance(this).currentSession != null
+    }
 }
 
 typealias ParameterIndex = Int


### PR DESCRIPTION
## Summary
- skip generating default-parameter folding when a debug session is active
- guard the check with project lifecycle validation to avoid issues with default or disposed projects

## Testing
- ./gradlew test --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ee70053930832ead248f5eebff1029