### PR TITLE
Group tracing breakpoints by annotation and file name

### DIFF
--- a/examples/data/PseudoAnnotationsLoggableTestData.java
+++ b/examples/data/PseudoAnnotationsLoggableTestData.java
@@ -1,6 +1,11 @@
 package data;
 
 public class PseudoAnnotationsLoggableTestData {
+    public static void main(String[] args) {
+        int value = 0;
+        System.out.println(new PseudoAnnotationsLoggableTestData().returnFromSwitch(value));
+    }
+
 
     public String conditionalReturn(boolean flag) {
         if (flag) {

--- a/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointUtil.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointUtil.kt
@@ -12,11 +12,12 @@ import com.intellij.xdebugger.XDebuggerUtil
 import com.intellij.xdebugger.breakpoints.SuspendPolicy
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint
 import com.intellij.xdebugger.evaluation.EvaluationMode
+import com.intellij.xdebugger.impl.breakpoints.XBreakpointBase
 import kotlin.math.max
 
 object BreakpointUtil {
 
-    fun toggleBreakpoint(project: Project, file: VirtualFile, lineNumber: Int, logExpression: String?) {
+    fun toggleBreakpoint(project: Project, file: VirtualFile, lineNumber: Int, logExpression: String? = null, groupName: String? = null) {
         runReadAction {
             PsiManager.getInstance(project).findFile(file)?.let { psiFile ->
                 PsiDocumentManager.getInstance(project).getDocument(psiFile)
@@ -32,6 +33,7 @@ object BreakpointUtil {
             bpMgr.allBreakpoints.find { it.sourcePosition?.file == file && it.sourcePosition?.line == line }
                 ?.let { bpMgr.removeBreakpoint(it) }
                 ?: bpMgr.addLineBreakpoint(bpType, file.url, line, bpType.createBreakpointProperties(file, line)).apply {
+                    (this as? XBreakpointBase<*, *, *>)?.group = groupName
                     logExpression ?: return@apply
                     suspendPolicy = SuspendPolicy.NONE
                     isLogMessage = true

--- a/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
@@ -2,12 +2,7 @@ package com.intellij.advancedExpressionFolding.pseudo
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiCodeBlock
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiParameter
-import com.intellij.psi.PsiStatement
+import com.intellij.psi.*
 import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.breakpoints.SuspendPolicy
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint
@@ -66,9 +61,9 @@ class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotation
         @Suppress("UNUSED_PARAMETER") exitStatements: List<PsiStatement>,
     ) {
         val target = resolveTarget(method, body) ?: return
-        BreakpointUtil.toggleBreakpoint(method.project, target.file, target.entryLine, buildEntryExpression(method))
+        toggleBreakpoint(method.project, target.file, target.entryLine, buildEntryExpression(method))
         target.exitLine?.let { exitLine ->
-            BreakpointUtil.toggleBreakpoint(method.project, target.file, exitLine, buildExitExpression(method))
+            toggleBreakpoint(method.project, target.file, exitLine, buildExitExpression(method))
         }
     }
 
@@ -79,13 +74,22 @@ class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotation
     ) {
         val target = resolveTarget(method, body) ?: return
         if (hasTracingBreakpoint(method.project, target.file, target.entryLine, buildEntryExpression(method))) {
-            BreakpointUtil.toggleBreakpoint(method.project, target.file, target.entryLine, buildEntryExpression(method))
+            toggleBreakpoint(method.project, target.file, target.entryLine, buildEntryExpression(method))
         }
         target.exitLine?.let { exitLine ->
             if (hasTracingBreakpoint(method.project, target.file, exitLine, buildExitExpression(method))) {
-                BreakpointUtil.toggleBreakpoint(method.project, target.file, exitLine, buildExitExpression(method))
+                toggleBreakpoint(method.project, target.file, exitLine, buildExitExpression(method))
             }
         }
+    }
+
+    private fun toggleBreakpoint(
+        project: Project,
+        file: VirtualFile,
+        exitLine: Int,
+        buildExitExpression: String
+    ) {
+        BreakpointUtil.toggleBreakpoint(project, file, exitLine, buildExitExpression, groupName = "$annotationName-${file.name}")
     }
 
     private fun resolveTarget(method: PsiMethod, body: PsiCodeBlock): LoggingTarget? {


### PR DESCRIPTION
This update improves breakpoint organization in the debugger by grouping tracing breakpoints under their annotation name and file name. This makes them easier to locate and manage in the breakpoints view.

Additionally, all parameters are now passed to the toggleBreakpoint method in TracingLoggableAnnotationCompletionContributor to fully support grouped breakpoint handling.