### PR TITLE
Generate HTML outputs for wiki docs

### DIFF
--- a/docs/docusaurus/features/generated/_category_.json
+++ b/docs/docusaurus/features/generated/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Toggle Reference (auto-generated)",
+  "position": 99,
+  "link": {
+    "type": "generated-index",
+    "title": "Toggle Reference",
+    "description": "Auto-generated reference pages converted from the historical GitHub wiki."
+  }
+}

--- a/docs/docusaurus/features/generated/arithmetic-expressions.md
+++ b/docs/docusaurus/features/generated/arithmetic-expressions.md
@@ -1,0 +1,749 @@
+---
+title: Arithmetic Expressions
+slug: /features/arithmetic-expressions
+sidebar_label: Arithmetic Expressions
+description: Folds BigDecimal, BigInteger, and Math operations into infix math.
+---
+
+:::info Toggle summary
+- **State key:** `arithmeticExpressions`
+- **Default:** Off
+- **Controlled by:** `arithmeticExpressions`
+:::
+
+## Arithmetic Expressions
+Folds BigDecimal, BigInteger, and Math operations into infix math.
+
+
+---
+
+### Detailed Folding Reference
+
+#### BigDecimalData
+
+**addBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigDecimal.add` into infix addition between the operands.
+
+**multiplyBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Collapses `BigDecimal.multiply` into infix multiplication.
+
+**divideBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigDecimal.divide` as infix division.
+
+**subtractBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Replaces `BigDecimal.subtract` with infix subtraction.
+
+**remainderBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigDecimal.remainder` with the modulus operator.
+
+**powBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigDecimal.pow` into a superscript exponent.
+
+**minBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigDecimal.min` as-is while simplifying operand literals.
+
+**maxBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Preserves `BigDecimal.max`, only collapsing constructor literals.
+
+**negateBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Keeps `BigDecimal.negate` untouched aside from literal folding.
+
+**plusBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.plus();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.plus();
+```
+Maintains `BigDecimal.plus` while collapsing instantiations.
+
+**absBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.abs();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.abs();
+```
+Retains `BigDecimal.abs` with the literal simplified.
+
+**valueOfBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigDecimal.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigDecimal.valueOf` into the literal value.
+
+**equalsBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigDecimal.equals`, with operands folded to simple literals.
+
+#### BigIntegerData
+
+**addBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigInteger.add` into infix addition.
+
+**multiplyBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Replaces `BigInteger.multiply` with infix multiplication.
+
+**divideBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigInteger.divide` as infix division.
+
+**subtractBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Collapses `BigInteger.subtract` to infix subtraction.
+
+**remainderBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.remainder` with the modulus operator.
+
+**powBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigInteger.pow` into an exponent glyph.
+
+**minBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigInteger.min` untouched beyond literal folding.
+
+**maxBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Keeps `BigInteger.max` in method-call form with simplified operands.
+
+**negateBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Retains `BigInteger.negate`, folding only constructor literals.
+
+**valueOfBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigInteger.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigInteger.valueOf` into the literal value.
+
+**equalsBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigInteger.equals` with literal operands.
+
+**andBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.and(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a & b;
+```
+Rewrites `BigInteger.and` as the infix bitwise AND operator.
+
+**gcdBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.gcd(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.gcd(b);
+```
+Leaves `BigInteger.gcd` as a method call.
+
+**notBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.not();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.not();
+```
+Keeps `BigInteger.not` unchanged.
+
+**orBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.or(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a | b;
+```
+Transforms `BigInteger.or` into the infix bitwise OR operator.
+
+**shiftLeftBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftLeft(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a << 2;
+```
+Collapses `BigInteger.shiftLeft` to the left-shift operator.
+
+**shiftRightBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftRight(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a >> 2;
+```
+Replaces `BigInteger.shiftRight` with the right-shift operator.
+
+**signumBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.signum();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.signum();
+```
+Leaves `BigInteger.signum` untouched aside from literal folding.
+
+**xorBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.xor(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a ^ b;
+```
+Rewrites `BigInteger.xor` as the infix XOR operator.
+
+**andNotBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.andNot(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a & b;
+```
+Collapses `BigInteger.andNot` into a bitwise AND expression.
+
+**modBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.mod(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.mod` with the modulus operator.
+
+#### MathData
+
+**minMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.min(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = min(a, b);
+```
+Rewrites `Math.min` to the short `min` intrinsic.
+
+**maxMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.max(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = max(a, b);
+```
+Rewrites `Math.max` to the short `max` intrinsic.
+
+**powMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.pow(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = aᵇ;
+```
+Collapses `Math.pow` into an exponent glyph.
+
+**acosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.acos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = acos(a);
+```
+Shortens `Math.acos` to `acos`.
+
+**absMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.abs(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = |a|;
+```
+Converts `Math.abs` into an absolute value bar.
+
+**asinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.asin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = asin(a);
+```
+Shortens `Math.asin` to `asin`.
+
+**atanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = atan(a);
+```
+Reduces `Math.atan` to `atan`.
+
+**atan2Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+Leaves `Math.atan2` unchanged because no shorter form is applied.
+
+**cbrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cbrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ∛a;
+```
+Turns `Math.cbrt` into a cube-root radical.
+
+**ceilMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ceil(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ceil(a);
+```
+Shrinks `Math.ceil` to `ceil`.
+
+**cosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cos(a);
+```
+Shortens `Math.cos` to `cos`.
+
+**coshMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cosh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cosh(a);
+```
+Reduces `Math.cosh` to `cosh`.
+
+**floorMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.floor(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = floor(a);
+```
+Shortens `Math.floor` to `floor`.
+
+**logMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ln(a);
+```
+Converts `Math.log` to the natural logarithm symbol.
+
+**log10Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log10(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = log(a);
+```
+Maps `Math.log10` to the common logarithm notation.
+
+**randomMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.random();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.random();
+```
+Leaves `Math.random` unchanged.
+
+**rintMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.rint(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = rint(a);
+```
+Shortens `Math.rint` to `rint`.
+
+**roundMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.round(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = round(a);
+```
+Rewrites `Math.round` as `round`.
+
+**sinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sin(a);
+```
+Shortens `Math.sin` to `sin`.
+
+**sinhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sinh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sinh(a);
+```
+Reduces `Math.sinh` to `sinh`.
+
+**sqrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sqrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sqrt(a);
+```
+Shortens `Math.sqrt` to `sqrt`.
+
+**tanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tan(a);
+```
+Reduces `Math.tan` to `tan`.
+
+**tanhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tanh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tanh(a);
+```
+Shortens `Math.tanh` to `tanh`.
+
+**toDegreesMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toDegrees(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toDegrees(a);
+```
+Rewrites `Math.toDegrees` as `toDegrees`.
+
+**toRadiansMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toRadians(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toRadians(a);
+```
+Rewrites `Math.toRadians` as `toRadians`.
+
+**ulpMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ulp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ulp(a);
+```
+Shortens `Math.ulp` to `ulp`.
+
+**expMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.exp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 𝑒ᵃ;
+```
+Collapses `Math.exp` into an exponential expression.
+
+#### LongData
+
+**valueOfLong**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Long.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Long.valueOf` with the original string value.
+
+#### IntegerData
+
+**valueOfInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Integer.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Integer.valueOf` to the source string.
+
+#### FloatData
+
+**valueOfFloat**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Float.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Float.valueOf` with the original string literal.
+
+#### DoubleData
+
+**valueOfDouble**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Double.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Double.valueOf` to the source string.

--- a/docs/docusaurus/features/generated/asserts-collapse.md
+++ b/docs/docusaurus/features/generated/asserts-collapse.md
@@ -1,0 +1,38 @@
+---
+title: Asserts Collapse
+slug: /features/asserts-collapse
+sidebar_label: Asserts Collapse
+description: Folds assert statements into terse checks.
+---
+
+:::info Toggle summary
+- **State key:** `assertsCollapse`
+- **Default:** On
+- **Controlled by:** `assertsCollapse`
+:::
+
+## Asserts Collapse
+Folds assert statements into terse checks.
+
+### Example: AssertTestData
+
+examples/data/AssertTestData.java:
+```java
+        if (args.length == 0) {
+            throw new IllegalArgumentException();
+        }
+// ...
+        }
+        if (args.length == 2)
+            throw new IllegalArgumentException("...");
+```
+
+folded/AssertTestData-folded.java:
+```java
+        assert args.length != 0;
+        assert args.length != 1 : "...";
+        assert args.length != 2 : "...";
+```
+
+Highlights AssertTestData with asserts collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/cast-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/cast-expressions-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Cast Expressions Collapse
+slug: /features/cast-expressions-collapse
+sidebar_label: Cast Expressions Collapse
+description: Folds explicit type cast calls into concise Kotlin-style expressions.
+---
+
+:::info Toggle summary
+- **State key:** `castExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `castExpressionsCollapse`
+:::
+
+## Cast Expressions Collapse
+Folds explicit type cast calls into concise Kotlin-style expressions.
+
+### Example: TypeCastTestData
+
+examples/data/TypeCastTestData.java:
+```java
+                ((TypeCastTestData) t.getObject()).getObject() instanceof TypeCastTestData) {
+                System.out.println(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()).getObject());
+        handle(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()));
+```
+
+folded/TypeCastTestData-folded.java:
+```java
+                t.getObject().getObject() instanceof TypeCastTestData) {
+                System.out.println(t.getObject().getObject().getObject());
+        handle(t.getObject().getObject());
+```
+
+Highlights TypeCastTestData with cast expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/check-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/check-expressions-collapse.md
@@ -1,0 +1,67 @@
+---
+title: Check Expressions Collapse
+slug: /features/check-expressions-collapse
+sidebar_label: Check Expressions Collapse
+description: Folds null checks and Elvis patterns into safe-call expressions.
+---
+
+:::info Toggle summary
+- **State key:** `checkExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `checkExpressionsCollapse`
+:::
+
+## Check Expressions Collapse
+Folds null checks and Elvis patterns into safe-call expressions.
+
+### Example: ElvisTestData
+
+examples/data/ElvisTestData.java:
+```java
+        System.out.println(e != null ? e : "");
+        System.out.println(e != null ? e.sayHello() : "");
+// ...
+        if (e != null) {
+                e.get().sayHello();
+        }
+        if (e.get() != null) {
+                e.get().sayHello();
+        }
+```
+
+folded/ElvisTestData-folded.java:
+```java
+        System.out.println(e ?: "");
+        System.out.println(e?.sayHello() ?: "");
+// ...
+        e?.get().sayHello();
+        e.get()?.sayHello();
+```
+
+Highlights ElvisTestData with check expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with check expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/compact-control-flow-syntax-collapse.md
+++ b/docs/docusaurus/features/generated/compact-control-flow-syntax-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Compact Control Flow Syntax Collapse
+slug: /features/compact-control-flow-syntax-collapse
+sidebar_label: Compact Control Flow Syntax Collapse
+description: Folds compact if/else syntax inspired by Go.
+---
+
+:::info Toggle summary
+- **State key:** `compactControlFlowSyntaxCollapse`
+- **Default:** Off
+- **Controlled by:** `compactControlFlowSyntaxCollapse`
+:::
+
+## Compact Control Flow Syntax Collapse
+Folds compact if/else syntax inspired by Go.
+
+### Example: CompactControlFlowTestData
+
+examples/data/CompactControlFlowTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        for (String arg : args) {
+```
+
+folded/CompactControlFlowTestData-folded.java:
+```java
+        if args.length > 0 {
+// ...
+        for String arg : args {
+```
+
+Highlights CompactControlFlowTestData with compact control flow syntax collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/comparing-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/comparing-expressions-collapse.md
@@ -1,0 +1,46 @@
+---
+title: Comparing Expressions Collapse
+slug: /features/comparing-expressions-collapse
+sidebar_label: Comparing Expressions Collapse
+description: Folds equals and compareTo calls into direct comparison expressions.
+---
+
+:::info Toggle summary
+- **State key:** `comparingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `comparingExpressionsCollapse`
+:::
+
+## Comparing Expressions Collapse
+Folds equals and compareTo calls into direct comparison expressions.
+
+### Example: EqualsCompareTestData
+
+examples/data/EqualsCompareTestData.java:
+```java
+        System.out.println(a.equals(b));
+        System.out.println(!a.equals(b));
+        System.out.println(a.compareTo(b) == 0);
+        System.out.println(a.compareTo(b) != 0);
+// ...
+        System.out.println(a.compareTo(b) > 0);
+        System.out.println(a.compareTo(b) == 1);
+        System.out.println(a.compareTo(b) > -1);
+        System.out.println(a.compareTo(b) >= 0); // Should be a >= b
+```
+
+folded/EqualsCompareTestData-folded.java:
+```java
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+// ...
+        System.out.println(a > b);
+        System.out.println(a > b);
+        System.out.println(a ≥ b);
+        System.out.println(a ≥ b); // Should be a >= b
+```
+
+Highlights EqualsCompareTestData with comparing expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/comparing-local-dates-collapse.md
+++ b/docs/docusaurus/features/generated/comparing-local-dates-collapse.md
@@ -1,0 +1,40 @@
+---
+title: comparingLocalDatesCollapse
+slug: /features/comparing-local-dates-collapse
+sidebar_label: comparingLocalDatesCollapse
+description: Folds java.time isBefore/isAfter checks into readable date comparisons.
+---
+
+:::info Toggle summary
+- **State key:** `comparingLocalDatesCollapse`
+- **Default:** On
+- **Controlled by:** `comparingLocalDatesCollapse`
+:::
+
+## Comparing Local Dates Collapse
+Folds java.time isBefore/isAfter checks into readable date comparisons.
+
+### Example: LocalDateTestData
+
+examples/data/LocalDateTestData.java:
+```java
+        boolean isBefore = d1.isBefore(d2);
+        boolean isAfter = d1.isAfter(d2);
+        boolean d2SmallerOrEqualD1 = !d1.isBefore(d2);;
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(d2);
+// ...
+        if (date1.isBefore(date2) | date1.isAfter(date2) | !date1.isBefore(date2) | !date1.isAfter(date2)) {
+```
+
+folded/LocalDateTestData-folded.java:
+```java
+        boolean isBefore = d1 < d2;
+        boolean isAfter = d1 > d2;
+        boolean d2SmallerOrEqualD1 = d1 ≥ d2;;
+        boolean d1SmallerOrEqualD2 = d1 ≤ d2;
+// ...
+        if (date1 < date2 | date1 > date2 | date1 ≥ date2 | date1 ≤ date2) {
+```
+
+Highlights LocalDateTestData with comparing local dates collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/concatenation-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/concatenation-expressions-collapse.md
@@ -1,0 +1,168 @@
+---
+title: Concatenation Expressions Collapse
+slug: /features/concatenation-expressions-collapse
+sidebar_label: Concatenation Expressions Collapse
+description: Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions.
+---
+
+:::info Toggle summary
+- **State key:** `concatenationExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `concatenationExpressionsCollapse`
+:::
+
+## Concatenation Expressions Collapse
+Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions.
+
+### Example: StringBuilderTestData
+
+examples/data/StringBuilderTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder("[");
+// ...
+        sb1.append(arg);
+```
+
+folded/StringBuilderTestData-folded.java:
+```java
+        StringBuilder sb1 = "[";
+// ...
+        sb1 += arg;
+```
+
+Highlights StringBuilderTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: InterpolatedStringTestData
+
+examples/data/InterpolatedStringTestData.java:
+```java
+        System.out.println("Hello, " + args[0]);
+        System.out.println("Hello, " + args[0] + "!");
+        System.out.println(args[0] + ", hello!");
+        System.out.println(args[0] + ", " + args[0]);
+// ...
+        System.out.println("Hello, " + name);
+        System.out.println("Hello, " + name + "!");
+        System.out.println(name + ", hello!");
+// ...
+        System.out.println("Length: " + args.length);
+        System.out.println("Sum: " + (2 + 3));
+        System.out.println("Upper: " + name.toUpperCase());
+```
+
+folded/InterpolatedStringTestData-folded.java:
+```java
+        System.out.println("Hello, ${args[0]}");
+        System.out.println("Hello, ${args[0]}!");
+        System.out.println("${args[0]}, hello!");
+        System.out.println("${args[0]}, ${args[0]}");
+// ...
+        System.out.println("Hello, $name");
+        System.out.println("Hello, $name!");
+        System.out.println("$name, hello!");
+// ...
+        System.out.println("Length: ${args.length}");
+        System.out.println("Sum: ${(2 + 3)}");
+        System.out.println("Upper: ${name.toUpperCase()}");
+```
+
+Highlights InterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append("Hello, " + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + ", hello!");
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder("Hello, ").append(args[0]); // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += "Hello, ${args[0]}";
+        System.out.println(sb1);
+// ...
+        sb2 += "${args[0]}, hello!";
+        System.out.println(sb2);
+        StringBuilder sb3 = "Hello, " + args[0]; // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";
+        new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";
+```
+
+Highlights AppendSetterInterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/const.md
+++ b/docs/docusaurus/features/generated/const.md
@@ -1,0 +1,103 @@
+---
+title: Const
+slug: /features/const
+sidebar_label: Const
+description: Folds static final fields into Kotlin-style const declarations.
+---
+
+:::info Toggle summary
+- **State key:** `const`
+- **Default:** On
+- **Controlled by:** `const`
+:::
+
+## Const
+Folds static final fields into Kotlin-style const declarations.
+
+### Example: ConstTestData
+
+examples/data/ConstTestData.java:
+```java
+    static final Pattern PATTERN = Pattern.compile(".*");
+    static final Pattern PATTERN_STATIC_IMPORT = compile(".*");
+
+// ...
+    protected final static String PROTECTED_FINAL_STATIC_VAR = "";
+
+    static public final String STATIC_PUBLIC_FINAL_VAR = "";
+// ...
+    static final public String STATIC_FINAL_PUBLIC_VAR = "";
+```
+
+folded/ConstTestData-folded.java:
+```java
+    default const PATTERN = Pattern.compile(".*");
+    default const Pattern PATTERN_STATIC_IMPORT = compile(".*");
+
+// ...
+    protected const PROTECTED_FINAL_STATIC_VAR = "";
+
+    const STATIC_PUBLIC_FINAL_VAR = "";
+// ...
+    const STATIC_FINAL_PUBLIC_VAR = "";
+```
+
+Highlights ConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ConstructorReferenceNotationWithConstTestData
+
+examples/data/ConstructorReferenceNotationWithConstTestData.java:
+```java
+        public static final ConstClass SELF = new ConstClass();
+        public static final ConstClass SELF_ANN = new ConstClass() {
+        };
+        public static final ConstClass SELF_SUB = new SubConstClass();
+        public static final ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private static final HashMap<String, String> MAP = new HashMap<>();
+        private static final HashMap<String, String> MAP2 = new HashMap<String, String>();
+        private static final Map<String, String> MAP3 = new HashMap<>();
+        private static final Map<String, String> MAP_TREE = new TreeMap<>();
+        private static final Map<String, String> MAP4 = Map.of();
+```
+
+folded/ConstructorReferenceNotationWithConstTestData-folded.java:
+```java
+        const ConstClass SELF = ::new;
+        const ConstClass SELF_ANN = ::new{};
+        const ConstClass SELF_SUB = new SubConstClass();
+        const ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private const HashMap<String, String> MAP = ::new;
+        private const HashMap<String, String> MAP2 = ::new;
+        private const Map<String, String> MAP3 = new HashMap<>();
+        private const Map<String, String> MAP_TREE = new TreeMap<>();
+        private const Map<String, String> MAP4 = Map.of();
+```
+
+Highlights ConstructorReferenceNotationWithConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with const.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/control-flow-multi-statement-code-block-collapse.md
+++ b/docs/docusaurus/features/generated/control-flow-multi-statement-code-block-collapse.md
@@ -1,0 +1,35 @@
+---
+title: Control Flow Multi Statement Code Block Collapse
+slug: /features/control-flow-multi-statement-code-block-collapse
+sidebar_label: Control Flow Multi Statement Code Block Collapse
+description: Folds multi-statement control-flow braces in read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `controlFlowMultiStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowMultiStatementCodeBlockCollapse`
+:::
+
+## Control Flow Multi Statement Code Block Collapse
+Folds multi-statement control-flow braces in read-only files.
+
+### Example: ControlFlowMultiStatementTestData
+
+examples/data/ControlFlowMultiStatementTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowMultiStatementTestData-folded.java:
+```java
+        if (args.length > 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowMultiStatementTestData with control flow multi statement code block collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/control-flow-single-statement-code-block-collapse.md
+++ b/docs/docusaurus/features/generated/control-flow-single-statement-code-block-collapse.md
@@ -1,0 +1,35 @@
+---
+title: Control Flow Single Statement Code Block Collapse
+slug: /features/control-flow-single-statement-code-block-collapse
+sidebar_label: Control Flow Single Statement Code Block Collapse
+description: Folds single-statement control-flow braces in read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `controlFlowSingleStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowSingleStatementCodeBlockCollapse`
+:::
+
+## Control Flow Single Statement Code Block Collapse
+Folds single-statement control-flow braces in read-only files.
+
+### Example: ControlFlowSingleStatementTestData
+
+examples/data/ControlFlowSingleStatementTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowSingleStatementTestData-folded.java:
+```java
+        if (args.length > 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowSingleStatementTestData with control flow single statement code block collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/dynamic.md
+++ b/docs/docusaurus/features/generated/dynamic.md
@@ -1,0 +1,36 @@
+---
+title: Dynamic
+slug: /features/dynamic
+sidebar_label: Dynamic
+description: Applies dynamic naming to methods based on a configuration file.
+---
+
+:::info Toggle summary
+- **State key:** `dynamic`
+- **Default:** On
+- **Controlled by:** `dynamic`
+:::
+
+## Dynamic names for methods based on $user.home/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with dynamic names for methods based on $user.home/dynamic-ajf2.toml.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/emojify.md
+++ b/docs/docusaurus/features/generated/emojify.md
@@ -1,0 +1,50 @@
+---
+title: Emojify
+slug: /features/emojify
+sidebar_label: Emojify
+description: Replaces select syntax elements with emoji equivalents.
+---
+
+:::info Toggle summary
+- **State key:** `emojify`
+- **Default:** Off
+- **Controlled by:** `emojify`
+:::
+
+## Emojify
+Replaces select syntax elements with emoji equivalents.
+
+### Example: EmojifyTestData
+
+examples/data/EmojifyTestData.java:
+```java
+package data;
+
+import java.time.DayOfWeek;
+// ...
+public class EmojifyTestData {
+
+    public final class FinalData {
+// ...
+
+        public void anotherMethod() {
+            final int anotherFinalVariable;
+```
+
+folded/EmojifyTestData-folded.java:
+```java
+📦 data;
+
+🚢 java.time.DayOfWeek;
+// ...
+public 🏛️ EmojifyTestData {
+
+    public 🔒 🏛️ FinalData {
+// ...
+
+        public 💀 anotherMethod() {
+            🔒 🔢 anotherFinalVariable;
+```
+
+Highlights EmojifyTestData with emojify.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/experimental.md
+++ b/docs/docusaurus/features/generated/experimental.md
@@ -1,0 +1,38 @@
+---
+title: Experimental
+slug: /features/experimental
+sidebar_label: Experimental
+description: Enables experimental folding prototypes.
+---
+
+:::info Toggle summary
+- **State key:** `experimental`
+- **Default:** Off
+- **Controlled by:** `experimental`
+:::
+
+## Experimental
+Enables experimental folding prototypes.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with experimental.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/expression-func.md
+++ b/docs/docusaurus/features/generated/expression-func.md
@@ -1,0 +1,38 @@
+---
+title: Expression Func
+slug: /features/expression-func
+sidebar_label: Expression Func
+description: Folds single-expression methods into expression-bodied functions.
+---
+
+:::info Toggle summary
+- **State key:** `expressionFunc`
+- **Default:** On
+- **Controlled by:** `expressionFunc`
+:::
+
+## Expression Func
+Folds single-expression methods into expression-bodied functions.
+
+### Example: ExpressionFuncTestData
+
+examples/data/ExpressionFuncTestData.java:
+```java
+    public long findNinjaId() {
+        return 1L;
+    }
+// ...
+    private void printStatus() {
+        new HashMap<String, String>().put("a", "b");
+    }
+```
+
+folded/ExpressionFuncTestData-folded.java:
+```java
+    findNinjaId { 1L }
+// ...
+    private void printStatus() { new HashMap<String, String>().put("a", "b") }
+```
+
+Highlights ExpressionFuncTestData with expression func.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/final-emoji.md
+++ b/docs/docusaurus/features/generated/final-emoji.md
@@ -1,0 +1,38 @@
+---
+title: Final Emoji
+slug: /features/final-emoji
+sidebar_label: Final Emoji
+description: Replaces final modifiers with lock emoji markers.
+---
+
+:::info Toggle summary
+- **State key:** `finalEmoji`
+- **Default:** Off
+- **Controlled by:** `finalEmoji`
+:::
+
+## Final Emoji
+Replaces final modifiers with lock emoji markers.
+
+### Example: FinalEmojiTestData
+
+examples/data/FinalEmojiTestData.java:
+```java
+    public final String m() {
+        final String s = "1";
+        final var s2 = "2";
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalEmojiTestData-folded.java:
+```java
+    public 🔒 String m() {
+        🔒 String s = "1";
+        🔒 var s2 = "2";
+// ...
+        void main(🔒 String arg, 🔒 int i, 🔒 Object o, Data data);
+```
+
+Highlights FinalEmojiTestData with final emoji.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/final-removal.md
+++ b/docs/docusaurus/features/generated/final-removal.md
@@ -1,0 +1,38 @@
+---
+title: Final Removal
+slug: /features/final-removal
+sidebar_label: Final Removal
+description: Folds the final modifier away from non-field declarations.
+---
+
+:::info Toggle summary
+- **State key:** `finalRemoval`
+- **Default:** Off
+- **Controlled by:** `finalRemoval`
+:::
+
+## Final Removal
+Folds the final modifier away from non-field declarations.
+
+### Example: FinalRemovalTestData
+
+examples/data/FinalRemovalTestData.java:
+```java
+    public final String m() {
+        final String s = "1";
+        final var s2 = "2";
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalRemovalTestData-folded.java:
+```java
+    public  String m() {
+         String s = "1";
+         var s2 = "2";
+// ...
+        void main( String arg,  int i,  Object o, Data data);
+```
+
+Highlights FinalRemovalTestData with final removal.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/get-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/get-expressions-collapse.md
@@ -1,0 +1,67 @@
+---
+title: Get Expressions Collapse
+slug: /features/get-expressions-collapse
+sidebar_label: Get Expressions Collapse
+description: Folds collection access and literal builders into indexed or map-style expressions.
+---
+
+:::info Toggle summary
+- **State key:** `getExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getExpressionsCollapse`
+:::
+
+## Get Expressions Collapse
+Folds collection access and literal builders into indexed or map-style expressions.
+
+### Example: GetSetPutTestData
+
+examples/data/GetSetPutTestData.java:
+```java
+        List<String> list = Arrays.asList("one", "two");
+        list.set(1,"three" );
+        System.out.println(list.get(list.size() - 1));
+        System.out.println(args[args.length - 1]);
+// ...
+        map.put("one", 1);
+        System.out.println(map.get("two"));
+        List<String> singleton = java.util.Collections.singletonList("one");
+```
+
+folded/GetSetPutTestData-folded.java:
+```java
+        List<String> list = ["one", "two"];
+        list[1] = "three";
+        System.out.println(list.getLast());
+        System.out.println(args.last());
+// ...
+        map["one"] = 1;
+        System.out.println(map["two"]);
+        List<String> singleton = ["one"];
+```
+
+Highlights GetSetPutTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/get-set-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/get-set-expressions-collapse.md
@@ -1,0 +1,381 @@
+---
+title: Get Set Expressions Collapse
+slug: /features/get-set-expressions-collapse
+sidebar_label: Get Set Expressions Collapse
+description: Folds Java getter and setter calls into property-style access.
+---
+
+:::info Toggle summary
+- **State key:** `getSetExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getSetExpressionsCollapse`
+:::
+
+## Get Set Expressions Collapse
+Folds Java getter and setter calls into property-style access.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append("Hello, " + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + ", hello!");
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder("Hello, ").append(args[0]); // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += "Hello, ${args[0]}";
+        System.out.println(sb1);
+// ...
+        sb2 += "${args[0]}, hello!";
+        System.out.println(sb2);
+        StringBuilder sb3 = "Hello, " + args[0]; // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";
+        new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";
+```
+
+Highlights AppendSetterInterpolatedStringTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: GetterSetterTestData
+
+examples/data/GetterSetterTestData.java:
+```java
+        d.setParent(d);
+        d.setName("Hello");
+        d.getParent().setName("Pum!");
+        System.out.println(d.getParent().getName());
+```
+
+folded/GetterSetterTestData-folded.java:
+```java
+        d.parent = d;
+        d.name = "Hello";
+        d.parent.name = "Pum!";
+        System.out.println(d.parent.name);
+```
+
+Highlights GetterSetterTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftBuilder
+
+examples/data/FieldShiftBuilder.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+// ...
+                .username(record.username());
+```
+
+folded/FieldShiftBuilder-folded.java:
+```java
+        this.username = <<;
+        this.active = <<;
+        this.userIdentifier = <<;
+        this.child = <<;
+// ...
+                .username(record<<);
+```
+
+Highlights FieldShiftBuilder with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftSetters
+
+examples/data/FieldShiftSetters.java:
+```java
+        this.username = username;
+// ...
+        this.active = active;
+```
+
+folded/FieldShiftSetters-folded.java:
+```java
+        this.username = <<;
+// ...
+        this.active = <<;
+```
+
+Highlights FieldShiftSetters with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogBrackets
+
+examples/data/LogBrackets.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogBrackets-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogBrackets with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogFoldingTextBlocksTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftFields
+
+examples/data/FieldShiftFields.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+        this.userIdentifier = child.userIdentifier;
+        this.userIdentifier = child.getUserIdentifier();
+// ...
+        result.username = source.child.username;
+        result.userIdentifier = source.child.child.child.userIdentifier;
+        result.active = source.child.active;
+        result.list = List.copyOf(source.list);
+```
+
+folded/FieldShiftFields-folded.java:
+```java
+        this.username = <<;
+        this.active = <<;
+        this.userIdentifier = <<;
+        this.child = <<;
+        this.userIdentifier = child.<<;
+        this.userIdentifier = child.<<;
+// ...
+        result.username = source.child.<<;
+        result.userIdentifier = source.child.child.child.<<;
+        result.active = source.child.<<;
+        result.list = List.copyOf(source.<<);
+```
+
+Highlights FieldShiftFields with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayWithoutValTestData
+
+examples/data/DestructuringAssignmentArrayWithoutValTestData.java:
+```java
+        Data first = array[0];
+// ...
+        Data second = array[1];
+        Data third = array[2];
+        Data fourth = array[3];
+```
+
+folded/DestructuringAssignmentArrayWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = array;
+// ...
+        Data ignored21 = data.array[4];
+        Data ignored22 = data.array[5];
+```
+
+Highlights DestructuringAssignmentArrayWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListWithoutValTestData
+
+examples/data/DestructuringAssignmentListWithoutValTestData.java:
+```java
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+// ...
+        Data ignored21 = data.getList().get(4);
+        Data ignored22 = data.getList().get(5);
+```
+
+folded/DestructuringAssignmentListWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = list;
+// ...
+        Data ignored21 = data.list.get(4);
+        Data ignored22 = data.list.get(5);
+```
+
+Highlights DestructuringAssignmentListWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+// ...
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/global-on.md
+++ b/docs/docusaurus/features/generated/global-on.md
@@ -1,0 +1,22 @@
+---
+title: globalOn
+slug: /features/global-on
+sidebar_label: globalOn
+description: Master switch that enables or disables all Advanced Expression Folding actions.
+---
+
+:::info Toggle summary
+- **State key:** `globalOn`
+- **Default:** On
+- **Controlled by:** `globalOn`
+:::
+
+![Keymap actions configured for folding and unfolding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/35863f50-d441-4402-8172-db6e75962350)
+
+# Global On (State field: globalOn)
+
+## Global On
+Master switch that enables or disables all Advanced Expression Folding actions.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.

--- a/docs/docusaurus/features/generated/if-null-safe.md
+++ b/docs/docusaurus/features/generated/if-null-safe.md
@@ -1,0 +1,47 @@
+---
+title: If Null Safe
+slug: /features/if-null-safe
+sidebar_label: If Null Safe
+description: Extends null-safe folding to if statements and guard clauses.
+---
+
+:::info Toggle summary
+- **State key:** `ifNullSafe`
+- **Default:** On
+- **Controlled by:** `ifNullSafe`
+:::
+
+[video](https://www.youtube.com/watch?v=zvpvhn7ISAw)
+
+
+![Null-safe if folding showcased on chained access](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/56aa2dbb-0aa1-4143-a296-801ffb0668cd)
+
+
+
+## If Null Safe
+Extends null-safe folding to if statements and guard clauses.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with if null safe.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/interface-extension-properties.md
+++ b/docs/docusaurus/features/generated/interface-extension-properties.md
@@ -1,0 +1,50 @@
+---
+title: Interface Extension Properties
+slug: /features/interface-extension-properties
+sidebar_label: Interface Extension Properties
+description: Folds interface getters and setters into Kotlin extension properties.
+---
+
+:::info Toggle summary
+- **State key:** `interfaceExtensionProperties`
+- **Default:** On
+- **Controlled by:** `interfaceExtensionProperties`
+:::
+
+## Interface Extension Properties
+Folds interface getters and setters into Kotlin extension properties.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with interface extension properties.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/kotlin-quick-return.md
+++ b/docs/docusaurus/features/generated/kotlin-quick-return.md
@@ -1,0 +1,47 @@
+---
+title: Kotlin Quick Return
+slug: /features/kotlin-quick-return
+sidebar_label: Kotlin Quick Return
+description: Folds Kotlin let/return idioms into quick-return expressions.
+---
+
+:::info Toggle summary
+- **State key:** `kotlinQuickReturn`
+- **Default:** On
+- **Controlled by:** `kotlinQuickReturn`
+:::
+
+## Kotlin Quick Return
+Folds Kotlin let/return idioms into quick-return expressions.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with kotlin quick return.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/local-date-literal-collapse.md
+++ b/docs/docusaurus/features/generated/local-date-literal-collapse.md
@@ -1,0 +1,65 @@
+---
+title: Local Date Literal Collapse
+slug: /features/local-date-literal-collapse
+sidebar_label: Local Date Literal Collapse
+description: Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms.
+---
+
+:::info Toggle summary
+- **State key:** `localDateLiteralCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralCollapse`
+:::
+
+## Local Date Literal Collapse
+Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms.
+
+### Example: LocalDateLiteralTestData
+
+examples/data/LocalDateLiteralTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralTestData-folded.java:
+```java
+        LocalDate d1 = 2018-01-10;
+        LocalDate d4 = 2018-01-10;
+        LocalDate d2 = 2018-12-10;
+        LocalDate d3 = 2018-04-04;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013-01-10);
+```
+
+Highlights LocalDateLiteralTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/local-date-literal-postfix-collapse.md
+++ b/docs/docusaurus/features/generated/local-date-literal-postfix-collapse.md
@@ -1,0 +1,40 @@
+---
+title: Local Date Literal Postfix Collapse
+slug: /features/local-date-literal-postfix-collapse
+sidebar_label: Local Date Literal Postfix Collapse
+description: Folds postfix LocalDate literals such as 2018Y-02M-12D.
+---
+
+:::info Toggle summary
+- **State key:** `localDateLiteralPostfixCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralPostfixCollapse`
+:::
+
+## Local Date Literal Postfix Collapse
+Folds postfix LocalDate literals such as 2018Y-02M-12D.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal postfix collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/log-folding-text-blocks.md
+++ b/docs/docusaurus/features/generated/log-folding-text-blocks.md
@@ -1,0 +1,34 @@
+---
+title: Log Folding Text Blocks
+slug: /features/log-folding-text-blocks
+sidebar_label: Log Folding Text Blocks
+description: Folds log Text Blocks into compact placeholders.
+---
+
+:::info Toggle summary
+- **State key:** `logFoldingTextBlocks`
+- **Default:** Off
+- **Controlled by:** `logFoldingTextBlocks`
+:::
+
+## Log Folding Text Blocks
+Folds log Text Blocks into compact placeholders.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogFoldingTextBlocksTestData with log folding text blocks.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/lombok-dirty-off.md
+++ b/docs/docusaurus/features/generated/lombok-dirty-off.md
@@ -1,0 +1,34 @@
+---
+title: Lombok Dirty Off
+slug: /features/lombok-dirty-off
+sidebar_label: Lombok Dirty Off
+description: Skips folding Lombok accessors marked as dirty.
+---
+
+:::info Toggle summary
+- **State key:** `lombokDirtyOff`
+- **Default:** Off
+- **Controlled by:** `lombokDirtyOff`
+:::
+
+## Lombok Dirty Off
+Skips folding Lombok accessors marked as dirty.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok dirty off.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/lombok-pattern-off.md
+++ b/docs/docusaurus/features/generated/lombok-pattern-off.md
@@ -1,0 +1,67 @@
+---
+title: Lombok Pattern Off
+slug: /features/lombok-pattern-off
+sidebar_label: Lombok Pattern Off
+description: Uses a regex to disable Lombok folding for matching classes.
+---
+
+:::info Toggle summary
+- **State key:** `lombokPatternOff`
+- **Default:** Off
+- **Controlled by:** `lombokPatternOff`
+:::
+
+## Lombok Pattern Off
+Uses a regex to disable Lombok folding for matching classes.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return "ToStringFull{" +
+                    "data=" + data +
+                    ", ok=" + ok +
+                    '}';
+// ...
+                return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';
+// ...
+                return "ToStringPartial{" + "data=" + data + '}';
+```
+
+Highlights LombokPatternOffTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/lombok.md
+++ b/docs/docusaurus/features/generated/lombok.md
@@ -1,0 +1,209 @@
+---
+title: Lombok
+slug: /features/lombok
+sidebar_label: Lombok
+description: Folds Java bean patterns into Lombok-style annotations.
+---
+
+:::info Toggle summary
+- **State key:** `lombok`
+- **Default:** On
+- **Controlled by:** `lombok`
+:::
+
+![Animated overview of Lombok folding support](https://github.com/user-attachments/assets/7d2bdcf7-15ad-45a2-9aad-1f596443c4d7)
+
+old video:
+[video](https://www.youtube.com/watch?v=dKMWL3YJacU)
+
+
+## Lombok
+Folds Java bean patterns into Lombok-style annotations.
+
+### Example: LombokTestData
+
+examples/data/LombokTestData.java:
+```java
+public class LombokTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokTestData data;
+        boolean ok;
+```
+
+Highlights LombokTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return "ToStringFull{" +
+                    "data=" + data +
+                    ", ok=" + ok +
+                    '}';
+// ...
+                return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';
+// ...
+                return "ToStringPartial{" + "data=" + data + '}';
+```
+
+Highlights LombokPatternOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with lombok.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/memory-improvement.md
+++ b/docs/docusaurus/features/generated/memory-improvement.md
@@ -1,0 +1,28 @@
+---
+title: memoryImprovement
+slug: /features/memory-improvement
+sidebar_label: memoryImprovement
+description: Caches folding descriptors for large test data files.
+---
+
+:::info Toggle summary
+- **State key:** `memoryImprovement`
+- **Default:** On
+- **Controlled by:** `memoryImprovement`
+:::
+
+* only for files in **testData** folder
+
+![Diff view before folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/89ccca5b-92ce-47ad-b051-7eabb39f94c2)
+
+=>
+
+![Diff view after folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/440c30a8-1088-4e6a-bf25-bde6627aa7af)
+
+# Memory Improvement (State field: memoryImprovement)
+
+## Memory Improvement
+Caches folding descriptors for large test data files.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.

--- a/docs/docusaurus/features/generated/nullable.md
+++ b/docs/docusaurus/features/generated/nullable.md
@@ -1,0 +1,166 @@
+---
+title: Nullable
+slug: /features/nullable
+sidebar_label: Nullable
+description: Folds nullability annotations into ? and !! markers.
+---
+
+:::info Toggle summary
+- **State key:** `nullable`
+- **Default:** Off
+- **Controlled by:** `nullable`
+:::
+
+## Nullable
+Folds nullability annotations into ? and !! markers.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+// ...
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with nullable.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/optional.md
+++ b/docs/docusaurus/features/generated/optional.md
@@ -1,0 +1,79 @@
+---
+title: Optional
+slug: /features/optional
+sidebar_label: Optional
+description: Displays java.util.Optional flows as Kotlin-style null-safe chains.
+---
+
+:::info Toggle summary
+- **State key:** `optional`
+- **Default:** On
+- **Controlled by:** `optional`
+:::
+
+## Optional
+Displays java.util.Optional flows as Kotlin-style null-safe chains.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with optional.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/override-hide.md
+++ b/docs/docusaurus/features/generated/override-hide.md
@@ -1,0 +1,36 @@
+---
+title: Override Hide
+slug: /features/override-hide
+sidebar_label: Override Hide
+description: Hides @Override annotations from view.
+---
+
+:::info Toggle summary
+- **State key:** `overrideHide`
+- **Default:** On
+- **Controlled by:** `overrideHide`
+:::
+
+## Override Hide
+Hides @Override annotations from view.
+
+### Example: OverrideHideTestData
+
+examples/data/OverrideHideTestData.java:
+```java
+            @Override
+// ...
+            @Override
+```
+
+folded/OverrideHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+```
+
+Highlights OverrideHideTestData with override hide.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/println.md
+++ b/docs/docusaurus/features/generated/println.md
@@ -1,0 +1,51 @@
+---
+title: Println
+slug: /features/println
+sidebar_label: Println
+description: Folds System.out.println calls into println.
+---
+
+:::info Toggle summary
+- **State key:** `println`
+- **Default:** On
+- **Controlled by:** `println`
+:::
+
+![System.out.println call folded to println](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/75a5224f-7b52-4b71-9774-2814e8a867ba)
+
+
+## Println
+Folds System.out.println calls into println.
+
+### Example: PrintlnTestData
+
+examples/data/PrintlnTestData.java:
+```java
+        System.out.println("Hello");
+        System.out.println
+// ...
+        System.
+                out.println("Spacing");
+        System.out.
+// ...
+        System.out.println("Passed as parameter: " +
+this.getClass());
+        System.out.println("""
+```
+
+folded/PrintlnTestData-folded.java:
+```java
+        println("Hello");
+        println
+// ...
+        println("Spacing");
+        println(3.14);
+        println(string);
+// ...
+        println("Passed as parameter: " + string);
+        println("Passed as parameter: " + this.getClass());
+        println("""
+```
+
+Highlights PrintlnTestData with println.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/range-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/range-expressions-collapse.md
@@ -1,0 +1,38 @@
+---
+title: Range Expressions Collapse
+slug: /features/range-expressions-collapse
+sidebar_label: Range Expressions Collapse
+description: Folds indexed loops into Kotlin-style range expressions.
+---
+
+:::info Toggle summary
+- **State key:** `rangeExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `rangeExpressionsCollapse`
+:::
+
+## Range Expressions Collapse
+Folds indexed loops into Kotlin-style range expressions.
+
+### Example: ForRangeTestData
+
+examples/data/ForRangeTestData.java:
+```java
+                for (int i = 0; i < args.length; i++) {
+                        String arg = args
+                                [i];
+// ...
+                for (int i = 0; i < args.length; i++) {
+                        String arg = args
+                                [i];
+```
+
+folded/ForRangeTestData-folded.java:
+```java
+                for ((int i, String arg) : args) {
+// ...
+                for (String arg : args) {
+```
+
+Highlights ForRangeTestData with range expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/semicolons-collapse.md
+++ b/docs/docusaurus/features/generated/semicolons-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Semicolons Collapse
+slug: /features/semicolons-collapse
+sidebar_label: Semicolons Collapse
+description: Folds redundant semicolons inside read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `semicolonsCollapse`
+- **Default:** Off
+- **Controlled by:** `semicolonsCollapse`
+:::
+
+## Semicolons Collapse
+Folds redundant semicolons inside read-only files.
+
+### Example: SemicolonTestData
+
+examples/data/SemicolonTestData.java:
+```java
+package data;
+// ...
+import java.util.Arrays;
+```
+
+folded/SemicolonTestData-folded.java:
+```java
+package data
+// ...
+import java.util.Arrays
+```
+
+Highlights SemicolonTestData with semicolons collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/slicing-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/slicing-expressions-collapse.md
@@ -1,0 +1,54 @@
+---
+title: Slicing Expressions Collapse
+slug: /features/slicing-expressions-collapse
+sidebar_label: Slicing Expressions Collapse
+description: Folds List.subList and String.substring calls into concise slice notation.
+---
+
+:::info Toggle summary
+- **State key:** `slicingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `slicingExpressionsCollapse`
+:::
+
+## Slicing Expressions Collapse
+Folds List.subList and String.substring calls into concise slice notation.
+
+### Example: SliceTestData
+
+examples/data/SliceTestData.java:
+```java
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(1, 2));
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(0, 2));
+        System.out.println(list.subList(1, list.size() - 2));
+        System.out.println(list.subList(0, list.size() - 2));
+// ...
+        System.out.println(f.substring(1));
+        System.out.println(f.substring(1, 2));
+        System.out.println(f.substring(1, f.length()));
+        System.out.println(f.substring(0, 2));
+        System.out.println(f.substring(1, f.length() - 2));
+        System.out.println(f.substring(0, f.length() - 2));
+```
+
+folded/SliceTestData-folded.java:
+```java
+        System.out.println(list[1:]);
+        System.out.println(list[1:2]);
+        System.out.println(list[1:]);
+        System.out.println(list[:2]);
+        System.out.println(list[1:-2]);
+        System.out.println(list[:-2]);
+// ...
+        System.out.println(f[1:]);
+        System.out.println(f[1:2]);
+        System.out.println(f[1:]);
+        System.out.println(f[:2]);
+        System.out.println(f[1:-2]);
+        System.out.println(f[:-2]);
+```
+
+Highlights SliceTestData with slicing expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/stream-spread.md
+++ b/docs/docusaurus/features/generated/stream-spread.md
@@ -1,0 +1,79 @@
+---
+title: Stream Spread
+slug: /features/stream-spread
+sidebar_label: Stream Spread
+description: Displays stream pipelines using Groovy-style spread notation.
+---
+
+:::info Toggle summary
+- **State key:** `streamSpread`
+- **Default:** On
+- **Controlled by:** `streamSpread`
+:::
+
+## Stream Spread
+Displays stream pipelines using Groovy-style spread notation.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with stream spread.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/summary-parent-override.md
+++ b/docs/docusaurus/features/generated/summary-parent-override.md
@@ -1,0 +1,34 @@
+---
+title: Summary Parent Override
+slug: /features/summary-parent-override
+sidebar_label: Summary Parent Override
+description: Folds overridden methods into parent summary stubs.
+---
+
+:::info Toggle summary
+- **State key:** `summaryParentOverride`
+- **Default:** Off
+- **Controlled by:** `summaryParentOverride`
+:::
+
+## Summary Parent Override
+Folds overridden methods into parent summary stubs.
+
+### Example: SummaryParentOverrideTestData
+
+examples/data/SummaryParentOverrideTestData.java:
+```java
+    class ParentClass extends GrandparentClass {
+// ...
+        public void grandparentMethod() {
+```
+
+folded/SummaryParentOverrideTestData-folded.java:
+```java
+    class ParentClass extends GrandparentClass(1-grandparentMethod) {
+// ...
+        public void grandparentMethod() { // overrides from GrandparentClass
+```
+
+Highlights SummaryParentOverrideTestData with summary parent override.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/suppress-warnings-hide.md
+++ b/docs/docusaurus/features/generated/suppress-warnings-hide.md
@@ -1,0 +1,36 @@
+---
+title: Suppress Warnings Hide
+slug: /features/suppress-warnings-hide
+sidebar_label: Suppress Warnings Hide
+description: Hides @SuppressWarnings annotations from view.
+---
+
+:::info Toggle summary
+- **State key:** `suppressWarningsHide`
+- **Default:** On
+- **Controlled by:** `suppressWarningsHide`
+:::
+
+## Suppress Warnings Hide
+Hides @SuppressWarnings annotations from view.
+
+### Example: SuppressWarningsHideTestData
+
+examples/data/SuppressWarningsHideTestData.java:
+```java
+    @SuppressWarnings("deprecation")
+// ...
+    @SuppressWarnings({"rawtypes", "unchecked"})
+```
+
+folded/SuppressWarningsHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+```
+
+Highlights SuppressWarningsHideTestData with suppress warnings hide.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/generated/var-expressions-collapse.md
+++ b/docs/docusaurus/features/generated/var-expressions-collapse.md
@@ -1,0 +1,109 @@
+---
+title: Var Expressions Collapse
+slug: /features/var-expressions-collapse
+sidebar_label: Var Expressions Collapse
+description: Folds variable declarations into val/var style declarations.
+---
+
+:::info Toggle summary
+- **State key:** `varExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `varExpressionsCollapse`
+:::
+
+## Var Expressions Collapse
+Folds variable declarations into val/var style declarations.
+
+### Example: VarTestData
+
+examples/data/VarTestData.java:
+```java
+        String string = "Hello, world";
+// ...
+        int count = 0;
+        for (String arg : args) {
+```
+
+folded/VarTestData-folded.java:
+```java
+        val string = "Hello, world";
+// ...
+        var count = 0;
+        for (val arg : args) {
+```
+
+Highlights VarTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated-html/arithmetic-expressions.html
+++ b/docs/docusaurus/features/wiki-generated-html/arithmetic-expressions.html
@@ -1,0 +1,767 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Arithmetic Expressions</title>
+    <meta name="description" content="Folds BigDecimal, BigInteger, and Math operations into infix math." />
+  </head>
+  <body>
+    <h1>Arithmetic Expressions</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>arithmeticExpressions</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>arithmeticExpressions</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `arithmeticExpressions`
+- **Default:** Off
+- **Controlled by:** `arithmeticExpressions`
+:::
+
+## Arithmetic Expressions
+Folds BigDecimal, BigInteger, and Math operations into infix math.
+
+
+---
+
+### Detailed Folding Reference
+
+#### BigDecimalData
+
+**addBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigDecimal.add` into infix addition between the operands.
+
+**multiplyBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Collapses `BigDecimal.multiply` into infix multiplication.
+
+**divideBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigDecimal.divide` as infix division.
+
+**subtractBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Replaces `BigDecimal.subtract` with infix subtraction.
+
+**remainderBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigDecimal.remainder` with the modulus operator.
+
+**powBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigDecimal.pow` into a superscript exponent.
+
+**minBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigDecimal.min` as-is while simplifying operand literals.
+
+**maxBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Preserves `BigDecimal.max`, only collapsing constructor literals.
+
+**negateBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Keeps `BigDecimal.negate` untouched aside from literal folding.
+
+**plusBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.plus();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.plus();
+```
+Maintains `BigDecimal.plus` while collapsing instantiations.
+
+**absBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.abs();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.abs();
+```
+Retains `BigDecimal.abs` with the literal simplified.
+
+**valueOfBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigDecimal.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigDecimal.valueOf` into the literal value.
+
+**equalsBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigDecimal.equals`, with operands folded to simple literals.
+
+#### BigIntegerData
+
+**addBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigInteger.add` into infix addition.
+
+**multiplyBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Replaces `BigInteger.multiply` with infix multiplication.
+
+**divideBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigInteger.divide` as infix division.
+
+**subtractBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Collapses `BigInteger.subtract` to infix subtraction.
+
+**remainderBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.remainder` with the modulus operator.
+
+**powBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigInteger.pow` into an exponent glyph.
+
+**minBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigInteger.min` untouched beyond literal folding.
+
+**maxBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Keeps `BigInteger.max` in method-call form with simplified operands.
+
+**negateBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Retains `BigInteger.negate`, folding only constructor literals.
+
+**valueOfBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigInteger.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigInteger.valueOf` into the literal value.
+
+**equalsBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigInteger.equals` with literal operands.
+
+**andBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.and(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a &amp; b;
+```
+Rewrites `BigInteger.and` as the infix bitwise AND operator.
+
+**gcdBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.gcd(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.gcd(b);
+```
+Leaves `BigInteger.gcd` as a method call.
+
+**notBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.not();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.not();
+```
+Keeps `BigInteger.not` unchanged.
+
+**orBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.or(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a | b;
+```
+Transforms `BigInteger.or` into the infix bitwise OR operator.
+
+**shiftLeftBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftLeft(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a &lt;&lt; 2;
+```
+Collapses `BigInteger.shiftLeft` to the left-shift operator.
+
+**shiftRightBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftRight(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a &gt;&gt; 2;
+```
+Replaces `BigInteger.shiftRight` with the right-shift operator.
+
+**signumBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.signum();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.signum();
+```
+Leaves `BigInteger.signum` untouched aside from literal folding.
+
+**xorBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.xor(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a ^ b;
+```
+Rewrites `BigInteger.xor` as the infix XOR operator.
+
+**andNotBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.andNot(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a &amp; b;
+```
+Collapses `BigInteger.andNot` into a bitwise AND expression.
+
+**modBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.mod(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.mod` with the modulus operator.
+
+#### MathData
+
+**minMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.min(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = min(a, b);
+```
+Rewrites `Math.min` to the short `min` intrinsic.
+
+**maxMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.max(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = max(a, b);
+```
+Rewrites `Math.max` to the short `max` intrinsic.
+
+**powMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.pow(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = aᵇ;
+```
+Collapses `Math.pow` into an exponent glyph.
+
+**acosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.acos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = acos(a);
+```
+Shortens `Math.acos` to `acos`.
+
+**absMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.abs(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = |a|;
+```
+Converts `Math.abs` into an absolute value bar.
+
+**asinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.asin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = asin(a);
+```
+Shortens `Math.asin` to `asin`.
+
+**atanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = atan(a);
+```
+Reduces `Math.atan` to `atan`.
+
+**atan2Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+Leaves `Math.atan2` unchanged because no shorter form is applied.
+
+**cbrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cbrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ∛a;
+```
+Turns `Math.cbrt` into a cube-root radical.
+
+**ceilMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ceil(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ceil(a);
+```
+Shrinks `Math.ceil` to `ceil`.
+
+**cosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cos(a);
+```
+Shortens `Math.cos` to `cos`.
+
+**coshMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cosh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cosh(a);
+```
+Reduces `Math.cosh` to `cosh`.
+
+**floorMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.floor(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = floor(a);
+```
+Shortens `Math.floor` to `floor`.
+
+**logMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ln(a);
+```
+Converts `Math.log` to the natural logarithm symbol.
+
+**log10Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log10(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = log(a);
+```
+Maps `Math.log10` to the common logarithm notation.
+
+**randomMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.random();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.random();
+```
+Leaves `Math.random` unchanged.
+
+**rintMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.rint(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = rint(a);
+```
+Shortens `Math.rint` to `rint`.
+
+**roundMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.round(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = round(a);
+```
+Rewrites `Math.round` as `round`.
+
+**sinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sin(a);
+```
+Shortens `Math.sin` to `sin`.
+
+**sinhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sinh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sinh(a);
+```
+Reduces `Math.sinh` to `sinh`.
+
+**sqrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sqrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sqrt(a);
+```
+Shortens `Math.sqrt` to `sqrt`.
+
+**tanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tan(a);
+```
+Reduces `Math.tan` to `tan`.
+
+**tanhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tanh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tanh(a);
+```
+Shortens `Math.tanh` to `tanh`.
+
+**toDegreesMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toDegrees(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toDegrees(a);
+```
+Rewrites `Math.toDegrees` as `toDegrees`.
+
+**toRadiansMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toRadians(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toRadians(a);
+```
+Rewrites `Math.toRadians` as `toRadians`.
+
+**ulpMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ulp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ulp(a);
+```
+Shortens `Math.ulp` to `ulp`.
+
+**expMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.exp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 𝑒ᵃ;
+```
+Collapses `Math.exp` into an exponential expression.
+
+#### LongData
+
+**valueOfLong**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Long.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Long.valueOf` with the original string value.
+
+#### IntegerData
+
+**valueOfInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Integer.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Integer.valueOf` to the source string.
+
+#### FloatData
+
+**valueOfFloat**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Float.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Float.valueOf` with the original string literal.
+
+#### DoubleData
+
+**valueOfDouble**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Double.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Double.valueOf` to the source string.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/asserts-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/asserts-collapse.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Asserts Collapse</title>
+    <meta name="description" content="Folds assert statements into terse checks." />
+  </head>
+  <body>
+    <h1>Asserts Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>assertsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>assertsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `assertsCollapse`
+- **Default:** On
+- **Controlled by:** `assertsCollapse`
+:::
+
+## Asserts Collapse
+Folds assert statements into terse checks.
+
+### Example: AssertTestData
+
+examples/data/AssertTestData.java:
+```java
+        if (args.length == 0) {
+            throw new IllegalArgumentException();
+        }
+// ...
+        }
+        if (args.length == 2)
+            throw new IllegalArgumentException(&quot;...&quot;);
+```
+
+folded/AssertTestData-folded.java:
+```java
+        assert args.length != 0;
+        assert args.length != 1 : &quot;...&quot;;
+        assert args.length != 2 : &quot;...&quot;;
+```
+
+Highlights AssertTestData with asserts collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/cast-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/cast-expressions-collapse.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Cast Expressions Collapse</title>
+    <meta name="description" content="Folds explicit type cast calls into concise Kotlin-style expressions." />
+  </head>
+  <body>
+    <h1>Cast Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>castExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>castExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `castExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `castExpressionsCollapse`
+:::
+
+## Cast Expressions Collapse
+Folds explicit type cast calls into concise Kotlin-style expressions.
+
+### Example: TypeCastTestData
+
+examples/data/TypeCastTestData.java:
+```java
+                ((TypeCastTestData) t.getObject()).getObject() instanceof TypeCastTestData) {
+                System.out.println(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()).getObject());
+        handle(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()));
+```
+
+folded/TypeCastTestData-folded.java:
+```java
+                t.getObject().getObject() instanceof TypeCastTestData) {
+                System.out.println(t.getObject().getObject().getObject());
+        handle(t.getObject().getObject());
+```
+
+Highlights TypeCastTestData with cast expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/check-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/check-expressions-collapse.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Check Expressions Collapse</title>
+    <meta name="description" content="Folds null checks and Elvis patterns into safe-call expressions." />
+  </head>
+  <body>
+    <h1>Check Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>checkExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>checkExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `checkExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `checkExpressionsCollapse`
+:::
+
+## Check Expressions Collapse
+Folds null checks and Elvis patterns into safe-call expressions.
+
+### Example: ElvisTestData
+
+examples/data/ElvisTestData.java:
+```java
+        System.out.println(e != null ? e : &quot;&quot;);
+        System.out.println(e != null ? e.sayHello() : &quot;&quot;);
+// ...
+        if (e != null) {
+                e.get().sayHello();
+        }
+        if (e.get() != null) {
+                e.get().sayHello();
+        }
+```
+
+folded/ElvisTestData-folded.java:
+```java
+        System.out.println(e ?: &quot;&quot;);
+        System.out.println(e?.sayHello() ?: &quot;&quot;);
+// ...
+        e?.get().sayHello();
+        e.get()?.sayHello();
+```
+
+Highlights ElvisTestData with check expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                &amp;&amp; data.getData1() != null
+// ...
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data != null
+                &amp;&amp; data != null
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                &amp;&amp; data?.data1 != null
+// ...
+                &amp;&amp; data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with check expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/compact-control-flow-syntax-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/compact-control-flow-syntax-collapse.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Compact Control Flow Syntax Collapse</title>
+    <meta name="description" content="Folds compact if/else syntax inspired by Go." />
+  </head>
+  <body>
+    <h1>Compact Control Flow Syntax Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>compactControlFlowSyntaxCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>compactControlFlowSyntaxCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `compactControlFlowSyntaxCollapse`
+- **Default:** Off
+- **Controlled by:** `compactControlFlowSyntaxCollapse`
+:::
+
+## Compact Control Flow Syntax Collapse
+Folds compact if/else syntax inspired by Go.
+
+### Example: CompactControlFlowTestData
+
+examples/data/CompactControlFlowTestData.java:
+```java
+        if (args.length &gt; 0) {
+// ...
+        for (String arg : args) {
+```
+
+folded/CompactControlFlowTestData-folded.java:
+```java
+        if args.length &gt; 0 {
+// ...
+        for String arg : args {
+```
+
+Highlights CompactControlFlowTestData with compact control flow syntax collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/comparing-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/comparing-expressions-collapse.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Comparing Expressions Collapse</title>
+    <meta name="description" content="Folds equals and compareTo calls into direct comparison expressions." />
+  </head>
+  <body>
+    <h1>Comparing Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>comparingExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>comparingExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `comparingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `comparingExpressionsCollapse`
+:::
+
+## Comparing Expressions Collapse
+Folds equals and compareTo calls into direct comparison expressions.
+
+### Example: EqualsCompareTestData
+
+examples/data/EqualsCompareTestData.java:
+```java
+        System.out.println(a.equals(b));
+        System.out.println(!a.equals(b));
+        System.out.println(a.compareTo(b) == 0);
+        System.out.println(a.compareTo(b) != 0);
+// ...
+        System.out.println(a.compareTo(b) &gt; 0);
+        System.out.println(a.compareTo(b) == 1);
+        System.out.println(a.compareTo(b) &gt; -1);
+        System.out.println(a.compareTo(b) &gt;= 0); // Should be a &gt;= b
+```
+
+folded/EqualsCompareTestData-folded.java:
+```java
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+// ...
+        System.out.println(a &gt; b);
+        System.out.println(a &gt; b);
+        System.out.println(a ≥ b);
+        System.out.println(a ≥ b); // Should be a &gt;= b
+```
+
+Highlights EqualsCompareTestData with comparing expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/comparing-local-dates-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/comparing-local-dates-collapse.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>comparingLocalDatesCollapse</title>
+    <meta name="description" content="Folds java.time isBefore/isAfter checks into readable date comparisons." />
+  </head>
+  <body>
+    <h1>comparingLocalDatesCollapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>comparingLocalDatesCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>comparingLocalDatesCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `comparingLocalDatesCollapse`
+- **Default:** On
+- **Controlled by:** `comparingLocalDatesCollapse`
+:::
+
+## Comparing Local Dates Collapse
+Folds java.time isBefore/isAfter checks into readable date comparisons.
+
+### Example: LocalDateTestData
+
+examples/data/LocalDateTestData.java:
+```java
+        boolean isBefore = d1.isBefore(d2);
+        boolean isAfter = d1.isAfter(d2);
+        boolean d2SmallerOrEqualD1 = !d1.isBefore(d2);;
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(d2);
+// ...
+        if (date1.isBefore(date2) | date1.isAfter(date2) | !date1.isBefore(date2) | !date1.isAfter(date2)) {
+```
+
+folded/LocalDateTestData-folded.java:
+```java
+        boolean isBefore = d1 &lt; d2;
+        boolean isAfter = d1 &gt; d2;
+        boolean d2SmallerOrEqualD1 = d1 ≥ d2;;
+        boolean d1SmallerOrEqualD2 = d1 ≤ d2;
+// ...
+        if (date1 &lt; date2 | date1 &gt; date2 | date1 ≥ date2 | date1 ≤ date2) {
+```
+
+Highlights LocalDateTestData with comparing local dates collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/concatenation-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/concatenation-expressions-collapse.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Concatenation Expressions Collapse</title>
+    <meta name="description" content="Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions." />
+  </head>
+  <body>
+    <h1>Concatenation Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>concatenationExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>concatenationExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `concatenationExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `concatenationExpressionsCollapse`
+:::
+
+## Concatenation Expressions Collapse
+Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions.
+
+### Example: StringBuilderTestData
+
+examples/data/StringBuilderTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder(&quot;[&quot;);
+// ...
+        sb1.append(arg);
+```
+
+folded/StringBuilderTestData-folded.java:
+```java
+        StringBuilder sb1 = &quot;[&quot;;
+// ...
+        sb1 += arg;
+```
+
+Highlights StringBuilderTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: InterpolatedStringTestData
+
+examples/data/InterpolatedStringTestData.java:
+```java
+        System.out.println(&quot;Hello, &quot; + args[0]);
+        System.out.println(&quot;Hello, &quot; + args[0] + &quot;!&quot;);
+        System.out.println(args[0] + &quot;, hello!&quot;);
+        System.out.println(args[0] + &quot;, &quot; + args[0]);
+// ...
+        System.out.println(&quot;Hello, &quot; + name);
+        System.out.println(&quot;Hello, &quot; + name + &quot;!&quot;);
+        System.out.println(name + &quot;, hello!&quot;);
+// ...
+        System.out.println(&quot;Length: &quot; + args.length);
+        System.out.println(&quot;Sum: &quot; + (2 + 3));
+        System.out.println(&quot;Upper: &quot; + name.toUpperCase());
+```
+
+folded/InterpolatedStringTestData-folded.java:
+```java
+        System.out.println(&quot;Hello, ${args[0]}&quot;);
+        System.out.println(&quot;Hello, ${args[0]}!&quot;);
+        System.out.println(&quot;${args[0]}, hello!&quot;);
+        System.out.println(&quot;${args[0]}, ${args[0]}&quot;);
+// ...
+        System.out.println(&quot;Hello, $name&quot;);
+        System.out.println(&quot;Hello, $name!&quot;);
+        System.out.println(&quot;$name, hello!&quot;);
+// ...
+        System.out.println(&quot;Length: ${args.length}&quot;);
+        System.out.println(&quot;Sum: ${(2 + 3)}&quot;);
+        System.out.println(&quot;Upper: ${name.toUpperCase()}&quot;);
+```
+
+Highlights InterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append(&quot;Hello, &quot; + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + &quot;, hello!&quot;);
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder(&quot;Hello, &quot;).append(args[0]); // Should be StringBuilder sb3 = &quot;Hello, $(args[0)&quot;:
+// ...
+        new AppendSetterInterpolatedStringTestData().setName(&quot;Hello, &quot; + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + &quot;, hello!&quot;);
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += &quot;Hello, ${args[0]}&quot;;
+        System.out.println(sb1);
+// ...
+        sb2 += &quot;${args[0]}, hello!&quot;;
+        System.out.println(sb2);
+        StringBuilder sb3 = &quot;Hello, &quot; + args[0]; // Should be StringBuilder sb3 = &quot;Hello, $(args[0)&quot;:
+// ...
+        new AppendSetterInterpolatedStringTestData().name = &quot;Hello, ${args[0]}&quot;;
+        new AppendSetterInterpolatedStringTestData().name = &quot;${args[0]}, hello!&quot;;
+```
+
+Highlights AppendSetterInterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add(&quot;one&quot;);
+        list.remove(&quot;one&quot;);
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += &quot;one&quot;;
+        list -= &quot;one&quot;;
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/const.html
+++ b/docs/docusaurus/features/wiki-generated-html/const.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Const</title>
+    <meta name="description" content="Folds static final fields into Kotlin-style const declarations." />
+  </head>
+  <body>
+    <h1>Const</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>const</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>const</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `const`
+- **Default:** On
+- **Controlled by:** `const`
+:::
+
+## Const
+Folds static final fields into Kotlin-style const declarations.
+
+### Example: ConstTestData
+
+examples/data/ConstTestData.java:
+```java
+    static final Pattern PATTERN = Pattern.compile(&quot;.*&quot;);
+    static final Pattern PATTERN_STATIC_IMPORT = compile(&quot;.*&quot;);
+
+// ...
+    protected final static String PROTECTED_FINAL_STATIC_VAR = &quot;&quot;;
+
+    static public final String STATIC_PUBLIC_FINAL_VAR = &quot;&quot;;
+// ...
+    static final public String STATIC_FINAL_PUBLIC_VAR = &quot;&quot;;
+```
+
+folded/ConstTestData-folded.java:
+```java
+    default const PATTERN = Pattern.compile(&quot;.*&quot;);
+    default const Pattern PATTERN_STATIC_IMPORT = compile(&quot;.*&quot;);
+
+// ...
+    protected const PROTECTED_FINAL_STATIC_VAR = &quot;&quot;;
+
+    const STATIC_PUBLIC_FINAL_VAR = &quot;&quot;;
+// ...
+    const STATIC_FINAL_PUBLIC_VAR = &quot;&quot;;
+```
+
+Highlights ConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ConstructorReferenceNotationWithConstTestData
+
+examples/data/ConstructorReferenceNotationWithConstTestData.java:
+```java
+        public static final ConstClass SELF = new ConstClass();
+        public static final ConstClass SELF_ANN = new ConstClass() {
+        };
+        public static final ConstClass SELF_SUB = new SubConstClass();
+        public static final ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private static final HashMap&lt;String, String&gt; MAP = new HashMap&lt;&gt;();
+        private static final HashMap&lt;String, String&gt; MAP2 = new HashMap&lt;String, String&gt;();
+        private static final Map&lt;String, String&gt; MAP3 = new HashMap&lt;&gt;();
+        private static final Map&lt;String, String&gt; MAP_TREE = new TreeMap&lt;&gt;();
+        private static final Map&lt;String, String&gt; MAP4 = Map.of();
+```
+
+folded/ConstructorReferenceNotationWithConstTestData-folded.java:
+```java
+        const ConstClass SELF = ::new;
+        const ConstClass SELF_ANN = ::new{};
+        const ConstClass SELF_SUB = new SubConstClass();
+        const ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private const HashMap&lt;String, String&gt; MAP = ::new;
+        private const HashMap&lt;String, String&gt; MAP2 = ::new;
+        private const Map&lt;String, String&gt; MAP3 = new HashMap&lt;&gt;();
+        private const Map&lt;String, String&gt; MAP_TREE = new TreeMap&lt;&gt;();
+        private const Map&lt;String, String&gt; MAP4 = Map.of();
+```
+
+Highlights ConstructorReferenceNotationWithConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty(&quot;sort-desc&quot;).getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System[&quot;sort-desc&quot;].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with const.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/control-flow-multi-statement-code-block-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/control-flow-multi-statement-code-block-collapse.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Control Flow Multi Statement Code Block Collapse</title>
+    <meta name="description" content="Folds multi-statement control-flow braces in read-only files." />
+  </head>
+  <body>
+    <h1>Control Flow Multi Statement Code Block Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>controlFlowMultiStatementCodeBlockCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>controlFlowMultiStatementCodeBlockCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `controlFlowMultiStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowMultiStatementCodeBlockCollapse`
+:::
+
+## Control Flow Multi Statement Code Block Collapse
+Folds multi-statement control-flow braces in read-only files.
+
+### Example: ControlFlowMultiStatementTestData
+
+examples/data/ControlFlowMultiStatementTestData.java:
+```java
+        if (args.length &gt; 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowMultiStatementTestData-folded.java:
+```java
+        if (args.length &gt; 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowMultiStatementTestData with control flow multi statement code block collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/control-flow-single-statement-code-block-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/control-flow-single-statement-code-block-collapse.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Control Flow Single Statement Code Block Collapse</title>
+    <meta name="description" content="Folds single-statement control-flow braces in read-only files." />
+  </head>
+  <body>
+    <h1>Control Flow Single Statement Code Block Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>controlFlowSingleStatementCodeBlockCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>controlFlowSingleStatementCodeBlockCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `controlFlowSingleStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowSingleStatementCodeBlockCollapse`
+:::
+
+## Control Flow Single Statement Code Block Collapse
+Folds single-statement control-flow braces in read-only files.
+
+### Example: ControlFlowSingleStatementTestData
+
+examples/data/ControlFlowSingleStatementTestData.java:
+```java
+        if (args.length &gt; 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowSingleStatementTestData-folded.java:
+```java
+        if (args.length &gt; 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowSingleStatementTestData with control flow single statement code block collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/dynamic.html
+++ b/docs/docusaurus/features/wiki-generated-html/dynamic.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dynamic</title>
+    <meta name="description" content="Applies dynamic naming to methods based on a configuration file." />
+  </head>
+  <body>
+    <h1>Dynamic</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>dynamic</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>dynamic</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `dynamic`
+- **Default:** On
+- **Controlled by:** `dynamic`
+:::
+
+## Dynamic names for methods based on $user.home/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with dynamic names for methods based on $user.home/dynamic-ajf2.toml.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/emojify.html
+++ b/docs/docusaurus/features/wiki-generated-html/emojify.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Emojify</title>
+    <meta name="description" content="Replaces select syntax elements with emoji equivalents." />
+  </head>
+  <body>
+    <h1>Emojify</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>emojify</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>emojify</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `emojify`
+- **Default:** Off
+- **Controlled by:** `emojify`
+:::
+
+## Emojify
+Replaces select syntax elements with emoji equivalents.
+
+### Example: EmojifyTestData
+
+examples/data/EmojifyTestData.java:
+```java
+package data;
+
+import java.time.DayOfWeek;
+// ...
+public class EmojifyTestData {
+
+    public final class FinalData {
+// ...
+
+        public void anotherMethod() {
+            final int anotherFinalVariable;
+```
+
+folded/EmojifyTestData-folded.java:
+```java
+📦 data;
+
+🚢 java.time.DayOfWeek;
+// ...
+public 🏛️ EmojifyTestData {
+
+    public 🔒 🏛️ FinalData {
+// ...
+
+        public 💀 anotherMethod() {
+            🔒 🔢 anotherFinalVariable;
+```
+
+Highlights EmojifyTestData with emojify.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/experimental.html
+++ b/docs/docusaurus/features/wiki-generated-html/experimental.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Experimental</title>
+    <meta name="description" content="Enables experimental folding prototypes." />
+  </head>
+  <body>
+    <h1>Experimental</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>experimental</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>experimental</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `experimental`
+- **Default:** Off
+- **Controlled by:** `experimental`
+:::
+
+## Experimental
+Enables experimental folding prototypes.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty(&quot;sort-desc&quot;).getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System[&quot;sort-desc&quot;].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with experimental.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/expression-func.html
+++ b/docs/docusaurus/features/wiki-generated-html/expression-func.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Expression Func</title>
+    <meta name="description" content="Folds single-expression methods into expression-bodied functions." />
+  </head>
+  <body>
+    <h1>Expression Func</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>expressionFunc</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>expressionFunc</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `expressionFunc`
+- **Default:** On
+- **Controlled by:** `expressionFunc`
+:::
+
+## Expression Func
+Folds single-expression methods into expression-bodied functions.
+
+### Example: ExpressionFuncTestData
+
+examples/data/ExpressionFuncTestData.java:
+```java
+    public long findNinjaId() {
+        return 1L;
+    }
+// ...
+    private void printStatus() {
+        new HashMap&lt;String, String&gt;().put(&quot;a&quot;, &quot;b&quot;);
+    }
+```
+
+folded/ExpressionFuncTestData-folded.java:
+```java
+    findNinjaId { 1L }
+// ...
+    private void printStatus() { new HashMap&lt;String, String&gt;().put(&quot;a&quot;, &quot;b&quot;) }
+```
+
+Highlights ExpressionFuncTestData with expression func.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/final-emoji.html
+++ b/docs/docusaurus/features/wiki-generated-html/final-emoji.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Final Emoji</title>
+    <meta name="description" content="Replaces final modifiers with lock emoji markers." />
+  </head>
+  <body>
+    <h1>Final Emoji</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>finalEmoji</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>finalEmoji</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `finalEmoji`
+- **Default:** Off
+- **Controlled by:** `finalEmoji`
+:::
+
+## Final Emoji
+Replaces final modifiers with lock emoji markers.
+
+### Example: FinalEmojiTestData
+
+examples/data/FinalEmojiTestData.java:
+```java
+    public final String m() {
+        final String s = &quot;1&quot;;
+        final var s2 = &quot;2&quot;;
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalEmojiTestData-folded.java:
+```java
+    public 🔒 String m() {
+        🔒 String s = &quot;1&quot;;
+        🔒 var s2 = &quot;2&quot;;
+// ...
+        void main(🔒 String arg, 🔒 int i, 🔒 Object o, Data data);
+```
+
+Highlights FinalEmojiTestData with final emoji.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/final-removal.html
+++ b/docs/docusaurus/features/wiki-generated-html/final-removal.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Final Removal</title>
+    <meta name="description" content="Folds the final modifier away from non-field declarations." />
+  </head>
+  <body>
+    <h1>Final Removal</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>finalRemoval</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>finalRemoval</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `finalRemoval`
+- **Default:** Off
+- **Controlled by:** `finalRemoval`
+:::
+
+## Final Removal
+Folds the final modifier away from non-field declarations.
+
+### Example: FinalRemovalTestData
+
+examples/data/FinalRemovalTestData.java:
+```java
+    public final String m() {
+        final String s = &quot;1&quot;;
+        final var s2 = &quot;2&quot;;
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalRemovalTestData-folded.java:
+```java
+    public  String m() {
+         String s = &quot;1&quot;;
+         var s2 = &quot;2&quot;;
+// ...
+        void main( String arg,  int i,  Object o, Data data);
+```
+
+Highlights FinalRemovalTestData with final removal.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/get-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/get-expressions-collapse.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Get Expressions Collapse</title>
+    <meta name="description" content="Folds collection access and literal builders into indexed or map-style expressions." />
+  </head>
+  <body>
+    <h1>Get Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>getExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>getExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `getExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getExpressionsCollapse`
+:::
+
+## Get Expressions Collapse
+Folds collection access and literal builders into indexed or map-style expressions.
+
+### Example: GetSetPutTestData
+
+examples/data/GetSetPutTestData.java:
+```java
+        List&lt;String&gt; list = Arrays.asList(&quot;one&quot;, &quot;two&quot;);
+        list.set(1,&quot;three&quot; );
+        System.out.println(list.get(list.size() - 1));
+        System.out.println(args[args.length - 1]);
+// ...
+        map.put(&quot;one&quot;, 1);
+        System.out.println(map.get(&quot;two&quot;));
+        List&lt;String&gt; singleton = java.util.Collections.singletonList(&quot;one&quot;);
+```
+
+folded/GetSetPutTestData-folded.java:
+```java
+        List&lt;String&gt; list = [&quot;one&quot;, &quot;two&quot;];
+        list[1] = &quot;three&quot;;
+        System.out.println(list.getLast());
+        System.out.println(args.last());
+// ...
+        map[&quot;one&quot;] = 1;
+        System.out.println(map[&quot;two&quot;]);
+        List&lt;String&gt; singleton = [&quot;one&quot;];
+```
+
+Highlights GetSetPutTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty(&quot;sort-desc&quot;).getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System[&quot;sort-desc&quot;].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/get-set-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/get-set-expressions-collapse.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Get Set Expressions Collapse</title>
+    <meta name="description" content="Folds Java getter and setter calls into property-style access." />
+  </head>
+  <body>
+    <h1>Get Set Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>getSetExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>getSetExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `getSetExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getSetExpressionsCollapse`
+:::
+
+## Get Set Expressions Collapse
+Folds Java getter and setter calls into property-style access.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append(&quot;Hello, &quot; + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + &quot;, hello!&quot;);
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder(&quot;Hello, &quot;).append(args[0]); // Should be StringBuilder sb3 = &quot;Hello, $(args[0)&quot;:
+// ...
+        new AppendSetterInterpolatedStringTestData().setName(&quot;Hello, &quot; + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + &quot;, hello!&quot;);
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += &quot;Hello, ${args[0]}&quot;;
+        System.out.println(sb1);
+// ...
+        sb2 += &quot;${args[0]}, hello!&quot;;
+        System.out.println(sb2);
+        StringBuilder sb3 = &quot;Hello, &quot; + args[0]; // Should be StringBuilder sb3 = &quot;Hello, $(args[0)&quot;:
+// ...
+        new AppendSetterInterpolatedStringTestData().name = &quot;Hello, ${args[0]}&quot;;
+        new AppendSetterInterpolatedStringTestData().name = &quot;${args[0]}, hello!&quot;;
+```
+
+Highlights AppendSetterInterpolatedStringTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: GetterSetterTestData
+
+examples/data/GetterSetterTestData.java:
+```java
+        d.setParent(d);
+        d.setName(&quot;Hello&quot;);
+        d.getParent().setName(&quot;Pum!&quot;);
+        System.out.println(d.getParent().getName());
+```
+
+folded/GetterSetterTestData-folded.java:
+```java
+        d.parent = d;
+        d.name = &quot;Hello&quot;;
+        d.parent.name = &quot;Pum!&quot;;
+        System.out.println(d.parent.name);
+```
+
+Highlights GetterSetterTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftBuilder
+
+examples/data/FieldShiftBuilder.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+// ...
+                .username(record.username());
+```
+
+folded/FieldShiftBuilder-folded.java:
+```java
+        this.username = &lt;&lt;;
+        this.active = &lt;&lt;;
+        this.userIdentifier = &lt;&lt;;
+        this.child = &lt;&lt;;
+// ...
+                .username(record&lt;&lt;);
+```
+
+Highlights FieldShiftBuilder with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftSetters
+
+examples/data/FieldShiftSetters.java:
+```java
+        this.username = username;
+// ...
+        this.active = active;
+```
+
+folded/FieldShiftSetters-folded.java:
+```java
+        this.username = &lt;&lt;;
+// ...
+        this.active = &lt;&lt;;
+```
+
+Highlights FieldShiftSetters with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                &amp;&amp; data.getData1() != null
+// ...
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data != null
+                &amp;&amp; data != null
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                &amp;&amp; data?.data1 != null
+// ...
+                &amp;&amp; data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogBrackets
+
+examples/data/LogBrackets.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: %s&quot;, name);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: %s, Age: %d&quot;, name, age);
+```
+
+folded/LogBrackets-folded.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: $name&quot;);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: $name, Age: $age&quot;);
+```
+
+Highlights LogBrackets with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: %s&quot;, name);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: %s, Age: %d&quot;, name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: $name&quot;);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: $name, Age: $age&quot;);
+```
+
+Highlights LogFoldingTextBlocksTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftFields
+
+examples/data/FieldShiftFields.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+        this.userIdentifier = child.userIdentifier;
+        this.userIdentifier = child.getUserIdentifier();
+// ...
+        result.username = source.child.username;
+        result.userIdentifier = source.child.child.child.userIdentifier;
+        result.active = source.child.active;
+        result.list = List.copyOf(source.list);
+```
+
+folded/FieldShiftFields-folded.java:
+```java
+        this.username = &lt;&lt;;
+        this.active = &lt;&lt;;
+        this.userIdentifier = &lt;&lt;;
+        this.child = &lt;&lt;;
+        this.userIdentifier = child.&lt;&lt;;
+        this.userIdentifier = child.&lt;&lt;;
+// ...
+        result.username = source.child.&lt;&lt;;
+        result.userIdentifier = source.child.child.child.&lt;&lt;;
+        result.active = source.child.&lt;&lt;;
+        result.list = List.copyOf(source.&lt;&lt;);
+```
+
+Highlights FieldShiftFields with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayWithoutValTestData
+
+examples/data/DestructuringAssignmentArrayWithoutValTestData.java:
+```java
+        Data first = array[0];
+// ...
+        Data second = array[1];
+        Data third = array[2];
+        Data fourth = array[3];
+```
+
+folded/DestructuringAssignmentArrayWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = array;
+// ...
+        Data ignored21 = data.array[4];
+        Data ignored22 = data.array[5];
+```
+
+Highlights DestructuringAssignmentArrayWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListWithoutValTestData
+
+examples/data/DestructuringAssignmentListWithoutValTestData.java:
+```java
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+// ...
+        Data ignored21 = data.getList().get(4);
+        Data ignored22 = data.getList().get(5);
+```
+
+folded/DestructuringAssignmentListWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = list;
+// ...
+        Data ignored21 = data.list.get(4);
+        Data ignored22 = data.list.get(5);
+```
+
+Highlights DestructuringAssignmentListWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, &quot;args are null&quot;);
+            Preconditions.checkNotNull(l, &quot;l is null&quot;);
+            Preconditions.checkNotNull(z.getData(), &quot;o is null&quot;);
+            Preconditions.checkNotNull(o, &quot;o is null&quot;);
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, &quot;args are null&quot;);
+            this.l = Preconditions.checkNotNull(l, &quot;l is null&quot;);
+            this.data = Preconditions.checkNotNull(z.getData(), &quot;saaa is null&quot;);
+            this.o = Preconditions.checkNotNull(o, &quot;o is null&quot;);
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = &lt;&lt;!!;
+            this.l = &lt;&lt;!!;
+            this.data = z.&lt;&lt;!!;
+            this.o = &lt;&lt;!!;
+// ...
+            this.args = &lt;&lt;!!;
+            this.l = &lt;&lt;!!;
+            this.data = z.&lt;&lt;!!;
+            this.o = &lt;&lt;!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/global-on.html
+++ b/docs/docusaurus/features/wiki-generated-html/global-on.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>globalOn</title>
+    <meta name="description" content="Master switch that enables or disables all Advanced Expression Folding actions." />
+  </head>
+  <body>
+    <h1>globalOn</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>globalOn</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>globalOn</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `globalOn`
+- **Default:** On
+- **Controlled by:** `globalOn`
+:::
+
+![Keymap actions configured for folding and unfolding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/35863f50-d441-4402-8172-db6e75962350)
+
+# Global On (State field: globalOn)
+
+## Global On
+Master switch that enables or disables all Advanced Expression Folding actions.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/if-null-safe.html
+++ b/docs/docusaurus/features/wiki-generated-html/if-null-safe.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>If Null Safe</title>
+    <meta name="description" content="Extends null-safe folding to if statements and guard clauses." />
+  </head>
+  <body>
+    <h1>If Null Safe</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>ifNullSafe</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>ifNullSafe</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `ifNullSafe`
+- **Default:** On
+- **Controlled by:** `ifNullSafe`
+:::
+
+[video](https://www.youtube.com/watch?v=zvpvhn7ISAw)
+
+
+![Null-safe if folding showcased on chained access](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/56aa2dbb-0aa1-4143-a296-801ffb0668cd)
+
+
+
+## If Null Safe
+Extends null-safe folding to if statements and guard clauses.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                &amp;&amp; data.getData1() != null
+// ...
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data != null
+                &amp;&amp; data != null
+                &amp;&amp; data.getData1() != null
+                &amp;&amp; data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                &amp;&amp; data?.data1 != null
+// ...
+                &amp;&amp; data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with if null safe.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/interface-extension-properties.html
+++ b/docs/docusaurus/features/wiki-generated-html/interface-extension-properties.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Interface Extension Properties</title>
+    <meta name="description" content="Folds interface getters and setters into Kotlin extension properties." />
+  </head>
+  <body>
+    <h1>Interface Extension Properties</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>interfaceExtensionProperties</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>interfaceExtensionProperties</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `interfaceExtensionProperties`
+- **Default:** On
+- **Controlled by:** `interfaceExtensionProperties`
+:::
+
+## Interface Extension Properties
+Folds interface getters and setters into Kotlin extension properties.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with interface extension properties.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/kotlin-quick-return.html
+++ b/docs/docusaurus/features/wiki-generated-html/kotlin-quick-return.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Kotlin Quick Return</title>
+    <meta name="description" content="Folds Kotlin let/return idioms into quick-return expressions." />
+  </head>
+  <body>
+    <h1>Kotlin Quick Return</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>kotlinQuickReturn</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>kotlinQuickReturn</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `kotlinQuickReturn`
+- **Default:** On
+- **Controlled by:** `kotlinQuickReturn`
+:::
+
+## Kotlin Quick Return
+Folds Kotlin let/return idioms into quick-return expressions.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with kotlin quick return.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/local-date-literal-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/local-date-literal-collapse.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Local Date Literal Collapse</title>
+    <meta name="description" content="Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms." />
+  </head>
+  <body>
+    <h1>Local Date Literal Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>localDateLiteralCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>localDateLiteralCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `localDateLiteralCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralCollapse`
+:::
+
+## Local Date Literal Collapse
+Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms.
+
+### Example: LocalDateLiteralTestData
+
+examples/data/LocalDateLiteralTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralTestData-folded.java:
+```java
+        LocalDate d1 = 2018-01-10;
+        LocalDate d4 = 2018-01-10;
+        LocalDate d2 = 2018-12-10;
+        LocalDate d3 = 2018-04-04;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013-01-10);
+```
+
+Highlights LocalDateLiteralTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/local-date-literal-postfix-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/local-date-literal-postfix-collapse.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Local Date Literal Postfix Collapse</title>
+    <meta name="description" content="Folds postfix LocalDate literals such as 2018Y-02M-12D." />
+  </head>
+  <body>
+    <h1>Local Date Literal Postfix Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>localDateLiteralPostfixCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>localDateLiteralPostfixCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `localDateLiteralPostfixCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralPostfixCollapse`
+:::
+
+## Local Date Literal Postfix Collapse
+Folds postfix LocalDate literals such as 2018Y-02M-12D.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal postfix collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/log-folding-text-blocks.html
+++ b/docs/docusaurus/features/wiki-generated-html/log-folding-text-blocks.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Log Folding Text Blocks</title>
+    <meta name="description" content="Folds log Text Blocks into compact placeholders." />
+  </head>
+  <body>
+    <h1>Log Folding Text Blocks</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>logFoldingTextBlocks</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>logFoldingTextBlocks</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `logFoldingTextBlocks`
+- **Default:** Off
+- **Controlled by:** `logFoldingTextBlocks`
+:::
+
+## Log Folding Text Blocks
+Folds log Text Blocks into compact placeholders.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: %s&quot;, name);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: %s, Age: %d&quot;, name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug(&quot;Debug message with 1 parameter - Name: $name&quot;);
+// ...
+        log.info(MY_MARKER, &quot;Info message with 2 parameters - Name: $name, Age: $age&quot;);
+```
+
+Highlights LogFoldingTextBlocksTestData with log folding text blocks.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/lombok-dirty-off.html
+++ b/docs/docusaurus/features/wiki-generated-html/lombok-dirty-off.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lombok Dirty Off</title>
+    <meta name="description" content="Skips folding Lombok accessors marked as dirty." />
+  </head>
+  <body>
+    <h1>Lombok Dirty Off</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>lombokDirtyOff</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>lombokDirtyOff</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `lombokDirtyOff`
+- **Default:** Off
+- **Controlled by:** `lombokDirtyOff`
+:::
+
+## Lombok Dirty Off
+Skips folding Lombok accessors marked as dirty.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok dirty off.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/lombok-pattern-off.html
+++ b/docs/docusaurus/features/wiki-generated-html/lombok-pattern-off.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lombok Pattern Off</title>
+    <meta name="description" content="Uses a regex to disable Lombok folding for matching classes." />
+  </head>
+  <body>
+    <h1>Lombok Pattern Off</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>lombokPatternOff</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>lombokPatternOff</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `lombokPatternOff`
+- **Default:** Off
+- **Controlled by:** `lombokPatternOff`
+:::
+
+## Lombok Pattern Off
+Uses a regex to disable Lombok folding for matching classes.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return &quot;ToStringFull{&quot; +
+                    &quot;data=&quot; + data +
+                    &quot;, ok=&quot; + ok +
+                    &#x27;}&#x27;;
+// ...
+                return &quot;ToStringPartial{&quot; +
+                        &quot;data=&quot; + data +
+                        &#x27;}&#x27;;
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return &quot;ToStringFull{&quot; + &quot;data=&quot; + data + &quot;, ok=&quot; + ok + &#x27;}&#x27;;
+// ...
+                return &quot;ToStringPartial{&quot; + &quot;data=&quot; + data + &#x27;}&#x27;;
+```
+
+Highlights LombokPatternOffTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/lombok.html
+++ b/docs/docusaurus/features/wiki-generated-html/lombok.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Lombok</title>
+    <meta name="description" content="Folds Java bean patterns into Lombok-style annotations." />
+  </head>
+  <body>
+    <h1>Lombok</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>lombok</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>lombok</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `lombok`
+- **Default:** On
+- **Controlled by:** `lombok`
+:::
+
+![Animated overview of Lombok folding support](https://github.com/user-attachments/assets/7d2bdcf7-15ad-45a2-9aad-1f596443c4d7)
+
+old video:
+[video](https://www.youtube.com/watch?v=dKMWL3YJacU)
+
+
+## Lombok
+Folds Java bean patterns into Lombok-style annotations.
+
+### Example: LombokTestData
+
+examples/data/LombokTestData.java:
+```java
+public class LombokTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokTestData data;
+        boolean ok;
+```
+
+Highlights LombokTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return &quot;ToStringFull{&quot; +
+                    &quot;data=&quot; + data +
+                    &quot;, ok=&quot; + ok +
+                    &#x27;}&#x27;;
+// ...
+                return &quot;ToStringPartial{&quot; +
+                        &quot;data=&quot; + data +
+                        &#x27;}&#x27;;
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return &quot;ToStringFull{&quot; + &quot;data=&quot; + data + &quot;, ok=&quot; + ok + &#x27;}&#x27;;
+// ...
+                return &quot;ToStringPartial{&quot; + &quot;data=&quot; + data + &#x27;}&#x27;;
+```
+
+Highlights LombokPatternOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty(&quot;sort-desc&quot;).getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System[&quot;sort-desc&quot;].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with lombok.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/memory-improvement.html
+++ b/docs/docusaurus/features/wiki-generated-html/memory-improvement.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>memoryImprovement</title>
+    <meta name="description" content="Caches folding descriptors for large test data files." />
+  </head>
+  <body>
+    <h1>memoryImprovement</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>memoryImprovement</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>memoryImprovement</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `memoryImprovement`
+- **Default:** On
+- **Controlled by:** `memoryImprovement`
+:::
+
+* only for files in **testData** folder
+
+![Diff view before folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/89ccca5b-92ce-47ad-b051-7eabb39f94c2)
+
+=&gt;
+
+![Diff view after folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/440c30a8-1088-4e6a-bf25-bde6627aa7af)
+
+# Memory Improvement (State field: memoryImprovement)
+
+## Memory Improvement
+Caches folding descriptors for large test data files.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/nullable.html
+++ b/docs/docusaurus/features/wiki-generated-html/nullable.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Nullable</title>
+    <meta name="description" content="Folds nullability annotations into ? and !! markers." />
+  </head>
+  <body>
+    <h1>Nullable</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>nullable</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>nullable</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `nullable`
+- **Default:** Off
+- **Controlled by:** `nullable`
+:::
+
+## Nullable
+Folds nullability annotations into ? and !! markers.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, &quot;args are null&quot;);
+            Preconditions.checkNotNull(l, &quot;l is null&quot;);
+            Preconditions.checkNotNull(z.getData(), &quot;o is null&quot;);
+            Preconditions.checkNotNull(o, &quot;o is null&quot;);
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, &quot;args are null&quot;);
+            this.l = Preconditions.checkNotNull(l, &quot;l is null&quot;);
+            this.data = Preconditions.checkNotNull(z.getData(), &quot;saaa is null&quot;);
+            this.o = Preconditions.checkNotNull(o, &quot;o is null&quot;);
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = &lt;&lt;!!;
+            this.l = &lt;&lt;!!;
+            this.data = z.&lt;&lt;!!;
+            this.o = &lt;&lt;!!;
+// ...
+            this.args = &lt;&lt;!!;
+            this.l = &lt;&lt;!!;
+            this.data = z.&lt;&lt;!!;
+            this.o = &lt;&lt;!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty(&quot;sort-desc&quot;).getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System[&quot;sort-desc&quot;].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with nullable.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/optional.html
+++ b/docs/docusaurus/features/wiki-generated-html/optional.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Optional</title>
+    <meta name="description" content="Displays java.util.Optional flows as Kotlin-style null-safe chains." />
+  </head>
+  <body>
+    <h1>Optional</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>optional</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>optional</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `optional`
+- **Default:** On
+- **Controlled by:** `optional`
+:::
+
+## Optional
+Displays java.util.Optional flows as Kotlin-style null-safe chains.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add(&quot;one&quot;);
+        list.remove(&quot;one&quot;);
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += &quot;one&quot;;
+        list -= &quot;one&quot;;
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with optional.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/override-hide.html
+++ b/docs/docusaurus/features/wiki-generated-html/override-hide.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Override Hide</title>
+    <meta name="description" content="Hides @Override annotations from view." />
+  </head>
+  <body>
+    <h1>Override Hide</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>overrideHide</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>overrideHide</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `overrideHide`
+- **Default:** On
+- **Controlled by:** `overrideHide`
+:::
+
+## Override Hide
+Hides @Override annotations from view.
+
+### Example: OverrideHideTestData
+
+examples/data/OverrideHideTestData.java:
+```java
+            @Override
+// ...
+            @Override
+```
+
+folded/OverrideHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+```
+
+Highlights OverrideHideTestData with override hide.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/println.html
+++ b/docs/docusaurus/features/wiki-generated-html/println.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Println</title>
+    <meta name="description" content="Folds System.out.println calls into println." />
+  </head>
+  <body>
+    <h1>Println</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>println</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>println</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `println`
+- **Default:** On
+- **Controlled by:** `println`
+:::
+
+![System.out.println call folded to println](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/75a5224f-7b52-4b71-9774-2814e8a867ba)
+
+
+## Println
+Folds System.out.println calls into println.
+
+### Example: PrintlnTestData
+
+examples/data/PrintlnTestData.java:
+```java
+        System.out.println(&quot;Hello&quot;);
+        System.out.println
+// ...
+        System.
+                out.println(&quot;Spacing&quot;);
+        System.out.
+// ...
+        System.out.println(&quot;Passed as parameter: &quot; +
+this.getClass());
+        System.out.println(&quot;&quot;&quot;
+```
+
+folded/PrintlnTestData-folded.java:
+```java
+        println(&quot;Hello&quot;);
+        println
+// ...
+        println(&quot;Spacing&quot;);
+        println(3.14);
+        println(string);
+// ...
+        println(&quot;Passed as parameter: &quot; + string);
+        println(&quot;Passed as parameter: &quot; + this.getClass());
+        println(&quot;&quot;&quot;
+```
+
+Highlights PrintlnTestData with println.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/range-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/range-expressions-collapse.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Range Expressions Collapse</title>
+    <meta name="description" content="Folds indexed loops into Kotlin-style range expressions." />
+  </head>
+  <body>
+    <h1>Range Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>rangeExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>rangeExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `rangeExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `rangeExpressionsCollapse`
+:::
+
+## Range Expressions Collapse
+Folds indexed loops into Kotlin-style range expressions.
+
+### Example: ForRangeTestData
+
+examples/data/ForRangeTestData.java:
+```java
+                for (int i = 0; i &lt; args.length; i++) {
+                        String arg = args
+                                [i];
+// ...
+                for (int i = 0; i &lt; args.length; i++) {
+                        String arg = args
+                                [i];
+```
+
+folded/ForRangeTestData-folded.java:
+```java
+                for ((int i, String arg) : args) {
+// ...
+                for (String arg : args) {
+```
+
+Highlights ForRangeTestData with range expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/semicolons-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/semicolons-collapse.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Semicolons Collapse</title>
+    <meta name="description" content="Folds redundant semicolons inside read-only files." />
+  </head>
+  <body>
+    <h1>Semicolons Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>semicolonsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>semicolonsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `semicolonsCollapse`
+- **Default:** Off
+- **Controlled by:** `semicolonsCollapse`
+:::
+
+## Semicolons Collapse
+Folds redundant semicolons inside read-only files.
+
+### Example: SemicolonTestData
+
+examples/data/SemicolonTestData.java:
+```java
+package data;
+// ...
+import java.util.Arrays;
+```
+
+folded/SemicolonTestData-folded.java:
+```java
+package data
+// ...
+import java.util.Arrays
+```
+
+Highlights SemicolonTestData with semicolons collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/slicing-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/slicing-expressions-collapse.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Slicing Expressions Collapse</title>
+    <meta name="description" content="Folds List.subList and String.substring calls into concise slice notation." />
+  </head>
+  <body>
+    <h1>Slicing Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>slicingExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>slicingExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `slicingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `slicingExpressionsCollapse`
+:::
+
+## Slicing Expressions Collapse
+Folds List.subList and String.substring calls into concise slice notation.
+
+### Example: SliceTestData
+
+examples/data/SliceTestData.java:
+```java
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(1, 2));
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(0, 2));
+        System.out.println(list.subList(1, list.size() - 2));
+        System.out.println(list.subList(0, list.size() - 2));
+// ...
+        System.out.println(f.substring(1));
+        System.out.println(f.substring(1, 2));
+        System.out.println(f.substring(1, f.length()));
+        System.out.println(f.substring(0, 2));
+        System.out.println(f.substring(1, f.length() - 2));
+        System.out.println(f.substring(0, f.length() - 2));
+```
+
+folded/SliceTestData-folded.java:
+```java
+        System.out.println(list[1:]);
+        System.out.println(list[1:2]);
+        System.out.println(list[1:]);
+        System.out.println(list[:2]);
+        System.out.println(list[1:-2]);
+        System.out.println(list[:-2]);
+// ...
+        System.out.println(f[1:]);
+        System.out.println(f[1:2]);
+        System.out.println(f[1:]);
+        System.out.println(f[:2]);
+        System.out.println(f[1:-2]);
+        System.out.println(f[:-2]);
+```
+
+Highlights SliceTestData with slicing expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/stream-spread.html
+++ b/docs/docusaurus/features/wiki-generated-html/stream-spread.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Stream Spread</title>
+    <meta name="description" content="Displays stream pipelines using Groovy-style spread notation." />
+  </head>
+  <body>
+    <h1>Stream Spread</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>streamSpread</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>streamSpread</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `streamSpread`
+- **Default:** On
+- **Controlled by:** `streamSpread`
+:::
+
+## Stream Spread
+Displays stream pipelines using Groovy-style spread notation.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add(&quot;one&quot;);
+        list.remove(&quot;one&quot;);
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += &quot;one&quot;;
+        list -= &quot;one&quot;;
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with stream spread.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/summary-parent-override.html
+++ b/docs/docusaurus/features/wiki-generated-html/summary-parent-override.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Summary Parent Override</title>
+    <meta name="description" content="Folds overridden methods into parent summary stubs." />
+  </head>
+  <body>
+    <h1>Summary Parent Override</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>summaryParentOverride</code></dd>
+      <dt>Default</dt>
+      <dd>Off</dd>
+      <dt>Controlled by</dt>
+      <dd><code>summaryParentOverride</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `summaryParentOverride`
+- **Default:** Off
+- **Controlled by:** `summaryParentOverride`
+:::
+
+## Summary Parent Override
+Folds overridden methods into parent summary stubs.
+
+### Example: SummaryParentOverrideTestData
+
+examples/data/SummaryParentOverrideTestData.java:
+```java
+    class ParentClass extends GrandparentClass {
+// ...
+        public void grandparentMethod() {
+```
+
+folded/SummaryParentOverrideTestData-folded.java:
+```java
+    class ParentClass extends GrandparentClass(1-grandparentMethod) {
+// ...
+        public void grandparentMethod() { // overrides from GrandparentClass
+```
+
+Highlights SummaryParentOverrideTestData with summary parent override.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/suppress-warnings-hide.html
+++ b/docs/docusaurus/features/wiki-generated-html/suppress-warnings-hide.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Suppress Warnings Hide</title>
+    <meta name="description" content="Hides @SuppressWarnings annotations from view." />
+  </head>
+  <body>
+    <h1>Suppress Warnings Hide</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>suppressWarningsHide</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>suppressWarningsHide</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `suppressWarningsHide`
+- **Default:** On
+- **Controlled by:** `suppressWarningsHide`
+:::
+
+## Suppress Warnings Hide
+Hides @SuppressWarnings annotations from view.
+
+### Example: SuppressWarningsHideTestData
+
+examples/data/SuppressWarningsHideTestData.java:
+```java
+    @SuppressWarnings(&quot;deprecation&quot;)
+// ...
+    @SuppressWarnings({&quot;rawtypes&quot;, &quot;unchecked&quot;})
+```
+
+folded/SuppressWarningsHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+```
+
+Highlights SuppressWarningsHideTestData with suppress warnings hide.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated-html/var-expressions-collapse.html
+++ b/docs/docusaurus/features/wiki-generated-html/var-expressions-collapse.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Var Expressions Collapse</title>
+    <meta name="description" content="Folds variable declarations into val/var style declarations." />
+  </head>
+  <body>
+    <h1>Var Expressions Collapse</h1>
+    <section aria-labelledby="feature-summary">
+      <h2 id="feature-summary">Summary</h2>
+      <dl>
+      <dt>State key</dt>
+      <dd><code>varExpressionsCollapse</code></dd>
+      <dt>Default</dt>
+      <dd>On</dd>
+      <dt>Controlled by</dt>
+      <dd><code>varExpressionsCollapse</code></dd>
+      </dl>
+    </section>
+    <section aria-labelledby="feature-body">
+      <h2 id="feature-body">Details</h2>
+      <pre>:::info Toggle summary
+- **State key:** `varExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `varExpressionsCollapse`
+:::
+
+## Var Expressions Collapse
+Folds variable declarations into val/var style declarations.
+
+### Example: VarTestData
+
+examples/data/VarTestData.java:
+```java
+        String string = &quot;Hello, world&quot;;
+// ...
+        int count = 0;
+        for (String arg : args) {
+```
+
+folded/VarTestData-folded.java:
+```java
+        val string = &quot;Hello, world&quot;;
+// ...
+        var count = 0;
+        for (val arg : args) {
+```
+
+Highlights VarTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.</pre>
+    </section>
+  </body>
+</html>

--- a/docs/docusaurus/features/wiki-generated/_category_.json
+++ b/docs/docusaurus/features/wiki-generated/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Toggle Reference (auto-generated)",
+  "position": 99,
+  "link": {
+    "type": "generated-index",
+    "title": "Toggle Reference",
+    "description": "Auto-generated reference pages converted from the historical GitHub wiki."
+  }
+}

--- a/docs/docusaurus/features/wiki-generated/arithmetic-expressions.md
+++ b/docs/docusaurus/features/wiki-generated/arithmetic-expressions.md
@@ -1,0 +1,749 @@
+---
+title: Arithmetic Expressions
+slug: /features/arithmetic-expressions
+sidebar_label: Arithmetic Expressions
+description: Folds BigDecimal, BigInteger, and Math operations into infix math.
+---
+
+:::info Toggle summary
+- **State key:** `arithmeticExpressions`
+- **Default:** Off
+- **Controlled by:** `arithmeticExpressions`
+:::
+
+## Arithmetic Expressions
+Folds BigDecimal, BigInteger, and Math operations into infix math.
+
+
+---
+
+### Detailed Folding Reference
+
+#### BigDecimalData
+
+**addBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigDecimal.add` into infix addition between the operands.
+
+**multiplyBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Collapses `BigDecimal.multiply` into infix multiplication.
+
+**divideBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigDecimal.divide` as infix division.
+
+**subtractBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Replaces `BigDecimal.subtract` with infix subtraction.
+
+**remainderBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigDecimal.remainder` with the modulus operator.
+
+**powBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigDecimal.pow` into a superscript exponent.
+
+**minBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigDecimal.min` as-is while simplifying operand literals.
+
+**maxBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Preserves `BigDecimal.max`, only collapsing constructor literals.
+
+**negateBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Keeps `BigDecimal.negate` untouched aside from literal folding.
+
+**plusBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.plus();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.plus();
+```
+Maintains `BigDecimal.plus` while collapsing instantiations.
+
+**absBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.abs();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.abs();
+```
+Retains `BigDecimal.abs` with the literal simplified.
+
+**valueOfBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigDecimal.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigDecimal.valueOf` into the literal value.
+
+**equalsBigDecimal**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigDecimal.equals`, with operands folded to simple literals.
+
+#### BigIntegerData
+
+**addBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.add(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a + b;
+```
+Transforms `BigInteger.add` into infix addition.
+
+**multiplyBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.multiply(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a * b;
+```
+Replaces `BigInteger.multiply` with infix multiplication.
+
+**divideBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.divide(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a / b;
+```
+Rewrites `BigInteger.divide` as infix division.
+
+**subtractBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.subtract(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a - b;
+```
+Collapses `BigInteger.subtract` to infix subtraction.
+
+**remainderBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.remainder(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.remainder` with the modulus operator.
+
+**powBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.pow(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a²;
+```
+Folds `BigInteger.pow` into an exponent glyph.
+
+**minBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.min(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.min(b);
+```
+Leaves `BigInteger.min` untouched beyond literal folding.
+
+**maxBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.max(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.max(b);
+```
+Keeps `BigInteger.max` in method-call form with simplified operands.
+
+**negateBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.negate();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.negate();
+```
+Retains `BigInteger.negate`, folding only constructor literals.
+
+**valueOfBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = BigInteger.valueOf(10);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 10;
+```
+Collapses `BigInteger.valueOf` into the literal value.
+
+**equalsBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.equals(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.equals(b);
+```
+Preserves `BigInteger.equals` with literal operands.
+
+**andBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.and(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a & b;
+```
+Rewrites `BigInteger.and` as the infix bitwise AND operator.
+
+**gcdBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.gcd(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.gcd(b);
+```
+Leaves `BigInteger.gcd` as a method call.
+
+**notBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.not();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.not();
+```
+Keeps `BigInteger.not` unchanged.
+
+**orBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.or(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a | b;
+```
+Transforms `BigInteger.or` into the infix bitwise OR operator.
+
+**shiftLeftBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftLeft(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a << 2;
+```
+Collapses `BigInteger.shiftLeft` to the left-shift operator.
+
+**shiftRightBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.shiftRight(2);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a >> 2;
+```
+Replaces `BigInteger.shiftRight` with the right-shift operator.
+
+**signumBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.signum();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a.signum();
+```
+Leaves `BigInteger.signum` untouched aside from literal folding.
+
+**xorBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.xor(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a ^ b;
+```
+Rewrites `BigInteger.xor` as the infix XOR operator.
+
+**andNotBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.andNot(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a & b;
+```
+Collapses `BigInteger.andNot` into a bitwise AND expression.
+
+**modBigInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = a.mod(b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a % b;
+```
+Substitutes `BigInteger.mod` with the modulus operator.
+
+#### MathData
+
+**minMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.min(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = min(a, b);
+```
+Rewrites `Math.min` to the short `min` intrinsic.
+
+**maxMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.max(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = max(a, b);
+```
+Rewrites `Math.max` to the short `max` intrinsic.
+
+**powMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.pow(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = aᵇ;
+```
+Collapses `Math.pow` into an exponent glyph.
+
+**acosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.acos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = acos(a);
+```
+Shortens `Math.acos` to `acos`.
+
+**absMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.abs(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = |a|;
+```
+Converts `Math.abs` into an absolute value bar.
+
+**asinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.asin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = asin(a);
+```
+Shortens `Math.asin` to `asin`.
+
+**atanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = atan(a);
+```
+Reduces `Math.atan` to `atan`.
+
+**atan2Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.atan2(a, b);
+```
+Leaves `Math.atan2` unchanged because no shorter form is applied.
+
+**cbrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cbrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ∛a;
+```
+Turns `Math.cbrt` into a cube-root radical.
+
+**ceilMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ceil(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ceil(a);
+```
+Shrinks `Math.ceil` to `ceil`.
+
+**cosMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cos(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cos(a);
+```
+Shortens `Math.cos` to `cos`.
+
+**coshMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.cosh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = cosh(a);
+```
+Reduces `Math.cosh` to `cosh`.
+
+**floorMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.floor(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = floor(a);
+```
+Shortens `Math.floor` to `floor`.
+
+**logMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ln(a);
+```
+Converts `Math.log` to the natural logarithm symbol.
+
+**log10Math**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.log10(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = log(a);
+```
+Maps `Math.log10` to the common logarithm notation.
+
+**randomMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.random();
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = Math.random();
+```
+Leaves `Math.random` unchanged.
+
+**rintMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.rint(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = rint(a);
+```
+Shortens `Math.rint` to `rint`.
+
+**roundMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.round(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = round(a);
+```
+Rewrites `Math.round` as `round`.
+
+**sinMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sin(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sin(a);
+```
+Shortens `Math.sin` to `sin`.
+
+**sinhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sinh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sinh(a);
+```
+Reduces `Math.sinh` to `sinh`.
+
+**sqrtMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.sqrt(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = sqrt(a);
+```
+Shortens `Math.sqrt` to `sqrt`.
+
+**tanMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tan(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tan(a);
+```
+Reduces `Math.tan` to `tan`.
+
+**tanhMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.tanh(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = tanh(a);
+```
+Shortens `Math.tanh` to `tanh`.
+
+**toDegreesMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toDegrees(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toDegrees(a);
+```
+Rewrites `Math.toDegrees` as `toDegrees`.
+
+**toRadiansMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.toRadians(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = toRadians(a);
+```
+Rewrites `Math.toRadians` as `toRadians`.
+
+**ulpMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.ulp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = ulp(a);
+```
+Shortens `Math.ulp` to `ulp`.
+
+**expMath**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Math.exp(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = 𝑒ᵃ;
+```
+Collapses `Math.exp` into an exponential expression.
+
+#### LongData
+
+**valueOfLong**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Long.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Long.valueOf` with the original string value.
+
+#### IntegerData
+
+**valueOfInteger**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Integer.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Integer.valueOf` to the source string.
+
+#### FloatData
+
+**valueOfFloat**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Float.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Replaces `Float.valueOf` with the original string literal.
+
+#### DoubleData
+
+**valueOfDouble**
+examples/data/ArithmeticExpressionsTestData.java:
+```java
+            blackhole = Double.valueOf(a);
+```
+folded/ArithmeticExpressionsTestData-folded.java:
+```java
+            blackhole = a;
+```
+Collapses `Double.valueOf` to the source string.

--- a/docs/docusaurus/features/wiki-generated/asserts-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/asserts-collapse.md
@@ -1,0 +1,38 @@
+---
+title: Asserts Collapse
+slug: /features/asserts-collapse
+sidebar_label: Asserts Collapse
+description: Folds assert statements into terse checks.
+---
+
+:::info Toggle summary
+- **State key:** `assertsCollapse`
+- **Default:** On
+- **Controlled by:** `assertsCollapse`
+:::
+
+## Asserts Collapse
+Folds assert statements into terse checks.
+
+### Example: AssertTestData
+
+examples/data/AssertTestData.java:
+```java
+        if (args.length == 0) {
+            throw new IllegalArgumentException();
+        }
+// ...
+        }
+        if (args.length == 2)
+            throw new IllegalArgumentException("...");
+```
+
+folded/AssertTestData-folded.java:
+```java
+        assert args.length != 0;
+        assert args.length != 1 : "...";
+        assert args.length != 2 : "...";
+```
+
+Highlights AssertTestData with asserts collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/cast-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/cast-expressions-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Cast Expressions Collapse
+slug: /features/cast-expressions-collapse
+sidebar_label: Cast Expressions Collapse
+description: Folds explicit type cast calls into concise Kotlin-style expressions.
+---
+
+:::info Toggle summary
+- **State key:** `castExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `castExpressionsCollapse`
+:::
+
+## Cast Expressions Collapse
+Folds explicit type cast calls into concise Kotlin-style expressions.
+
+### Example: TypeCastTestData
+
+examples/data/TypeCastTestData.java:
+```java
+                ((TypeCastTestData) t.getObject()).getObject() instanceof TypeCastTestData) {
+                System.out.println(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()).getObject());
+        handle(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()));
+```
+
+folded/TypeCastTestData-folded.java:
+```java
+                t.getObject().getObject() instanceof TypeCastTestData) {
+                System.out.println(t.getObject().getObject().getObject());
+        handle(t.getObject().getObject());
+```
+
+Highlights TypeCastTestData with cast expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/check-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/check-expressions-collapse.md
@@ -1,0 +1,67 @@
+---
+title: Check Expressions Collapse
+slug: /features/check-expressions-collapse
+sidebar_label: Check Expressions Collapse
+description: Folds null checks and Elvis patterns into safe-call expressions.
+---
+
+:::info Toggle summary
+- **State key:** `checkExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `checkExpressionsCollapse`
+:::
+
+## Check Expressions Collapse
+Folds null checks and Elvis patterns into safe-call expressions.
+
+### Example: ElvisTestData
+
+examples/data/ElvisTestData.java:
+```java
+        System.out.println(e != null ? e : "");
+        System.out.println(e != null ? e.sayHello() : "");
+// ...
+        if (e != null) {
+                e.get().sayHello();
+        }
+        if (e.get() != null) {
+                e.get().sayHello();
+        }
+```
+
+folded/ElvisTestData-folded.java:
+```java
+        System.out.println(e ?: "");
+        System.out.println(e?.sayHello() ?: "");
+// ...
+        e?.get().sayHello();
+        e.get()?.sayHello();
+```
+
+Highlights ElvisTestData with check expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with check expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/compact-control-flow-syntax-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/compact-control-flow-syntax-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Compact Control Flow Syntax Collapse
+slug: /features/compact-control-flow-syntax-collapse
+sidebar_label: Compact Control Flow Syntax Collapse
+description: Folds compact if/else syntax inspired by Go.
+---
+
+:::info Toggle summary
+- **State key:** `compactControlFlowSyntaxCollapse`
+- **Default:** Off
+- **Controlled by:** `compactControlFlowSyntaxCollapse`
+:::
+
+## Compact Control Flow Syntax Collapse
+Folds compact if/else syntax inspired by Go.
+
+### Example: CompactControlFlowTestData
+
+examples/data/CompactControlFlowTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        for (String arg : args) {
+```
+
+folded/CompactControlFlowTestData-folded.java:
+```java
+        if args.length > 0 {
+// ...
+        for String arg : args {
+```
+
+Highlights CompactControlFlowTestData with compact control flow syntax collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/comparing-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/comparing-expressions-collapse.md
@@ -1,0 +1,46 @@
+---
+title: Comparing Expressions Collapse
+slug: /features/comparing-expressions-collapse
+sidebar_label: Comparing Expressions Collapse
+description: Folds equals and compareTo calls into direct comparison expressions.
+---
+
+:::info Toggle summary
+- **State key:** `comparingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `comparingExpressionsCollapse`
+:::
+
+## Comparing Expressions Collapse
+Folds equals and compareTo calls into direct comparison expressions.
+
+### Example: EqualsCompareTestData
+
+examples/data/EqualsCompareTestData.java:
+```java
+        System.out.println(a.equals(b));
+        System.out.println(!a.equals(b));
+        System.out.println(a.compareTo(b) == 0);
+        System.out.println(a.compareTo(b) != 0);
+// ...
+        System.out.println(a.compareTo(b) > 0);
+        System.out.println(a.compareTo(b) == 1);
+        System.out.println(a.compareTo(b) > -1);
+        System.out.println(a.compareTo(b) >= 0); // Should be a >= b
+```
+
+folded/EqualsCompareTestData-folded.java:
+```java
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+        System.out.println(a ≡ b);
+        System.out.println(a ≢ b);
+// ...
+        System.out.println(a > b);
+        System.out.println(a > b);
+        System.out.println(a ≥ b);
+        System.out.println(a ≥ b); // Should be a >= b
+```
+
+Highlights EqualsCompareTestData with comparing expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/comparing-local-dates-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/comparing-local-dates-collapse.md
@@ -1,0 +1,40 @@
+---
+title: comparingLocalDatesCollapse
+slug: /features/comparing-local-dates-collapse
+sidebar_label: comparingLocalDatesCollapse
+description: Folds java.time isBefore/isAfter checks into readable date comparisons.
+---
+
+:::info Toggle summary
+- **State key:** `comparingLocalDatesCollapse`
+- **Default:** On
+- **Controlled by:** `comparingLocalDatesCollapse`
+:::
+
+## Comparing Local Dates Collapse
+Folds java.time isBefore/isAfter checks into readable date comparisons.
+
+### Example: LocalDateTestData
+
+examples/data/LocalDateTestData.java:
+```java
+        boolean isBefore = d1.isBefore(d2);
+        boolean isAfter = d1.isAfter(d2);
+        boolean d2SmallerOrEqualD1 = !d1.isBefore(d2);;
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(d2);
+// ...
+        if (date1.isBefore(date2) | date1.isAfter(date2) | !date1.isBefore(date2) | !date1.isAfter(date2)) {
+```
+
+folded/LocalDateTestData-folded.java:
+```java
+        boolean isBefore = d1 < d2;
+        boolean isAfter = d1 > d2;
+        boolean d2SmallerOrEqualD1 = d1 ≥ d2;;
+        boolean d1SmallerOrEqualD2 = d1 ≤ d2;
+// ...
+        if (date1 < date2 | date1 > date2 | date1 ≥ date2 | date1 ≤ date2) {
+```
+
+Highlights LocalDateTestData with comparing local dates collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/concatenation-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/concatenation-expressions-collapse.md
@@ -1,0 +1,168 @@
+---
+title: Concatenation Expressions Collapse
+slug: /features/concatenation-expressions-collapse
+sidebar_label: Concatenation Expressions Collapse
+description: Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions.
+---
+
+:::info Toggle summary
+- **State key:** `concatenationExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `concatenationExpressionsCollapse`
+:::
+
+## Concatenation Expressions Collapse
+Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions.
+
+### Example: StringBuilderTestData
+
+examples/data/StringBuilderTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder("[");
+// ...
+        sb1.append(arg);
+```
+
+folded/StringBuilderTestData-folded.java:
+```java
+        StringBuilder sb1 = "[";
+// ...
+        sb1 += arg;
+```
+
+Highlights StringBuilderTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: InterpolatedStringTestData
+
+examples/data/InterpolatedStringTestData.java:
+```java
+        System.out.println("Hello, " + args[0]);
+        System.out.println("Hello, " + args[0] + "!");
+        System.out.println(args[0] + ", hello!");
+        System.out.println(args[0] + ", " + args[0]);
+// ...
+        System.out.println("Hello, " + name);
+        System.out.println("Hello, " + name + "!");
+        System.out.println(name + ", hello!");
+// ...
+        System.out.println("Length: " + args.length);
+        System.out.println("Sum: " + (2 + 3));
+        System.out.println("Upper: " + name.toUpperCase());
+```
+
+folded/InterpolatedStringTestData-folded.java:
+```java
+        System.out.println("Hello, ${args[0]}");
+        System.out.println("Hello, ${args[0]}!");
+        System.out.println("${args[0]}, hello!");
+        System.out.println("${args[0]}, ${args[0]}");
+// ...
+        System.out.println("Hello, $name");
+        System.out.println("Hello, $name!");
+        System.out.println("$name, hello!");
+// ...
+        System.out.println("Length: ${args.length}");
+        System.out.println("Sum: ${(2 + 3)}");
+        System.out.println("Upper: ${name.toUpperCase()}");
+```
+
+Highlights InterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append("Hello, " + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + ", hello!");
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder("Hello, ").append(args[0]); // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += "Hello, ${args[0]}";
+        System.out.println(sb1);
+// ...
+        sb2 += "${args[0]}, hello!";
+        System.out.println(sb2);
+        StringBuilder sb3 = "Hello, " + args[0]; // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";
+        new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";
+```
+
+Highlights AppendSetterInterpolatedStringTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with concatenation expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/const.md
+++ b/docs/docusaurus/features/wiki-generated/const.md
@@ -1,0 +1,103 @@
+---
+title: Const
+slug: /features/const
+sidebar_label: Const
+description: Folds static final fields into Kotlin-style const declarations.
+---
+
+:::info Toggle summary
+- **State key:** `const`
+- **Default:** On
+- **Controlled by:** `const`
+:::
+
+## Const
+Folds static final fields into Kotlin-style const declarations.
+
+### Example: ConstTestData
+
+examples/data/ConstTestData.java:
+```java
+    static final Pattern PATTERN = Pattern.compile(".*");
+    static final Pattern PATTERN_STATIC_IMPORT = compile(".*");
+
+// ...
+    protected final static String PROTECTED_FINAL_STATIC_VAR = "";
+
+    static public final String STATIC_PUBLIC_FINAL_VAR = "";
+// ...
+    static final public String STATIC_FINAL_PUBLIC_VAR = "";
+```
+
+folded/ConstTestData-folded.java:
+```java
+    default const PATTERN = Pattern.compile(".*");
+    default const Pattern PATTERN_STATIC_IMPORT = compile(".*");
+
+// ...
+    protected const PROTECTED_FINAL_STATIC_VAR = "";
+
+    const STATIC_PUBLIC_FINAL_VAR = "";
+// ...
+    const STATIC_FINAL_PUBLIC_VAR = "";
+```
+
+Highlights ConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ConstructorReferenceNotationWithConstTestData
+
+examples/data/ConstructorReferenceNotationWithConstTestData.java:
+```java
+        public static final ConstClass SELF = new ConstClass();
+        public static final ConstClass SELF_ANN = new ConstClass() {
+        };
+        public static final ConstClass SELF_SUB = new SubConstClass();
+        public static final ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private static final HashMap<String, String> MAP = new HashMap<>();
+        private static final HashMap<String, String> MAP2 = new HashMap<String, String>();
+        private static final Map<String, String> MAP3 = new HashMap<>();
+        private static final Map<String, String> MAP_TREE = new TreeMap<>();
+        private static final Map<String, String> MAP4 = Map.of();
+```
+
+folded/ConstructorReferenceNotationWithConstTestData-folded.java:
+```java
+        const ConstClass SELF = ::new;
+        const ConstClass SELF_ANN = ::new{};
+        const ConstClass SELF_SUB = new SubConstClass();
+        const ConstClass SELF_SUB_ANN = new SubConstClass() {
+// ...
+        private const HashMap<String, String> MAP = ::new;
+        private const HashMap<String, String> MAP2 = ::new;
+        private const Map<String, String> MAP3 = new HashMap<>();
+        private const Map<String, String> MAP_TREE = new TreeMap<>();
+        private const Map<String, String> MAP4 = Map.of();
+```
+
+Highlights ConstructorReferenceNotationWithConstTestData with const.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with const.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/control-flow-multi-statement-code-block-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/control-flow-multi-statement-code-block-collapse.md
@@ -1,0 +1,35 @@
+---
+title: Control Flow Multi Statement Code Block Collapse
+slug: /features/control-flow-multi-statement-code-block-collapse
+sidebar_label: Control Flow Multi Statement Code Block Collapse
+description: Folds multi-statement control-flow braces in read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `controlFlowMultiStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowMultiStatementCodeBlockCollapse`
+:::
+
+## Control Flow Multi Statement Code Block Collapse
+Folds multi-statement control-flow braces in read-only files.
+
+### Example: ControlFlowMultiStatementTestData
+
+examples/data/ControlFlowMultiStatementTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowMultiStatementTestData-folded.java:
+```java
+        if (args.length > 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowMultiStatementTestData with control flow multi statement code block collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/control-flow-single-statement-code-block-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/control-flow-single-statement-code-block-collapse.md
@@ -1,0 +1,35 @@
+---
+title: Control Flow Single Statement Code Block Collapse
+slug: /features/control-flow-single-statement-code-block-collapse
+sidebar_label: Control Flow Single Statement Code Block Collapse
+description: Folds single-statement control-flow braces in read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `controlFlowSingleStatementCodeBlockCollapse`
+- **Default:** Off
+- **Controlled by:** `controlFlowSingleStatementCodeBlockCollapse`
+:::
+
+## Control Flow Single Statement Code Block Collapse
+Folds single-statement control-flow braces in read-only files.
+
+### Example: ControlFlowSingleStatementTestData
+
+examples/data/ControlFlowSingleStatementTestData.java:
+```java
+        if (args.length > 0) {
+// ...
+        }
+        if (args.length == 0) {
+```
+
+folded/ControlFlowSingleStatementTestData-folded.java:
+```java
+        if (args.length > 0) 
+// ...
+        if (args.length == 0) 
+```
+
+Highlights ControlFlowSingleStatementTestData with control flow single statement code block collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/dynamic.md
+++ b/docs/docusaurus/features/wiki-generated/dynamic.md
@@ -1,0 +1,36 @@
+---
+title: Dynamic
+slug: /features/dynamic
+sidebar_label: Dynamic
+description: Applies dynamic naming to methods based on a configuration file.
+---
+
+:::info Toggle summary
+- **State key:** `dynamic`
+- **Default:** On
+- **Controlled by:** `dynamic`
+:::
+
+## Dynamic names for methods based on $user.home/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with dynamic names for methods based on $user.home/dynamic-ajf2.toml.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/emojify.md
+++ b/docs/docusaurus/features/wiki-generated/emojify.md
@@ -1,0 +1,50 @@
+---
+title: Emojify
+slug: /features/emojify
+sidebar_label: Emojify
+description: Replaces select syntax elements with emoji equivalents.
+---
+
+:::info Toggle summary
+- **State key:** `emojify`
+- **Default:** Off
+- **Controlled by:** `emojify`
+:::
+
+## Emojify
+Replaces select syntax elements with emoji equivalents.
+
+### Example: EmojifyTestData
+
+examples/data/EmojifyTestData.java:
+```java
+package data;
+
+import java.time.DayOfWeek;
+// ...
+public class EmojifyTestData {
+
+    public final class FinalData {
+// ...
+
+        public void anotherMethod() {
+            final int anotherFinalVariable;
+```
+
+folded/EmojifyTestData-folded.java:
+```java
+📦 data;
+
+🚢 java.time.DayOfWeek;
+// ...
+public 🏛️ EmojifyTestData {
+
+    public 🔒 🏛️ FinalData {
+// ...
+
+        public 💀 anotherMethod() {
+            🔒 🔢 anotherFinalVariable;
+```
+
+Highlights EmojifyTestData with emojify.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/experimental.md
+++ b/docs/docusaurus/features/wiki-generated/experimental.md
@@ -1,0 +1,38 @@
+---
+title: Experimental
+slug: /features/experimental
+sidebar_label: Experimental
+description: Enables experimental folding prototypes.
+---
+
+:::info Toggle summary
+- **State key:** `experimental`
+- **Default:** Off
+- **Controlled by:** `experimental`
+:::
+
+## Experimental
+Enables experimental folding prototypes.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with experimental.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/expression-func.md
+++ b/docs/docusaurus/features/wiki-generated/expression-func.md
@@ -1,0 +1,38 @@
+---
+title: Expression Func
+slug: /features/expression-func
+sidebar_label: Expression Func
+description: Folds single-expression methods into expression-bodied functions.
+---
+
+:::info Toggle summary
+- **State key:** `expressionFunc`
+- **Default:** On
+- **Controlled by:** `expressionFunc`
+:::
+
+## Expression Func
+Folds single-expression methods into expression-bodied functions.
+
+### Example: ExpressionFuncTestData
+
+examples/data/ExpressionFuncTestData.java:
+```java
+    public long findNinjaId() {
+        return 1L;
+    }
+// ...
+    private void printStatus() {
+        new HashMap<String, String>().put("a", "b");
+    }
+```
+
+folded/ExpressionFuncTestData-folded.java:
+```java
+    findNinjaId { 1L }
+// ...
+    private void printStatus() { new HashMap<String, String>().put("a", "b") }
+```
+
+Highlights ExpressionFuncTestData with expression func.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/final-emoji.md
+++ b/docs/docusaurus/features/wiki-generated/final-emoji.md
@@ -1,0 +1,38 @@
+---
+title: Final Emoji
+slug: /features/final-emoji
+sidebar_label: Final Emoji
+description: Replaces final modifiers with lock emoji markers.
+---
+
+:::info Toggle summary
+- **State key:** `finalEmoji`
+- **Default:** Off
+- **Controlled by:** `finalEmoji`
+:::
+
+## Final Emoji
+Replaces final modifiers with lock emoji markers.
+
+### Example: FinalEmojiTestData
+
+examples/data/FinalEmojiTestData.java:
+```java
+    public final String m() {
+        final String s = "1";
+        final var s2 = "2";
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalEmojiTestData-folded.java:
+```java
+    public 🔒 String m() {
+        🔒 String s = "1";
+        🔒 var s2 = "2";
+// ...
+        void main(🔒 String arg, 🔒 int i, 🔒 Object o, Data data);
+```
+
+Highlights FinalEmojiTestData with final emoji.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/final-removal.md
+++ b/docs/docusaurus/features/wiki-generated/final-removal.md
@@ -1,0 +1,38 @@
+---
+title: Final Removal
+slug: /features/final-removal
+sidebar_label: Final Removal
+description: Folds the final modifier away from non-field declarations.
+---
+
+:::info Toggle summary
+- **State key:** `finalRemoval`
+- **Default:** Off
+- **Controlled by:** `finalRemoval`
+:::
+
+## Final Removal
+Folds the final modifier away from non-field declarations.
+
+### Example: FinalRemovalTestData
+
+examples/data/FinalRemovalTestData.java:
+```java
+    public final String m() {
+        final String s = "1";
+        final var s2 = "2";
+// ...
+        void main(final String arg, final int i, final Object o, Data data);
+```
+
+folded/FinalRemovalTestData-folded.java:
+```java
+    public  String m() {
+         String s = "1";
+         var s2 = "2";
+// ...
+        void main( String arg,  int i,  Object o, Data data);
+```
+
+Highlights FinalRemovalTestData with final removal.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/get-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/get-expressions-collapse.md
@@ -1,0 +1,67 @@
+---
+title: Get Expressions Collapse
+slug: /features/get-expressions-collapse
+sidebar_label: Get Expressions Collapse
+description: Folds collection access and literal builders into indexed or map-style expressions.
+---
+
+:::info Toggle summary
+- **State key:** `getExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getExpressionsCollapse`
+:::
+
+## Get Expressions Collapse
+Folds collection access and literal builders into indexed or map-style expressions.
+
+### Example: GetSetPutTestData
+
+examples/data/GetSetPutTestData.java:
+```java
+        List<String> list = Arrays.asList("one", "two");
+        list.set(1,"three" );
+        System.out.println(list.get(list.size() - 1));
+        System.out.println(args[args.length - 1]);
+// ...
+        map.put("one", 1);
+        System.out.println(map.get("two"));
+        List<String> singleton = java.util.Collections.singletonList("one");
+```
+
+folded/GetSetPutTestData-folded.java:
+```java
+        List<String> list = ["one", "two"];
+        list[1] = "three";
+        System.out.println(list.getLast());
+        System.out.println(args.last());
+// ...
+        map["one"] = 1;
+        System.out.println(map["two"]);
+        List<String> singleton = ["one"];
+```
+
+Highlights GetSetPutTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with get expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/get-set-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/get-set-expressions-collapse.md
@@ -1,0 +1,381 @@
+---
+title: Get Set Expressions Collapse
+slug: /features/get-set-expressions-collapse
+sidebar_label: Get Set Expressions Collapse
+description: Folds Java getter and setter calls into property-style access.
+---
+
+:::info Toggle summary
+- **State key:** `getSetExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `getSetExpressionsCollapse`
+:::
+
+## Get Set Expressions Collapse
+Folds Java getter and setter calls into property-style access.
+
+### Example: AppendSetterInterpolatedStringTestData
+
+examples/data/AppendSetterInterpolatedStringTestData.java:
+```java
+        StringBuilder sb1 = new StringBuilder().append(args[0]);
+        sb1.append("Hello, " + args[0]);
+        System.out.println(sb1.toString());
+// ...
+        sb2.append(args[0] + ", hello!");
+        System.out.println(sb2.toString());
+        StringBuilder sb3 = new StringBuilder("Hello, ").append(args[0]); // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);
+        new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");
+```
+
+folded/AppendSetterInterpolatedStringTestData-folded.java:
+```java
+        StringBuilder sb1 = args[0];
+        sb1 += "Hello, ${args[0]}";
+        System.out.println(sb1);
+// ...
+        sb2 += "${args[0]}, hello!";
+        System.out.println(sb2);
+        StringBuilder sb3 = "Hello, " + args[0]; // Should be StringBuilder sb3 = "Hello, $(args[0)":
+// ...
+        new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";
+        new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";
+```
+
+Highlights AppendSetterInterpolatedStringTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: GetterSetterTestData
+
+examples/data/GetterSetterTestData.java:
+```java
+        d.setParent(d);
+        d.setName("Hello");
+        d.getParent().setName("Pum!");
+        System.out.println(d.getParent().getName());
+```
+
+folded/GetterSetterTestData-folded.java:
+```java
+        d.parent = d;
+        d.name = "Hello";
+        d.parent.name = "Pum!";
+        System.out.println(d.parent.name);
+```
+
+Highlights GetterSetterTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftBuilder
+
+examples/data/FieldShiftBuilder.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+// ...
+                .username(record.username());
+```
+
+folded/FieldShiftBuilder-folded.java:
+```java
+        this.username = <<;
+        this.active = <<;
+        this.userIdentifier = <<;
+        this.child = <<;
+// ...
+                .username(record<<);
+```
+
+Highlights FieldShiftBuilder with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftSetters
+
+examples/data/FieldShiftSetters.java:
+```java
+        this.username = username;
+// ...
+        this.active = active;
+```
+
+folded/FieldShiftSetters-folded.java:
+```java
+        this.username = <<;
+// ...
+        this.active = <<;
+```
+
+Highlights FieldShiftSetters with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogBrackets
+
+examples/data/LogBrackets.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogBrackets-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogBrackets with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogFoldingTextBlocksTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: FieldShiftFields
+
+examples/data/FieldShiftFields.java:
+```java
+        this.username = username;
+        this.active = active;
+        this.userIdentifier = userIdentifier;
+        this.child = child;
+        this.userIdentifier = child.userIdentifier;
+        this.userIdentifier = child.getUserIdentifier();
+// ...
+        result.username = source.child.username;
+        result.userIdentifier = source.child.child.child.userIdentifier;
+        result.active = source.child.active;
+        result.list = List.copyOf(source.list);
+```
+
+folded/FieldShiftFields-folded.java:
+```java
+        this.username = <<;
+        this.active = <<;
+        this.userIdentifier = <<;
+        this.child = <<;
+        this.userIdentifier = child.<<;
+        this.userIdentifier = child.<<;
+// ...
+        result.username = source.child.<<;
+        result.userIdentifier = source.child.child.child.<<;
+        result.active = source.child.<<;
+        result.list = List.copyOf(source.<<);
+```
+
+Highlights FieldShiftFields with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayWithoutValTestData
+
+examples/data/DestructuringAssignmentArrayWithoutValTestData.java:
+```java
+        Data first = array[0];
+// ...
+        Data second = array[1];
+        Data third = array[2];
+        Data fourth = array[3];
+```
+
+folded/DestructuringAssignmentArrayWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = array;
+// ...
+        Data ignored21 = data.array[4];
+        Data ignored22 = data.array[5];
+```
+
+Highlights DestructuringAssignmentArrayWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListWithoutValTestData
+
+examples/data/DestructuringAssignmentListWithoutValTestData.java:
+```java
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+// ...
+        Data ignored21 = data.getList().get(4);
+        Data ignored22 = data.getList().get(5);
+```
+
+folded/DestructuringAssignmentListWithoutValTestData-folded.java:
+```java
+        Data (first, second, third, fourth) = list;
+// ...
+        Data ignored21 = data.list.get(4);
+        Data ignored22 = data.list.get(5);
+```
+
+Highlights DestructuringAssignmentListWithoutValTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+// ...
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DynamicTestData
+
+examples/data/DynamicTestData.java:
+```java
+    public static void staticMethod(Data data) {
+// ...
+                .normalMethod(
+                        staticMethod(
+```
+
+folded/DynamicTestData-folded.java:
+```java
+    public static void changedStaticMethod(Data data) {
+// ...
+                .changedNormalMethod(
+                        changedStaticMethod(
+```
+
+Highlights DynamicTestData with get set expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/global-on.md
+++ b/docs/docusaurus/features/wiki-generated/global-on.md
@@ -1,0 +1,22 @@
+---
+title: globalOn
+slug: /features/global-on
+sidebar_label: globalOn
+description: Master switch that enables or disables all Advanced Expression Folding actions.
+---
+
+:::info Toggle summary
+- **State key:** `globalOn`
+- **Default:** On
+- **Controlled by:** `globalOn`
+:::
+
+![Keymap actions configured for folding and unfolding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/35863f50-d441-4402-8172-db6e75962350)
+
+# Global On (State field: globalOn)
+
+## Global On
+Master switch that enables or disables all Advanced Expression Folding actions.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.

--- a/docs/docusaurus/features/wiki-generated/if-null-safe.md
+++ b/docs/docusaurus/features/wiki-generated/if-null-safe.md
@@ -1,0 +1,47 @@
+---
+title: If Null Safe
+slug: /features/if-null-safe
+sidebar_label: If Null Safe
+description: Extends null-safe folding to if statements and guard clauses.
+---
+
+:::info Toggle summary
+- **State key:** `ifNullSafe`
+- **Default:** On
+- **Controlled by:** `ifNullSafe`
+:::
+
+[video](https://www.youtube.com/watch?v=zvpvhn7ISAw)
+
+
+![Null-safe if folding showcased on chained access](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/56aa2dbb-0aa1-4143-a296-801ffb0668cd)
+
+
+
+## If Null Safe
+Extends null-safe folding to if statements and guard clauses.
+
+### Example: IfNullSafeData
+
+examples/data/IfNullSafeData.java:
+```java
+        var threeChains = data != null
+                && data.getData1() != null
+// ...
+                && data.getData1() != null
+                && data != null
+                && data != null
+                && data.getData1() != null
+                && data.getData1().isActive();
+```
+
+folded/IfNullSafeData-folded.java:
+```java
+        var threeChains = data?.data1 != null
+                && data?.data1 != null
+// ...
+                && data?.data1?.active == true;
+```
+
+Highlights IfNullSafeData with if null safe.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/interface-extension-properties.md
+++ b/docs/docusaurus/features/wiki-generated/interface-extension-properties.md
@@ -1,0 +1,50 @@
+---
+title: Interface Extension Properties
+slug: /features/interface-extension-properties
+sidebar_label: Interface Extension Properties
+description: Folds interface getters and setters into Kotlin extension properties.
+---
+
+:::info Toggle summary
+- **State key:** `interfaceExtensionProperties`
+- **Default:** On
+- **Controlled by:** `interfaceExtensionProperties`
+:::
+
+## Interface Extension Properties
+Folds interface getters and setters into Kotlin extension properties.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with interface extension properties.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/kotlin-quick-return.md
+++ b/docs/docusaurus/features/wiki-generated/kotlin-quick-return.md
@@ -1,0 +1,47 @@
+---
+title: Kotlin Quick Return
+slug: /features/kotlin-quick-return
+sidebar_label: Kotlin Quick Return
+description: Folds Kotlin let/return idioms into quick-return expressions.
+---
+
+:::info Toggle summary
+- **State key:** `kotlinQuickReturn`
+- **Default:** On
+- **Controlled by:** `kotlinQuickReturn`
+:::
+
+## Kotlin Quick Return
+Folds Kotlin let/return idioms into quick-return expressions.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with kotlin quick return.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/local-date-literal-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/local-date-literal-collapse.md
@@ -1,0 +1,65 @@
+---
+title: Local Date Literal Collapse
+slug: /features/local-date-literal-collapse
+sidebar_label: Local Date Literal Collapse
+description: Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms.
+---
+
+:::info Toggle summary
+- **State key:** `localDateLiteralCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralCollapse`
+:::
+
+## Local Date Literal Collapse
+Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms.
+
+### Example: LocalDateLiteralTestData
+
+examples/data/LocalDateLiteralTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralTestData-folded.java:
+```java
+        LocalDate d1 = 2018-01-10;
+        LocalDate d4 = 2018-01-10;
+        LocalDate d2 = 2018-12-10;
+        LocalDate d3 = 2018-04-04;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013-01-10);
+```
+
+Highlights LocalDateLiteralTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/local-date-literal-postfix-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/local-date-literal-postfix-collapse.md
@@ -1,0 +1,40 @@
+---
+title: Local Date Literal Postfix Collapse
+slug: /features/local-date-literal-postfix-collapse
+sidebar_label: Local Date Literal Postfix Collapse
+description: Folds postfix LocalDate literals such as 2018Y-02M-12D.
+---
+
+:::info Toggle summary
+- **State key:** `localDateLiteralPostfixCollapse`
+- **Default:** Off
+- **Controlled by:** `localDateLiteralPostfixCollapse`
+:::
+
+## Local Date Literal Postfix Collapse
+Folds postfix LocalDate literals such as 2018Y-02M-12D.
+
+### Example: LocalDateLiteralPostfixTestData
+
+examples/data/LocalDateLiteralPostfixTestData.java:
+```java
+        LocalDate d1 = LocalDate.of(2018, 01, 10);
+        LocalDate d4 = LocalDate.of(2018, 01, 10);
+        LocalDate d2 = LocalDate.of(2018, 12, 10);
+        LocalDate d3 = LocalDate.of(2018,  4 ,  4   );
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));
+```
+
+folded/LocalDateLiteralPostfixTestData-folded.java:
+```java
+        LocalDate d1 = 2018Y-01M-10D;
+        LocalDate d4 = 2018Y-01M-10D;
+        LocalDate d2 = 2018Y-12M-10D;
+        LocalDate d3 = 2018Y-04M-04D;
+// ...
+        boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);
+```
+
+Highlights LocalDateLiteralPostfixTestData with local date literal postfix collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/log-folding-text-blocks.md
+++ b/docs/docusaurus/features/wiki-generated/log-folding-text-blocks.md
@@ -1,0 +1,34 @@
+---
+title: Log Folding Text Blocks
+slug: /features/log-folding-text-blocks
+sidebar_label: Log Folding Text Blocks
+description: Folds log Text Blocks into compact placeholders.
+---
+
+:::info Toggle summary
+- **State key:** `logFoldingTextBlocks`
+- **Default:** Off
+- **Controlled by:** `logFoldingTextBlocks`
+:::
+
+## Log Folding Text Blocks
+Folds log Text Blocks into compact placeholders.
+
+### Example: LogFoldingTextBlocksTestData
+
+examples/data/LogFoldingTextBlocksTestData.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: %s", name);
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);
+```
+
+folded/LogFoldingTextBlocksTestData-folded.java:
+```java
+        log.debug("Debug message with 1 parameter - Name: $name");
+// ...
+        log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+```
+
+Highlights LogFoldingTextBlocksTestData with log folding text blocks.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/lombok-dirty-off.md
+++ b/docs/docusaurus/features/wiki-generated/lombok-dirty-off.md
@@ -1,0 +1,34 @@
+---
+title: Lombok Dirty Off
+slug: /features/lombok-dirty-off
+sidebar_label: Lombok Dirty Off
+description: Skips folding Lombok accessors marked as dirty.
+---
+
+:::info Toggle summary
+- **State key:** `lombokDirtyOff`
+- **Default:** Off
+- **Controlled by:** `lombokDirtyOff`
+:::
+
+## Lombok Dirty Off
+Skips folding Lombok accessors marked as dirty.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok dirty off.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/lombok-pattern-off.md
+++ b/docs/docusaurus/features/wiki-generated/lombok-pattern-off.md
@@ -1,0 +1,67 @@
+---
+title: Lombok Pattern Off
+slug: /features/lombok-pattern-off
+sidebar_label: Lombok Pattern Off
+description: Uses a regex to disable Lombok folding for matching classes.
+---
+
+:::info Toggle summary
+- **State key:** `lombokPatternOff`
+- **Default:** Off
+- **Controlled by:** `lombokPatternOff`
+:::
+
+## Lombok Pattern Off
+Uses a regex to disable Lombok folding for matching classes.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return "ToStringFull{" +
+                    "data=" + data +
+                    ", ok=" + ok +
+                    '}';
+// ...
+                return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';
+// ...
+                return "ToStringPartial{" + "data=" + data + '}';
+```
+
+Highlights LombokPatternOffTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok pattern off.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/lombok.md
+++ b/docs/docusaurus/features/wiki-generated/lombok.md
@@ -1,0 +1,209 @@
+---
+title: Lombok
+slug: /features/lombok
+sidebar_label: Lombok
+description: Folds Java bean patterns into Lombok-style annotations.
+---
+
+:::info Toggle summary
+- **State key:** `lombok`
+- **Default:** On
+- **Controlled by:** `lombok`
+:::
+
+![Animated overview of Lombok folding support](https://github.com/user-attachments/assets/7d2bdcf7-15ad-45a2-9aad-1f596443c4d7)
+
+old video:
+[video](https://www.youtube.com/watch?v=dKMWL3YJacU)
+
+
+## Lombok
+Folds Java bean patterns into Lombok-style annotations.
+
+### Example: LombokTestData
+
+examples/data/LombokTestData.java:
+```java
+public class LombokTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokTestData data;
+        boolean ok;
+```
+
+Highlights LombokTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokDirtyOffTestData
+
+examples/data/LombokDirtyOffTestData.java:
+```java
+        public class DirtyData {
+// ...
+            private boolean ok;
+```
+
+folded/LombokDirtyOffTestData-folded.java:
+```java
+        @EqualsAndHashCode public class DirtyData {
+// ...
+            @Getter private boolean ok;
+```
+
+Highlights LombokDirtyOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffTestData
+
+examples/data/LombokPatternOffTestData.java:
+```java
+            return "ToStringFull{" +
+                    "data=" + data +
+                    ", ok=" + ok +
+                    '}';
+// ...
+                return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';
+```
+
+folded/LombokPatternOffTestData-folded.java:
+```java
+            return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';
+// ...
+                return "ToStringPartial{" + "data=" + data + '}';
+```
+
+Highlights LombokPatternOffTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: LombokPatternOffNegativeTestData
+
+examples/data/LombokPatternOffNegativeTestData.java:
+```java
+public class LombokPatternOffNegativeTestData {
+
+    private static final long serialVersionUID = 1234567L;
+// ...
+    public LombokPatternOffNegativeTestData getData() {
+        return data;
+    }
+// ...
+        this.string = string;
+    }
+```
+
+folded/LombokPatternOffNegativeTestData-folded.java:
+```java
+@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+// ...
+    @Getter public class LombokGetters {
+        LombokPatternOffNegativeTestData data;
+        boolean ok;
+```
+
+Highlights LombokPatternOffNegativeTestData with lombok.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with lombok.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/memory-improvement.md
+++ b/docs/docusaurus/features/wiki-generated/memory-improvement.md
@@ -1,0 +1,28 @@
+---
+title: memoryImprovement
+slug: /features/memory-improvement
+sidebar_label: memoryImprovement
+description: Caches folding descriptors for large test data files.
+---
+
+:::info Toggle summary
+- **State key:** `memoryImprovement`
+- **Default:** On
+- **Controlled by:** `memoryImprovement`
+:::
+
+* only for files in **testData** folder
+
+![Diff view before folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/89ccca5b-92ce-47ad-b051-7eabb39f94c2)
+
+=>
+
+![Diff view after folding a testData file](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/440c30a8-1088-4e6a-bf25-bde6627aa7af)
+
+# Memory Improvement (State field: memoryImprovement)
+
+## Memory Improvement
+Caches folding descriptors for large test data files.
+
+_No bundled example for this setting._
+This option affects editor behaviour without a dedicated sample file.

--- a/docs/docusaurus/features/wiki-generated/nullable.md
+++ b/docs/docusaurus/features/wiki-generated/nullable.md
@@ -1,0 +1,166 @@
+---
+title: Nullable
+slug: /features/nullable
+sidebar_label: Nullable
+description: Folds nullability annotations into ? and !! markers.
+---
+
+:::info Toggle summary
+- **State key:** `nullable`
+- **Default:** Off
+- **Controlled by:** `nullable`
+:::
+
+## Nullable
+Folds nullability annotations into ? and !! markers.
+
+### Example: NullableAnnotationTestData
+
+examples/data/NullableAnnotationTestData.java:
+```java
+    @NotNull
+    NullableAnnotationTestData data;
+    boolean ok;
+// ...
+    public void setString(String string) {
+        this.string = string;
+    }
+// ...
+    @Nonnull
+    private NullableAnnotationTestData data2;
+```
+
+folded/NullableAnnotationTestData-folded.java:
+```java
+    
+    @Getter @Setter NullableAnnotationTestData!! data;
+    @Getter @Setter boolean ok;
+    
+    @Getter @Setter String? string;
+// ...
+    
+    private NullableAnnotationTestData!! data2;
+```
+
+Highlights NullableAnnotationTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullTestData
+
+examples/data/NullableAnnotationCheckNotNullTestData.java:
+```java
+        public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);
+// ...
+        public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullTestData-folded.java:
+```java
+        public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+// ...
+        public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;
+```
+
+Highlights NullableAnnotationCheckNotNullTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: NullableAnnotationCheckNotNullFieldShiftTestData
+
+examples/data/NullableAnnotationCheckNotNullFieldShiftTestData.java:
+```java
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);
+// ...
+            this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");
+```
+
+folded/NullableAnnotationCheckNotNullFieldShiftTestData-folded.java:
+```java
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+// ...
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;
+```
+
+Highlights NullableAnnotationCheckNotNullFieldShiftTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: InterfaceExtensionPropertiesTestData
+
+examples/data/InterfaceExtensionPropertiesTestData.java:
+```java
+        String getName();
+        void setName(String name);
+
+        int getAge();
+        void setAge(int age);
+// ...
+        public String getName();
+        public void setName(String name);
+
+        public int getAge();
+        public void setAge(int age);
+```
+
+folded/InterfaceExtensionPropertiesTestData-folded.java:
+```java
+       @Getter String name;
+       @Setter String name;
+
+       @Getter int age;
+       @Setter int age;
+// ...
+       @Getter public String name;
+       @Setter public String name;
+
+       @Getter public int age;
+       @Setter public int age;
+```
+
+Highlights InterfaceExtensionPropertiesTestData with nullable.
+Removes boilerplate while preserving behavior.
+
+### Example: ExperimentalTestData
+
+examples/data/ExperimentalTestData.java:
+```java
+            try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+// ...
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+```
+
+folded/ExperimentalTestData-folded.java:
+```java
+            @SneakyThrows {
+                byte[] bytez = System["sort-desc"].getBytes();
+// ...
+            @SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);
+```
+
+Highlights ExperimentalTestData with nullable.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/optional.md
+++ b/docs/docusaurus/features/wiki-generated/optional.md
@@ -1,0 +1,79 @@
+---
+title: Optional
+slug: /features/optional
+sidebar_label: Optional
+description: Displays java.util.Optional flows as Kotlin-style null-safe chains.
+---
+
+:::info Toggle summary
+- **State key:** `optional`
+- **Default:** On
+- **Controlled by:** `optional`
+:::
+
+## Optional
+Displays java.util.Optional flows as Kotlin-style null-safe chains.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with optional.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with optional.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/override-hide.md
+++ b/docs/docusaurus/features/wiki-generated/override-hide.md
@@ -1,0 +1,36 @@
+---
+title: Override Hide
+slug: /features/override-hide
+sidebar_label: Override Hide
+description: Hides @Override annotations from view.
+---
+
+:::info Toggle summary
+- **State key:** `overrideHide`
+- **Default:** On
+- **Controlled by:** `overrideHide`
+:::
+
+## Override Hide
+Hides @Override annotations from view.
+
+### Example: OverrideHideTestData
+
+examples/data/OverrideHideTestData.java:
+```java
+            @Override
+// ...
+            @Override
+```
+
+folded/OverrideHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+```
+
+Highlights OverrideHideTestData with override hide.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/println.md
+++ b/docs/docusaurus/features/wiki-generated/println.md
@@ -1,0 +1,51 @@
+---
+title: Println
+slug: /features/println
+sidebar_label: Println
+description: Folds System.out.println calls into println.
+---
+
+:::info Toggle summary
+- **State key:** `println`
+- **Default:** On
+- **Controlled by:** `println`
+:::
+
+![System.out.println call folded to println](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/75a5224f-7b52-4b71-9774-2814e8a867ba)
+
+
+## Println
+Folds System.out.println calls into println.
+
+### Example: PrintlnTestData
+
+examples/data/PrintlnTestData.java:
+```java
+        System.out.println("Hello");
+        System.out.println
+// ...
+        System.
+                out.println("Spacing");
+        System.out.
+// ...
+        System.out.println("Passed as parameter: " +
+this.getClass());
+        System.out.println("""
+```
+
+folded/PrintlnTestData-folded.java:
+```java
+        println("Hello");
+        println
+// ...
+        println("Spacing");
+        println(3.14);
+        println(string);
+// ...
+        println("Passed as parameter: " + string);
+        println("Passed as parameter: " + this.getClass());
+        println("""
+```
+
+Highlights PrintlnTestData with println.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/range-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/range-expressions-collapse.md
@@ -1,0 +1,38 @@
+---
+title: Range Expressions Collapse
+slug: /features/range-expressions-collapse
+sidebar_label: Range Expressions Collapse
+description: Folds indexed loops into Kotlin-style range expressions.
+---
+
+:::info Toggle summary
+- **State key:** `rangeExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `rangeExpressionsCollapse`
+:::
+
+## Range Expressions Collapse
+Folds indexed loops into Kotlin-style range expressions.
+
+### Example: ForRangeTestData
+
+examples/data/ForRangeTestData.java:
+```java
+                for (int i = 0; i < args.length; i++) {
+                        String arg = args
+                                [i];
+// ...
+                for (int i = 0; i < args.length; i++) {
+                        String arg = args
+                                [i];
+```
+
+folded/ForRangeTestData-folded.java:
+```java
+                for ((int i, String arg) : args) {
+// ...
+                for (String arg : args) {
+```
+
+Highlights ForRangeTestData with range expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/semicolons-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/semicolons-collapse.md
@@ -1,0 +1,34 @@
+---
+title: Semicolons Collapse
+slug: /features/semicolons-collapse
+sidebar_label: Semicolons Collapse
+description: Folds redundant semicolons inside read-only files.
+---
+
+:::info Toggle summary
+- **State key:** `semicolonsCollapse`
+- **Default:** Off
+- **Controlled by:** `semicolonsCollapse`
+:::
+
+## Semicolons Collapse
+Folds redundant semicolons inside read-only files.
+
+### Example: SemicolonTestData
+
+examples/data/SemicolonTestData.java:
+```java
+package data;
+// ...
+import java.util.Arrays;
+```
+
+folded/SemicolonTestData-folded.java:
+```java
+package data
+// ...
+import java.util.Arrays
+```
+
+Highlights SemicolonTestData with semicolons collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/slicing-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/slicing-expressions-collapse.md
@@ -1,0 +1,54 @@
+---
+title: Slicing Expressions Collapse
+slug: /features/slicing-expressions-collapse
+sidebar_label: Slicing Expressions Collapse
+description: Folds List.subList and String.substring calls into concise slice notation.
+---
+
+:::info Toggle summary
+- **State key:** `slicingExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `slicingExpressionsCollapse`
+:::
+
+## Slicing Expressions Collapse
+Folds List.subList and String.substring calls into concise slice notation.
+
+### Example: SliceTestData
+
+examples/data/SliceTestData.java:
+```java
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(1, 2));
+        System.out.println(list.subList(1, list.size()));
+        System.out.println(list.subList(0, 2));
+        System.out.println(list.subList(1, list.size() - 2));
+        System.out.println(list.subList(0, list.size() - 2));
+// ...
+        System.out.println(f.substring(1));
+        System.out.println(f.substring(1, 2));
+        System.out.println(f.substring(1, f.length()));
+        System.out.println(f.substring(0, 2));
+        System.out.println(f.substring(1, f.length() - 2));
+        System.out.println(f.substring(0, f.length() - 2));
+```
+
+folded/SliceTestData-folded.java:
+```java
+        System.out.println(list[1:]);
+        System.out.println(list[1:2]);
+        System.out.println(list[1:]);
+        System.out.println(list[:2]);
+        System.out.println(list[1:-2]);
+        System.out.println(list[:-2]);
+// ...
+        System.out.println(f[1:]);
+        System.out.println(f[1:2]);
+        System.out.println(f[1:]);
+        System.out.println(f[:2]);
+        System.out.println(f[1:-2]);
+        System.out.println(f[:-2]);
+```
+
+Highlights SliceTestData with slicing expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/stream-spread.md
+++ b/docs/docusaurus/features/wiki-generated/stream-spread.md
@@ -1,0 +1,79 @@
+---
+title: Stream Spread
+slug: /features/stream-spread
+sidebar_label: Stream Spread
+description: Displays stream pipelines using Groovy-style spread notation.
+---
+
+:::info Toggle summary
+- **State key:** `streamSpread`
+- **Default:** On
+- **Controlled by:** `streamSpread`
+:::
+
+## Stream Spread
+Displays stream pipelines using Groovy-style spread notation.
+
+### Example: ConcatenationTestData
+
+examples/data/ConcatenationTestData.java:
+```java
+        list.add("one");
+        list.remove("one");
+// ...
+        list.addAll(singleton);
+        list.removeAll(singleton);
+        Collections.addAll(list, args);
+```
+
+folded/ConcatenationTestData-folded.java:
+```java
+        list += "one";
+        list -= "one";
+// ...
+        list += singleton;
+        list -= singleton;
+        list += args;
+```
+
+Highlights ConcatenationTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: OptionalTestData
+
+examples/data/OptionalTestData.java:
+```java
+            o = opt.get();
+// ...
+        o = opt.orElseThrow();
+```
+
+folded/OptionalTestData-folded.java:
+```java
+            o = opt!!;
+// ...
+        o = opt!!;
+```
+
+Highlights OptionalTestData with stream spread.
+Removes boilerplate while preserving behavior.
+
+### Example: SpreadTestData
+
+examples/data/SpreadTestData.java:
+```java
+        String empNames = list.stream()
+                .map(Data::getString)
+// ...
+        var p1 = data.getDataList().stream().map(Data::getData).toList();
+```
+
+folded/SpreadTestData-folded.java:
+```java
+        String empNames = list*.string()
+// ...
+        var p1 = data.getDataList().stream()*.data().toList();
+```
+
+Highlights SpreadTestData with stream spread.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/summary-parent-override.md
+++ b/docs/docusaurus/features/wiki-generated/summary-parent-override.md
@@ -1,0 +1,34 @@
+---
+title: Summary Parent Override
+slug: /features/summary-parent-override
+sidebar_label: Summary Parent Override
+description: Folds overridden methods into parent summary stubs.
+---
+
+:::info Toggle summary
+- **State key:** `summaryParentOverride`
+- **Default:** Off
+- **Controlled by:** `summaryParentOverride`
+:::
+
+## Summary Parent Override
+Folds overridden methods into parent summary stubs.
+
+### Example: SummaryParentOverrideTestData
+
+examples/data/SummaryParentOverrideTestData.java:
+```java
+    class ParentClass extends GrandparentClass {
+// ...
+        public void grandparentMethod() {
+```
+
+folded/SummaryParentOverrideTestData-folded.java:
+```java
+    class ParentClass extends GrandparentClass(1-grandparentMethod) {
+// ...
+        public void grandparentMethod() { // overrides from GrandparentClass
+```
+
+Highlights SummaryParentOverrideTestData with summary parent override.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/suppress-warnings-hide.md
+++ b/docs/docusaurus/features/wiki-generated/suppress-warnings-hide.md
@@ -1,0 +1,36 @@
+---
+title: Suppress Warnings Hide
+slug: /features/suppress-warnings-hide
+sidebar_label: Suppress Warnings Hide
+description: Hides @SuppressWarnings annotations from view.
+---
+
+:::info Toggle summary
+- **State key:** `suppressWarningsHide`
+- **Default:** On
+- **Controlled by:** `suppressWarningsHide`
+:::
+
+## Suppress Warnings Hide
+Hides @SuppressWarnings annotations from view.
+
+### Example: SuppressWarningsHideTestData
+
+examples/data/SuppressWarningsHideTestData.java:
+```java
+    @SuppressWarnings("deprecation")
+// ...
+    @SuppressWarnings({"rawtypes", "unchecked"})
+```
+
+folded/SuppressWarningsHideTestData-folded.java:
+```java
+package data;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+```
+
+Highlights SuppressWarningsHideTestData with suppress warnings hide.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/features/wiki-generated/var-expressions-collapse.md
+++ b/docs/docusaurus/features/wiki-generated/var-expressions-collapse.md
@@ -1,0 +1,109 @@
+---
+title: Var Expressions Collapse
+slug: /features/var-expressions-collapse
+sidebar_label: Var Expressions Collapse
+description: Folds variable declarations into val/var style declarations.
+---
+
+:::info Toggle summary
+- **State key:** `varExpressionsCollapse`
+- **Default:** On
+- **Controlled by:** `varExpressionsCollapse`
+:::
+
+## Var Expressions Collapse
+Folds variable declarations into val/var style declarations.
+
+### Example: VarTestData
+
+examples/data/VarTestData.java:
+```java
+        String string = "Hello, world";
+// ...
+        int count = 0;
+        for (String arg : args) {
+```
+
+folded/VarTestData-folded.java:
+```java
+        val string = "Hello, world";
+// ...
+        var count = 0;
+        for (val arg : args) {
+```
+
+Highlights VarTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: LetReturnIt
+
+examples/data/LetReturnIt.java:
+```java
+        String var1 = getData(someString);
+        if (var1 != null) {
+            return var1;
+// ...
+        if (var5 == null) {
+            return null;
+        }
+// ...
+        String var6 = getData(someString);
+        if (var6 == null) {
+            return null;
+        }
+```
+
+folded/LetReturnIt-folded.java:
+```java
+        val var1 = getData(someString)?.let { return it }
+        val var2 = getData(someString) ?: return null
+        val var4 = getData(someString)?.let { return it }
+        var4;
+        val var5 = getData(someString) ?: return null
+// ...
+        val var6 = getData(someString) ?: return null
+```
+
+Highlights LetReturnIt with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentArrayTestData
+
+examples/data/DestructuringAssignmentArrayTestData.java:
+```java
+        Data ignored1 = array[0];
+// ...
+        Data first = array[0];
+```
+
+folded/DestructuringAssignmentArrayTestData-folded.java:
+```java
+        val ignored1 = array[0];
+// ...
+        val first, second, third, fourth) = array;
+```
+
+Highlights DestructuringAssignmentArrayTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.
+
+### Example: DestructuringAssignmentListTestData
+
+examples/data/DestructuringAssignmentListTestData.java:
+```java
+        Data ignored1 = list.get(0);
+// ...
+        Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);
+```
+
+folded/DestructuringAssignmentListTestData-folded.java:
+```java
+        val ignored1 = list.get(0);
+// ...
+        val first, second, third, fourth) = list;
+```
+
+Highlights DestructuringAssignmentListTestData with var expressions collapse.
+Removes boilerplate while preserving behavior.

--- a/docs/docusaurus/generate_from_wiki.py
+++ b/docs/docusaurus/generate_from_wiki.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List
+
+ROOT = Path(__file__).resolve().parents[2]
+WIKI_FEATURES = ROOT / "wiki-clone" / "docs" / "features"
+MANUAL_FEATURES_DIR = ROOT / "docs" / "docusaurus" / "features"
+
+
+def camel_to_kebab(value: str) -> str:
+    value = re.sub("([a-z0-9])([A-Z])", r"\1-\2", value)
+    value = value.replace("_", "-")
+    return value.lower()
+
+
+def humanize_state(value: str) -> str:
+    words = [word for word in camel_to_kebab(value).split("-") if word]
+    if not words:
+        return value
+    return " ".join(word.capitalize() for word in words)
+
+
+@dataclass
+class FeatureDoc:
+    title: str
+    state_key: str
+    slug: str
+    sidebar_label: str
+    description: str
+    body_lines: List[str]
+    default_value: str | None = None
+    controlled_by: List[str] = field(default_factory=list)
+    related_features: List[str] = field(default_factory=list)
+
+
+FRONTMATTER_TEMPLATE = """---\ntitle: {title}\nslug: /features/{slug}\nsidebar_label: {sidebar_label}\ndescription: {description}\n---\n\n"""
+
+
+INFO_BLOCK_TEMPLATE = """:::info Toggle summary\n- **State key:** `{state_key}`\n{default_line}{controlled_line}{related_line}:::\n\n"""
+
+
+def parse_manual_slugs() -> set[str]:
+    slugs: set[str] = set()
+    for path in MANUAL_FEATURES_DIR.glob("*.md"):
+        text = path.read_text(encoding="utf-8")
+        match = re.search(r"^slug:\s*/features/([\w\-/]+)", text, re.MULTILINE)
+        if match:
+            slugs.add(match.group(1))
+    return slugs
+
+
+def extract_feature(path: Path) -> FeatureDoc | None:
+    raw_lines = path.read_text(encoding="utf-8").splitlines()
+    title_index = next(
+        (idx for idx, line in enumerate(raw_lines) if re.match(r"^#+\s+", line)),
+        None,
+    )
+    if title_index is None:
+        return None
+
+    title_line = raw_lines[title_index]
+    title_match = re.match(
+        r"^#+\s+(?P<title>.+?)\s*\(State field:\s*(?P<state>[^)]+)\)",
+        title_line,
+    )
+    if title_match:
+        title = title_match.group("title").strip()
+        state = title_match.group("state").strip()
+    else:
+        state = path.stem
+        candidate_title = title_line.lstrip("# ").strip()
+        if not candidate_title or candidate_title.lower().startswith("example"):
+            title = humanize_state(state)
+        else:
+            title = candidate_title
+
+    if title and title.islower():
+        title = title[:1].upper() + title[1:]
+
+    slug = camel_to_kebab(state)
+    sidebar_label = title
+
+    # gather lines after removing the heading and metadata entries
+    body_lines: List[str] = []
+    default_value: str | None = None
+    controlled_by: List[str] = []
+    related_features: List[str] = []
+    skip_indices: set[int] = {title_index}
+    for idx, line in enumerate(raw_lines):
+        if line.startswith("Default:"):
+            default_value = line.split(":", 1)[1].strip()
+            skip_indices.add(idx)
+        elif line.startswith("Controlled by:"):
+            value = line.split(":", 1)[1].strip()
+            extracted = [item.strip(" `") for item in value.split(",") if item.strip(" `")]
+            controlled_by.extend(extracted)
+            skip_indices.add(idx)
+        elif line.startswith("Related features:"):
+            value = line.split(":", 1)[1].strip()
+            if value and value.lower() != "(none)":
+                related_features.extend([item.strip() for item in value.split(",") if item.strip()])
+            skip_indices.add(idx)
+
+    for idx, line in enumerate(raw_lines):
+        if idx in skip_indices:
+            continue
+        heading_match = re.match(r"^(#+)(\s+.*)", line)
+        if heading_match:
+            hashes = len(heading_match.group(1))
+            if hashes >= 3:
+                line = "#" * (hashes - 1) + heading_match.group(2)
+        body_lines.append(line)
+
+    description = derive_description(raw_lines) or f"Overview of {humanize_state(state).lower()}."
+
+    info_block = INFO_BLOCK_TEMPLATE.format(
+        state_key=state,
+        default_line=f"- **Default:** {default_value}\n" if default_value else "",
+        controlled_line=(
+            "- **Controlled by:** "
+            + ", ".join(f"`{item}`" for item in controlled_by)
+            + "\n"
+            if controlled_by
+            else ""
+        ),
+        related_line=(
+            "- **Related features:** "
+            + ", ".join(related_features)
+            + "\n"
+            if related_features
+            else ""
+        ),
+    )
+
+    # ensure there is an empty line after the info block unless body starts with blank already
+    if body_lines and body_lines[0].strip():
+        body_lines.insert(0, "")
+    body_lines.insert(0, info_block.rstrip("\n"))
+
+    return FeatureDoc(
+        title=title,
+        state_key=state,
+        slug=slug,
+        sidebar_label=title,
+        description=description,
+        body_lines=body_lines,
+        default_value=default_value,
+        controlled_by=controlled_by,
+        related_features=related_features,
+    )
+
+
+def derive_description(lines: Iterable[str]) -> str | None:
+    lines = list(lines)
+    for idx, line in enumerate(lines):
+        heading_match = re.match(r"###\s+(.+)", line)
+        if heading_match:
+            # look ahead for first non-empty, non-heading line
+            for next_line in lines[idx + 1 :]:
+                stripped = next_line.strip()
+                if not stripped:
+                    continue
+                if stripped.startswith("#"):
+                    break
+                return stripped
+    return None
+
+
+def write_feature(doc: FeatureDoc, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{doc.slug}.md"
+    frontmatter = FRONTMATTER_TEMPLATE.format(
+        title=doc.title,
+        slug=doc.slug,
+        sidebar_label=doc.sidebar_label,
+        description=doc.description,
+    )
+    content = frontmatter + "\n".join(doc.body_lines).rstrip() + "\n"
+    if output_path.exists() and output_path.read_text(encoding="utf-8") == content:
+        return
+    output_path.write_text(content, encoding="utf-8")
+
+
+def render_summary_row(label: str, value: str) -> str:
+    return f"      <dt>{html.escape(label)}</dt>\n      <dd>{value}</dd>\n"
+
+
+def render_feature_html(doc: FeatureDoc) -> str:
+    summary_rows = [
+        render_summary_row("State key", f"<code>{html.escape(doc.state_key)}</code>"),
+    ]
+    if doc.default_value:
+        summary_rows.append(render_summary_row("Default", html.escape(doc.default_value)))
+    if doc.controlled_by:
+        controls = ", ".join(f"<code>{html.escape(item)}</code>" for item in doc.controlled_by)
+        summary_rows.append(render_summary_row("Controlled by", controls))
+    if doc.related_features:
+        related = ", ".join(html.escape(item) for item in doc.related_features)
+        summary_rows.append(render_summary_row("Related features", related))
+
+    body_markdown = "\n".join(doc.body_lines).strip()
+    body_html = f"<pre>{html.escape(body_markdown)}</pre>" if body_markdown else ""
+
+    summary_html = "".join(summary_rows)
+
+    return (
+        "<!DOCTYPE html>\n"
+        "<html lang=\"en\">\n"
+        "  <head>\n"
+        "    <meta charset=\"utf-8\" />\n"
+        f"    <title>{html.escape(doc.title)}</title>\n"
+        f"    <meta name=\"description\" content=\"{html.escape(doc.description)}\" />\n"
+        "  </head>\n"
+        "  <body>\n"
+        f"    <h1>{html.escape(doc.title)}</h1>\n"
+        "    <section aria-labelledby=\"feature-summary\">\n"
+        "      <h2 id=\"feature-summary\">Summary</h2>\n"
+        "      <dl>\n"
+        f"{summary_html}"
+        "      </dl>\n"
+        "    </section>\n"
+        "    <section aria-labelledby=\"feature-body\">\n"
+        "      <h2 id=\"feature-body\">Details</h2>\n"
+        f"      {body_html}\n"
+        "    </section>\n"
+        "  </body>\n"
+        "</html>\n"
+    )
+
+
+def write_feature_html(doc: FeatureDoc, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{doc.slug}.html"
+    content = render_feature_html(doc)
+    if output_path.exists() and output_path.read_text(encoding="utf-8") == content:
+        return
+    output_path.write_text(content, encoding="utf-8")
+
+
+def ensure_category(
+    output_dir: Path,
+    *,
+    label: str,
+    title: str,
+    description: str,
+    position: int,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    category_path = output_dir / "_category_.json"
+    if category_path.exists():
+        return
+    payload = {
+        "label": label,
+        "position": position,
+        "link": {
+            "type": "generated-index",
+            "title": title,
+            "description": description,
+        },
+    }
+    category_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def resolve_path(value: str | Path) -> Path:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        return ROOT / candidate
+    return candidate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate Docusaurus documentation pages from the wiki feature markdown files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs/docusaurus/features/generated",
+        type=str,
+        help="Directory where generated markdown files will be written. Relative paths are resolved from the repository root.",
+    )
+    parser.add_argument(
+        "--no-category",
+        action="store_true",
+        help="Skip creating a default _category_.json file in the output directory.",
+    )
+    parser.add_argument(
+        "--category-label",
+        default="Toggle Reference (auto-generated)",
+        help="Label to use for the generated category, when --no-category is not set.",
+    )
+    parser.add_argument(
+        "--category-title",
+        default="Toggle Reference",
+        help="Title for the generated category index, when --no-category is not set.",
+    )
+    parser.add_argument(
+        "--category-description",
+        default="Auto-generated reference pages converted from the historical GitHub wiki.",
+        help="Description for the generated category index, when --no-category is not set.",
+    )
+    parser.add_argument(
+        "--category-position",
+        type=int,
+        default=99,
+        help="Sidebar position for the generated category, when --no-category is not set.",
+    )
+    parser.add_argument(
+        "--html-output-dir",
+        type=str,
+        default=None,
+        help="Optional directory where raw HTML versions of the generated pages will be written.",
+    )
+    args = parser.parse_args()
+
+    output_dir = resolve_path(args.output_dir)
+    html_output_dir = resolve_path(args.html_output_dir) if args.html_output_dir else None
+
+    if not args.no_category:
+        ensure_category(
+            output_dir,
+            label=args.category_label,
+            title=args.category_title,
+            description=args.category_description,
+            position=args.category_position,
+        )
+
+    manual_slugs = parse_manual_slugs()
+    for path in sorted(WIKI_FEATURES.glob("*.md")):
+        doc = extract_feature(path)
+        if not doc:
+            continue
+        if doc.slug in manual_slugs:
+            # Skip generation when a curated guide already exists for this slug.
+            continue
+        write_feature(doc, output_dir)
+        if html_output_dir:
+            write_feature_html(doc, html_output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend the wiki documentation generator to capture metadata needed for HTML rendering and support an optional HTML output directory
- re-run the generator so the wiki pages now include committed HTML artifacts under docs/docusaurus/features/wiki-generated-html

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68efc0422d68832e928f8bd690fdb451