### PR TITLE
Handle missing project when downloading examples

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,6 +36,10 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
+        <notificationGroup id="Advanced Expression Folding"
+                           displayType="BALLOON"
+                           isLogByDefault="true"/>
+
         <!-- Suggests pseudo-annotations supported by the plugin -->
         <completion.contributor
                 language="JAVA"

--- a/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
@@ -1,0 +1,43 @@
+package com.intellij.advancedExpressionFolding.settings.view
+
+import com.intellij.ui.components.ActionLink
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import java.awt.event.ActionEvent
+import java.awt.event.ActionListener
+import javax.swing.JPanel
+
+class SettingsConfigurableTest {
+
+    @Test
+    fun downloadExamplesActionWithoutProjectDoesNotThrow() {
+        val configurable = SettingsConfigurable()
+        val downloadLink = configurable.createDownloadExamplesLink()
+
+        assertDoesNotThrow {
+            triggerAction(downloadLink)
+        }
+    }
+
+    @Test
+    fun exampleActionWithoutProjectDoesNotThrow() {
+        val configurable = SettingsConfigurable()
+        val examplePanel = createExamplePanel(configurable)
+        val exampleLink = examplePanel.components.filterIsInstance<ActionLink>().first()
+
+        assertDoesNotThrow {
+            triggerAction(exampleLink)
+        }
+    }
+
+    private fun createExamplePanel(configurable: SettingsConfigurable): JPanel {
+        return configurable.createExamplePanel(mapOf<ExampleFile, Description?>("Example.java" to null), null)
+    }
+
+    private fun triggerAction(actionLink: ActionLink) {
+        val event = ActionEvent(actionLink, ActionEvent.ACTION_PERFORMED, actionLink.text)
+        actionLink.getListeners(ActionListener::class.java).forEach { listener ->
+            listener.actionPerformed(event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- register a notification group so example checkout warnings can be delivered
- harden SettingsConfigurable example helpers to warn instead of throwing when no project or source root is available
- add a regression test ensuring the example actions no longer throw when no project is open

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f1ddff9b28832e993415dc53587e9f