### PR TITLE
Refactor folding regression tests to DSL-driven metadata

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -32,12 +32,16 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
     }
 
     protected fun doReadOnlyFoldingTest() {
-        val testName = getTestName(false)
-        val fileName = getTestFileName(testName)
-        testWrapper(fileName, testName) {
+        doReadOnlyFoldingTest(getTestName(false))
+    }
+
+    protected fun doReadOnlyFoldingTest(testNameArg: String) {
+        val fileName = getTestFileName(testNameArg)
+        testWrapper(fileName, testNameArg) {
             testReadOnlyFoldingRegions(
                 fileName,
-                null, true
+                null,
+                true,
             )
         }
     }

--- a/test/com/intellij/advancedExpressionFolding/FoldingTestDsl.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingTestDsl.kt
@@ -1,0 +1,53 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.IDynamicDataProvider
+import kotlin.reflect.KMutableProperty0
+
+data class FoldingTestCase(
+    val testName: String,
+    val toggles: List<KMutableProperty0<Boolean>>,
+    val readOnly: Boolean,
+    val dynamicProviderFactory: () -> IDynamicDataProvider,
+) {
+    override fun toString(): String = testName
+}
+
+class FoldingTestBuilder {
+    private val cases = mutableListOf<FoldingTestCase>()
+
+    fun folding(
+        testName: String,
+        vararg toggles: KMutableProperty0<Boolean>,
+        dynamic: () -> IDynamicDataProvider = { TestDynamicDataProvider() },
+    ) {
+        cases += FoldingTestCase(
+            testName = testName,
+            toggles = toggles.toList(),
+            readOnly = false,
+            dynamicProviderFactory = dynamic,
+        )
+    }
+
+    fun readOnly(
+        testName: String,
+        vararg toggles: KMutableProperty0<Boolean>,
+    ) {
+        cases += FoldingTestCase(
+            testName = testName,
+            toggles = toggles.toList(),
+            readOnly = true,
+            dynamicProviderFactory = { TestDynamicDataProvider() },
+        )
+    }
+
+    fun skip(vararg testNames: String) {
+        if (testNames.isEmpty()) return
+        val names = testNames.toSet()
+        cases.removeAll { it.testName in names }
+    }
+
+    internal fun build(): List<FoldingTestCase> = cases.toList()
+}
+
+fun buildFoldingTestCases(block: FoldingTestBuilder.() -> Unit): List<FoldingTestCase> =
+    FoldingTestBuilder().apply(block).build()

--- a/test/com/intellij/advancedExpressionFolding/FullFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FullFoldingTest.kt
@@ -1,12 +1,16 @@
 package com.intellij.advancedExpressionFolding
 
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
-import org.junit.jupiter.api.Test
 import java.io.File
 import java.nio.file.Files
 import kotlin.reflect.KMutableProperty0
 
 class FullFoldingTest : FoldingTest() {
+
+    override val skippedGeneratedTests: Set<String> = super.skippedGeneratedTests + setOf(
+        "destructuringAssignmentArrayWithoutValTestData",
+        "destructuringAssignmentListWithoutValTestData",
+    )
 
     @Suppress("DEPRECATION")
     override fun assignState(turnOnProperties: Array<out KMutableProperty0<Boolean>>) = getInstance().enableAll(state::emojify, state::finalEmoji, state::arithmeticExpressions)
@@ -20,17 +24,12 @@ class FullFoldingTest : FoldingTest() {
         return file.canonicalPath
     }
 
-    override fun destructuringAssignmentArrayWithoutValTestData() {
-        // ignored, already tested in destructuringAssignmentArrayTestData
-    }
-
-    override fun destructuringAssignmentListWithoutValTestData() {
-        // ignored, already tested in destructuringAssignmentListTestData
-    }
-
-    @Test
-    override fun lombokTestData() {
-        super.lombokTestData()
+    protected override fun registerGeneratedTests(builder: FoldingTestBuilder) {
+        super.registerGeneratedTests(builder)
+        builder.skip(
+            "destructuringAssignmentArrayWithoutValTestData",
+            "destructuringAssignmentListWithoutValTestData",
+        )
     }
 
 }

--- a/test/com/intellij/advancedExpressionFolding/performanceResult.kt
+++ b/test/com/intellij/advancedExpressionFolding/performanceResult.kt
@@ -1,82 +1,80 @@
 package com.intellij.advancedExpressionFolding
 
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import kotlin.reflect.KFunction0
 
 @EnabledIfEnvironmentVariable(named = "run-mode", matches = "never")
 object PerformanceResult : FoldingTest() {
 
     @Suppress("unused")
     val result = performance { // sum=370
-        ::appendSetterInterpolatedStringTestData to 4
-        ::arithmeticExpressionsTestData to 14
-        ::assertTestData to 6
-        ::compactControlFlowTestData to 5
-        ::concatenationTestData to 7
-        ::constTestData to 6
-        ::constructorReferenceNotationTestData to 6
-        ::constructorReferenceNotationWithConstTestData to 6
-        ::controlFlowMultiStatementTestData to 5
-        ::controlFlowSingleStatementTestData to 5
-        ::destructuringAssignmentArrayTestData to 5
-        ::destructuringAssignmentArrayWithoutValTestData to 5
-        ::destructuringAssignmentListTestData to 5
-        ::destructuringAssignmentListWithoutValTestData to 4
-        ::dynamicTestData to 4
-        ::elvisTestData to 4
-        ::emojifyTestData to 13
-        ::equalsCompareTestData to 4
-        ::experimentalTestData to 5
-        ::expressionFuncTestData to 6
-        ::fieldShiftBuilder to 6
-        ::fieldShiftFields to 6
-        ::fieldShiftSetters to 6
-        ::finalEmojiTestData to 4
-        ::finalRemovalTestData to 4
-        ::forRangeTestData to 5
-        ::getSetPutTestData to 5
-        ::getterSetterTestData to 4
-        ::ifNullSafeData to 6
-        ::interfaceExtensionPropertiesTestData to 8
-        ::interpolatedStringTestData to 4
-        ::letReturnIt to 5
-        ::localDateLiteralPostfixTestData to 4
-        ::localDateLiteralTestData to 4
-        ::localDateTestData to 7
-        ::logBrackets to 6
-        ::lombokDirtyOffTestData to 6
-        ::lombokPatternOffNegativeTestData to 23
-        ::lombokPatternOffTestData to 19
-        ::lombokTestData to 24
-        ::lombokUsageTestData to 4
-        ::methodDefaultParametersTestData to 7
-        ::nullableAnnotationCheckNotNullFieldShiftTestData to 5
-        ::nullableAnnotationCheckNotNullTestData to 7
-        ::nullableAnnotationTestData to 7
-        ::optionalTestData to 6
-        ::overrideHideTestData to 6
-        ::patternMatchingInstanceofTestData to 6
-        ::printlnTestData to 4
-        ::semicolonTestData to 4
-        ::sliceTestData to 5
-        ::spreadTestData to 6
-        ::stringBuilderTestData to 5
-        ::summaryParentOverrideTestData to 5
-        ::suppressWarningsHideTestData to 4
-        ::typeCastTestData to 4
-        ::varTestData to 4
+        "appendSetterInterpolatedStringTestData" to 4
+        "arithmeticExpressionsTestData" to 14
+        "assertTestData" to 6
+        "compactControlFlowTestData" to 5
+        "concatenationTestData" to 7
+        "constTestData" to 6
+        "constructorReferenceNotationTestData" to 6
+        "constructorReferenceNotationWithConstTestData" to 6
+        "controlFlowMultiStatementTestData" to 5
+        "controlFlowSingleStatementTestData" to 5
+        "destructuringAssignmentArrayTestData" to 5
+        "destructuringAssignmentArrayWithoutValTestData" to 5
+        "destructuringAssignmentListTestData" to 5
+        "destructuringAssignmentListWithoutValTestData" to 4
+        "dynamicTestData" to 4
+        "elvisTestData" to 4
+        "emojifyTestData" to 13
+        "equalsCompareTestData" to 4
+        "experimentalTestData" to 5
+        "expressionFuncTestData" to 6
+        "fieldShiftBuilder" to 6
+        "fieldShiftFields" to 6
+        "fieldShiftSetters" to 6
+        "finalEmojiTestData" to 4
+        "finalRemovalTestData" to 4
+        "forRangeTestData" to 5
+        "getSetPutTestData" to 5
+        "getterSetterTestData" to 4
+        "ifNullSafeData" to 6
+        "interfaceExtensionPropertiesTestData" to 8
+        "interpolatedStringTestData" to 4
+        "letReturnIt" to 5
+        "localDateLiteralPostfixTestData" to 4
+        "localDateLiteralTestData" to 4
+        "localDateTestData" to 7
+        "logBrackets" to 6
+        "lombokDirtyOffTestData" to 6
+        "lombokPatternOffNegativeTestData" to 23
+        "lombokPatternOffTestData" to 19
+        "lombokTestData" to 24
+        "lombokUsageTestData" to 4
+        "methodDefaultParametersTestData" to 7
+        "nullableAnnotationCheckNotNullFieldShiftTestData" to 5
+        "nullableAnnotationCheckNotNullTestData" to 7
+        "nullableAnnotationTestData" to 7
+        "optionalTestData" to 6
+        "overrideHideTestData" to 6
+        "patternMatchingInstanceofTestData" to 6
+        "printlnTestData" to 4
+        "semicolonTestData" to 4
+        "sliceTestData" to 5
+        "spreadTestData" to 6
+        "stringBuilderTestData" to 5
+        "summaryParentOverrideTestData" to 5
+        "suppressWarningsHideTestData" to 4
+        "typeCastTestData" to 4
+        "varTestData" to 4
 
     }
 
-    class PerformanceDSL {
-        infix fun (KFunction0<Unit>).to(@Suppress("UNUSED_PARAMETER") expectedValue: Int) {
-            // ignore
+    class PerformanceDSL(private val owner: PerformanceResult) {
+        infix fun String.to(@Suppress("UNUSED_PARAMETER") expectedValue: Int) {
+            owner.ensureGeneratedTest(this)
         }
     }
 
     private fun performance(block: PerformanceDSL.() -> Unit) {
-        val dsl = PerformanceDSL()
-        dsl.block()
+        PerformanceDSL(this).block()
     }
 
 }


### PR DESCRIPTION
## Summary
- centralize folding test definitions in a Kotlin DSL and update `FoldingTest` to invoke generated cases
- add helper plumbing for read-only tests, manual overrides, and skip handling in the full-suite runner
- adjust performance harness to validate case availability through the DSL metadata

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ec14f99448832e84070eb3aed14ac8