### PR TITLE
Add @Breakpointable pseudo annotation contributor

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,6 +49,9 @@
                 implementationClass="com.intellij.advancedExpressionFolding.pseudo.LoggableAnnotationCompletionContributor"/>
         <completion.contributor
                 language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.pseudo.BreakpointableAnnotationCompletionContributor"/>
+        <completion.contributor
+                language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.pseudo.TracingLoggableAnnotationCompletionContributor"/>
     </extensions>
 

--- a/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointableAnnotationCompletionContributor.kt
@@ -1,0 +1,23 @@
+package com.intellij.advancedExpressionFolding.pseudo
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+class BreakpointableAnnotationCompletionContributor : TracingLoggableAnnotationCompletionContributor() {
+
+    override val annotationName: String = "Breakpointable"
+
+    override fun toggleBreakpoint(
+        project: Project,
+        file: VirtualFile,
+        lineNumber: Int,
+        logExpression: String,
+    ) {
+        BreakpointUtil.toggleBreakpoint(
+            project,
+            file,
+            lineNumber,
+            groupName = "$annotationName-${file.name}",
+        )
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
@@ -7,7 +7,7 @@ import com.intellij.xdebugger.XDebuggerManager
 import com.intellij.xdebugger.breakpoints.SuspendPolicy
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint
 
-class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotationCompletionContributor() {
+open class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotationCompletionContributor() {
 
     override val annotationName: String = "TracingLoggable"
 
@@ -83,13 +83,19 @@ class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotation
         }
     }
 
-    private fun toggleBreakpoint(
+    protected open fun toggleBreakpoint(
         project: Project,
         file: VirtualFile,
-        exitLine: Int,
-        buildExitExpression: String
+        lineNumber: Int,
+        logExpression: String,
     ) {
-        BreakpointUtil.toggleBreakpoint(project, file, exitLine, buildExitExpression, groupName = "$annotationName-${file.name}")
+        BreakpointUtil.toggleBreakpoint(
+            project,
+            file,
+            lineNumber,
+            logExpression,
+            groupName = "$annotationName-${file.name}",
+        )
     }
 
     private fun resolveTarget(method: PsiMethod, body: PsiCodeBlock): LoggingTarget? {


### PR DESCRIPTION
## Summary
- allow TracingLoggable completion contributor to be extended and customize breakpoint toggling
- add Breakpointable pseudo-annotation completion contributor that toggles breakpoints without log expressions
- register the new contributor in the plugin descriptor

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f29f433410832e9b16b640f65741a9