### PR TITLE
Inline EDT helpers

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
@@ -61,16 +61,16 @@ object IntegrationTestApi {
         }
     }
 
-    private fun runOnEdt(action: () -> Unit) {
+    private inline fun runOnEdt(crossinline action: () -> Unit) {
         val application = ApplicationManager.getApplication()
         if (application.isDispatchThread) {
             action()
         } else {
-            application.invokeAndWait(action, ModalityState.defaultModalityState())
+            application.invokeAndWait({ action() }, ModalityState.defaultModalityState())
         }
     }
 
-    private fun <T> computeOnEdt(action: () -> T): T {
+    private inline fun <T> computeOnEdt(noinline action: () -> T): T {
         val reference = AtomicReference<T?>()
         runOnEdt {
             reference.set(action())


### PR DESCRIPTION
## Summary
- inline the IntegrationTestApi EDT helpers to avoid extra allocations
- mark the runOnEdt parameter as crossinline and adjust the invokeAndWait call to use a Runnable wrapper
- make computeOnEdt inline with a noinline action parameter so callers remain compatible

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68eec844aaac832e937702a9c3e9276b