### PR TITLE
Support @Log pseudo-annotation in nested classes

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/LogAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/LogAnnotationCompletionContributorTest.kt
@@ -45,6 +45,42 @@ class LogAnnotationCompletionContributorTest : BaseTest() {
             ),
             Arguments.of(
                 TestCase(
+                    name = "Class-level logging applied to nested classes",
+                    input = @Language("JAVA") """
+                        @<caret>
+                        public class Outer {
+                            public void outerMethod() {
+                                System.out.println("work");
+                            }
+
+                            class Inner {
+                                public void innerMethod() {
+                                    System.out.println("inner");
+                                }
+                            }
+                        }
+                    """.trimIndent(),
+                    expected = @Language("JAVA") """
+                        public class Outer {
+                            public void outerMethod() {
+                                System.out.println("Entering Outer.outerMethod");
+                                System.out.println("work");
+                                System.out.println("Exiting Outer.outerMethod");
+                            }
+
+                            class Inner {
+                                public void innerMethod() {
+                                    System.out.println("Entering Inner.innerMethod");
+                                    System.out.println("inner");
+                                    System.out.println("Exiting Inner.innerMethod");
+                                }
+                            }
+                        }
+                    """.trimIndent()
+                )
+            ),
+            Arguments.of(
+                TestCase(
                     name = "Class-level logging applied to all methods",
                     input = @Language("JAVA") """
                         @<caret>


### PR DESCRIPTION
## Summary
- walk class bodies with `PsiRecursiveElementVisitor` so `@Log` completion applies logging to nested types as well
- add a regression test covering class-level logging when inner classes are present

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68efc2489f0c832eab1aad38ea71aa6e