### PR TITLE
Add bulk toggle controls to settings configurable

### DIFF
--- a/docs/wiki/settings.md
+++ b/docs/wiki/settings.md
@@ -1,0 +1,8 @@
+# Settings
+
+The **Advanced Expression Folding 2** settings page now includes dedicated bulk action buttons:
+
+- **Enable all** – marks every folding option available in the configurable for activation.
+- **Disable all** – clears every folding option, allowing you to quickly start from a clean slate.
+
+After using either button the checkbox list refreshes immediately, so you can review the selected options before applying the changes.


### PR DESCRIPTION
## Summary
- add bulk enable/disable buttons to the settings configurable and sync pending checkbox state during bulk updates
- document the new controls on the settings wiki page

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f1de2e7f44832eac106184e602dd33