### PR TITLE
Expose settings example helpers for tests

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,6 +36,10 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
+        <notificationGroup id="Advanced Expression Folding"
+                           displayType="BALLOON"
+                           isLogByDefault="true"/>
+
         <!-- Suggests the pseudo-annotation @Main used by the plugin -->
         <completion.contributor
                 language="JAVA"

--- a/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
@@ -1,0 +1,45 @@
+package com.intellij.advancedExpressionFolding.settings.view
+
+import com.intellij.ui.components.ActionLink
+import com.intellij.advancedExpressionFolding.settings.view.Description
+import com.intellij.advancedExpressionFolding.settings.view.ExampleFile
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import java.awt.event.ActionEvent
+import java.awt.event.ActionListener
+import javax.swing.JPanel
+
+class SettingsConfigurableTest {
+
+    @Test
+    fun downloadExamplesActionWithoutProjectDoesNotThrow() {
+        val configurable = SettingsConfigurable()
+        val downloadLink = configurable.createDownloadExamplesLink()
+
+        assertDoesNotThrow {
+            triggerAction(downloadLink)
+        }
+    }
+
+    @Test
+    fun exampleActionWithoutProjectDoesNotThrow() {
+        val configurable = SettingsConfigurable()
+        val examplePanel = createExamplePanel(configurable)
+        val exampleLink = examplePanel.components.filterIsInstance<ActionLink>().first()
+
+        assertDoesNotThrow {
+            triggerAction(exampleLink)
+        }
+    }
+
+    private fun createExamplePanel(configurable: SettingsConfigurable): JPanel {
+        return configurable.createExamplePanel(mapOf<ExampleFile, Description?>("Example.java" to null), null)
+    }
+
+    private fun triggerAction(actionLink: ActionLink) {
+        val event = ActionEvent(actionLink, ActionEvent.ACTION_PERFORMED, actionLink.text)
+        actionLink.getListeners(ActionListener::class.java).forEach { listener ->
+            listener.actionPerformed(event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make the example panel and download link builders internal so tests can invoke them directly
- update SettingsConfigurableTest to use the internal helpers instead of reflection

## Testing
- ./gradlew test --console=plain --no-daemon (fails: Kotlin incremental cache registration error in the container)


------
https://chatgpt.com/codex/tasks/task_e_68daf7a55f6c832ea4ae3620c7ed4116