### PR TITLE
Move pseudo-annotation completions into pseudo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Fork of abandoned [Advanced Java Folding](https://plugins.jetbrains.com/plugin/9
 For more information, read the [blog post](https://medium.com/@andrey_cheptsov/making-java-code-easier-to-read-without-changing-it-adeebd5c36de).
 
 ## Unreleased ##
-- [[pseudo-annotations] Quick completions like @Main (generate main method) and @Log (add System.out entry/exit logging).](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
+- [[pseudo-annotations] Quick completions like @Main (generate main method) and @Loggable (add System.out entry/exit logging).](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 
 ## 4.2.0 ##
 - [Add setting to prevent collapsing Java text blocks in log folding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/338)

--- a/docs/docusaurus/features/lombok-emulation.md
+++ b/docs/docusaurus/features/lombok-emulation.md
@@ -322,12 +322,12 @@ public static class RequiredArgs {
 
 ```java title="Original"
 public class LogJava {
-    Logger log = Logger.getLogger("LogAnnotation.class");
+    Logger log = Logger.getLogger("LoggableAnnotation.class");
 }
 ```
 
 ```java title="Folded"
-@Log public class LogJava {
+@Loggable public class LogJava {
 }
 ```
 

--- a/docs/docusaurus/features/pseudo-annotations.md
+++ b/docs/docusaurus/features/pseudo-annotations.md
@@ -75,9 +75,9 @@ public class Person {
 - Cleans up the pseudo-annotation after expansion.
 - Formats the inserted code so spacing stays consistent with the project style.
 
-## `@Log`
+## `@Loggable`
 
-`@Log` instruments methods with `System.out.println` calls that trace execution.
+`@Loggable` instruments methods with `System.out.println` calls that trace execution.
 
 - Apply it above a method to insert entry and exit statements around the existing body.
 - Apply it above a class to update every method and constructor in the file.
@@ -87,7 +87,7 @@ public class Person {
 
 ```java
 public class Test {
-    @Log
+    @Loggable
     public String greet(String name) {
         return "Hello " + name;
     }
@@ -109,5 +109,5 @@ public class Test {
 ## Example files
 
 - [@Main source sample](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [@Main completion tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
-- [@Log completion tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/LogAnnotationCompletionContributorTest.kt)
+- [@Main completion tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt)
+- [@Loggable completion tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt)

--- a/docs/docusaurus/options/index.md
+++ b/docs/docusaurus/options/index.md
@@ -288,7 +288,7 @@ Simplifies constructor references and inline field initialization.
 ### Pseudo-annotations for main method generation
 Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt)
 - [Documentation](../features/pseudo-annotations.md)
 
 ## overrideHide

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,13 +36,13 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
-        <!-- Suggests the pseudo-annotations @Main and @Log used by the plugin -->
+        <!-- Suggests pseudo-annotations supported by the plugin -->
         <completion.contributor
                 language="JAVA"
-                implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+                implementationClass="com.intellij.advancedExpressionFolding.pseudo.MainAnnotationCompletionContributor"/>
         <completion.contributor
                 language="JAVA"
-                implementationClass="com.intellij.advancedExpressionFolding.LogAnnotationCompletionContributor"/>
+                implementationClass="com.intellij.advancedExpressionFolding.pseudo.LoggableAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt
@@ -1,4 +1,4 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.pseudo
 
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
 import com.intellij.advancedExpressionFolding.settings.IState
@@ -29,7 +29,7 @@ import com.intellij.psi.PsiThrowStatement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 
-class LogAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(), IState by state {
+class LoggableAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(), IState by state {
 
     init {
         extend(
@@ -39,7 +39,7 @@ class LogAnnotationCompletionContributor(private val state: IState = getInstance
                 .withSuperParent(2, PsiAnnotation::class.java)
                 .withSuperParent(3, PsiModifierList::class.java)
                 .withSuperParent(4, PsiMethod::class.java),
-            MethodLogCompletionProvider()
+            MethodLoggableCompletionProvider()
         )
 
         extend(
@@ -49,17 +49,17 @@ class LogAnnotationCompletionContributor(private val state: IState = getInstance
                 .withSuperParent(2, PsiAnnotation::class.java)
                 .withSuperParent(3, PsiModifierList::class.java)
                 .withSuperParent(4, PsiClass::class.java),
-            ClassLogCompletionProvider()
+            ClassLoggableCompletionProvider()
         )
     }
 
-    private inner class MethodLogCompletionProvider : CompletionProvider<CompletionParameters>() {
+    private inner class MethodLoggableCompletionProvider : CompletionProvider<CompletionParameters>() {
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
             if (!pseudoAnnotations) return
 
-            val lookup = LookupElementBuilder.create("Log")
-                .withLookupString("@Log")
-                .withPresentableText("@Log")
+            val lookup = LookupElementBuilder.create("Loggable")
+                .withLookupString("@Loggable")
+                .withPresentableText("@Loggable")
                 .withInsertHandler { ctx, _ ->
                     handleMethodInsert(ctx)
                 }
@@ -69,13 +69,13 @@ class LogAnnotationCompletionContributor(private val state: IState = getInstance
         }
     }
 
-    private inner class ClassLogCompletionProvider : CompletionProvider<CompletionParameters>() {
+    private inner class ClassLoggableCompletionProvider : CompletionProvider<CompletionParameters>() {
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
             if (!pseudoAnnotations) return
 
-            val lookup = LookupElementBuilder.create("Log")
-                .withLookupString("@Log")
-                .withPresentableText("@Log")
+            val lookup = LookupElementBuilder.create("Loggable")
+                .withLookupString("@Loggable")
+                .withPresentableText("@Loggable")
                 .withInsertHandler { ctx, _ ->
                     handleClassInsert(ctx)
                 }
@@ -122,11 +122,11 @@ class LogAnnotationCompletionContributor(private val state: IState = getInstance
     }
 
     private fun removeAnnotation(method: PsiMethod) {
-        method.modifierList.findAnnotation("Log")?.delete()
+        method.modifierList.findAnnotation("Loggable")?.delete()
     }
 
     private fun removeAnnotation(psiClass: PsiClass) {
-        psiClass.modifierList?.findAnnotation("Log")?.delete()
+        psiClass.modifierList?.findAnnotation("Loggable")?.delete()
     }
 
     private fun applyLogging(method: PsiMethod) {

--- a/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
@@ -1,4 +1,4 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.pseudo
 
 import com.intellij.advancedExpressionFolding.processor.isVoid
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,7 +273,7 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Log") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Loggable") {
             example("PseudoAnnotationsMainTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }

--- a/test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.pseudo
 
+import com.intellij.advancedExpressionFolding.BaseTest
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.openapi.application.ApplicationManager
@@ -14,7 +15,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-class LogAnnotationCompletionContributorTest : BaseTest() {
+class LoggableAnnotationCompletionContributorTest : BaseTest() {
 
     companion object {
         private var originalPseudoAnnotationsValue: Boolean = false
@@ -128,7 +129,7 @@ class LogAnnotationCompletionContributorTest : BaseTest() {
     }
 
     @Test
-    fun `should offer @Log in completion for annotation above method`() {
+    fun `should offer @Loggable in completion for annotation above method`() {
         fixture.configureByText(
             "Test.java",
             @Language("JAVA") """
@@ -143,18 +144,18 @@ class LogAnnotationCompletionContributorTest : BaseTest() {
 
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
-        assertTrue(completions.any { it.lookupString == "Log" })
+        assertTrue(completions.any { it.lookupString == "Loggable" })
     }
 
     @ParameterizedTest
     @MethodSource("testCases")
-    fun `should insert logging when selecting @Log from completion`(testCase: TestCase) {
+    fun `should insert logging when selecting @Loggable from completion`(testCase: TestCase) {
         fixture.configureByText("Test.java", testCase.input)
 
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
 
-        val logCompletion = completions.find { it.lookupString == "Log" }
+        val logCompletion = completions.find { it.lookupString == "Loggable" }
         assertNotNull(logCompletion)
 
         ApplicationManager.getApplication().invokeAndWait {

--- a/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.pseudo
 
+import com.intellij.advancedExpressionFolding.BaseTest
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.openapi.application.ApplicationManager

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -280,7 +280,7 @@ Simplifies constructor references and inline field initialization.
 ### Pseudo-annotations for main method generation
 Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/pseudoAnnotations)
 
 ## overrideHide


### PR DESCRIPTION
## Summary
- move the @Main and @Loggable completion contributors and their tests into a new pseudo package, renaming the log contributor and test classes to Loggable*
- point plugin.xml, wiki/docs links, and the Lombok example snippet at the new @Loggable naming and package structure
- keep the pseudo-annotation documentation in sync with the relocated tests and renamed contributor

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f085b7fd84832e8c691df4012ef2b7