### PR TITLE
Add restore defaults bulk action to settings page

### DIFF
--- a/docs/wiki/settings.md
+++ b/docs/wiki/settings.md
@@ -4,5 +4,6 @@ The **Advanced Expression Folding 2** settings page now includes dedicated bulk 
 
 - **Enable all** – marks every folding option available in the configurable for activation.
 - **Disable all** – clears every folding option, allowing you to quickly start from a clean slate.
+- **Restore defaults** – resets every option to the plugin's recommended defaults.
 
 After using either button the checkbox list refreshes immediately, so you can review the selected options before applying the changes.

--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -96,6 +96,9 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
 
     fun disableAll() = updateAllState(false)
     fun enableAll(vararg excludeProperties: KMutableProperty0<Boolean>) = updateAllState(true, *excludeProperties)
+    fun restoreDefaults() {
+        myState = State()
+    }
 
     // used in integrationStubs
     fun enableEverything() = updateAllState(true, state::emojify, state::finalEmoji)

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -127,6 +127,12 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
                 applyBulkChange { disableAll() }
             }
             cell(disableAllButton)
+
+            val restoreDefaultsButton = JButton("Restore defaults")
+            restoreDefaultsButton.addActionListener {
+                applyBulkChange { restoreDefaults() }
+            }
+            cell(restoreDefaultsButton)
         }
         initialize(state)
     }.also {


### PR DESCRIPTION
## Summary
- add a Restore defaults bulk action button alongside Enable all/Disable all
- expose a restoreDefaults helper on AdvancedExpressionFoldingSettings to reset the state
- document the new bulk action in the settings wiki page

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f295eb0ad8832e86b0354973bc65ef