### PR TITLE
Generalize tracing breakpoint cleanup helper

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
@@ -87,13 +87,21 @@ abstract class AbstractLoggingAnnotationCompletionContributor(
         addLogging(method, body)
     }
 
+    protected open fun shouldRemoveClassLogging(psiClass: PsiClass): Boolean = false
+
+    protected open fun removeClassLogging(psiClass: PsiClass) {}
+
     protected fun applyLogging(psiClass: PsiClass) {
         psiClass.accept(object : PsiRecursiveElementVisitor() {
             override fun visitElement(element: PsiElement) {
                 if (element is PsiClass) {
                     removeAnnotation(element)
-                    element.methods.forEach { applyLogging(it) }
-                    element.constructors.forEach { applyLogging(it) }
+                    if (shouldRemoveClassLogging(element)) {
+                        removeClassLogging(element)
+                    } else {
+                        element.methods.forEach { applyLogging(it) }
+                        element.constructors.forEach { applyLogging(it) }
+                    }
                 }
                 super.visitElement(element)
             }

--- a/test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.PsiTreeUtil
@@ -128,6 +129,33 @@ class TracingLoggableAnnotationCompletionContributorTest : BaseTest() {
         assertEquals(setOf("\"Entering Test.first\" + \" with args: \" + \"value=\" + value", "\"Entering Test.second\""), expressions.toSet())
     }
 
+    @Test
+    fun `should remove tracing breakpoints when selecting @TracingLoggable on already traced class`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                @<caret>
+                public class Test {
+                    public void first(int value) {
+                        System.out.println(value);
+                    }
+
+                    public String second() {
+                        return "ok";
+                    }
+                }
+            """.trimIndent(),
+        )
+
+        selectTracingLoggableCompletion()
+        assertTrue(fileBreakpoints().isNotEmpty(), "Expected tracing breakpoints to be created")
+
+        addAnnotationPlaceholderBeforeClass()
+        selectTracingLoggableCompletion()
+
+        assertTrue(fileBreakpoints().isEmpty(), "Expected tracing breakpoints to be removed")
+    }
+
     private fun selectTracingLoggableCompletion() {
         val completions = fixture.complete(CompletionType.BASIC) ?: error("Expected completion results")
 
@@ -145,6 +173,21 @@ class TracingLoggableAnnotationCompletionContributorTest : BaseTest() {
         val offset = runReadAction {
             PsiTreeUtil.findChildrenOfType(fixture.file, PsiMethod::class.java).first { it.name == methodName }
                 .textRange.startOffset
+        }
+
+        ApplicationManager.getApplication().invokeAndWait {
+            WriteCommandAction.runWriteCommandAction(fixture.project) {
+                fixture.editor.document.insertString(offset, "@\n")
+            }
+            fixture.editor.caretModel.moveToOffset(offset + 1)
+            PsiDocumentManager.getInstance(fixture.project).commitAllDocuments()
+        }
+    }
+
+    private fun addAnnotationPlaceholderBeforeClass() {
+        val offset = runReadAction {
+            PsiTreeUtil.findChildOfType(fixture.file, PsiClass::class.java)?.textRange?.startOffset
+                ?: error("Expected class in file")
         }
 
         ApplicationManager.getApplication().invokeAndWait {


### PR DESCRIPTION
## Summary
- rename the class breakpoint removal helper to removeClassLogBreakpoints and allow optional class names with flexible markers
- reuse the generalized helper from the tracing contributor so class-level cleanup no longer depends on tracing-only assumptions

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f149c412e4832eacf25b5acc205d9c