### PR TITLE
Mark PrefixExpressionExt.tryGet inline

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
@@ -91,7 +91,7 @@ object PrefixExpressionExt {
                 return tryGet(element, document, methodNames::contains) { _, _ -> true }
             }
 
-            private fun tryGet(
+            private inline fun tryGet(
                 element: PsiMethodCallExpression,
                 document: Document,
                 isMethodNameSupported: (String) -> Boolean,


### PR DESCRIPTION
## Summary
- mark the helper `tryGet` in `PrefixExpressionExt` as `inline` so method reference arguments remain compatible

## Testing
- ./gradlew --no-daemon test --tests "com.intellij.advancedExpressionFolding.FoldingTest.localDateTestData" --console=plain --no-configuration-cache -x examples:test

------
https://chatgpt.com/codex/tasks/task_e_68eec828be00832eb7ed4b3c9579873c