### PR TITLE
Normalize const folding for modifier permutations

### DIFF
--- a/folded/ConstTestData-folded.java
+++ b/folded/ConstTestData-folded.java
@@ -34,20 +34,20 @@ public class ConstTestData {
     protected const PROTECTED_FINAL_STATIC_VAR = "";
 
     const STATIC_PUBLIC_FINAL_VAR = "";
-    static private final String STATIC_PRIVATE_FINAL_VAR = "";
-    static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+    private const STATIC_PRIVATE_FINAL_VAR = "";
+    protected const STATIC_PROTECTED_FINAL_VAR = "";
 
     const STATIC_FINAL_PUBLIC_VAR = "";
-    static final private String STATIC_FINAL_PRIVATE_VAR = "";
-    static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+    private const STATIC_FINAL_PRIVATE_VAR = "";
+    protected const STATIC_FINAL_PROTECTED_VAR = "";
 
     const FINAL_PUBLIC_STATIC_VAR = "";
-    final private static String FINAL_PRIVATE_STATIC_VAR = "";
-    final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+    private const FINAL_PRIVATE_STATIC_VAR = "";
+    protected const FINAL_PROTECTED_STATIC_VAR = "";
 
     const FINAL_STATIC_PUBLIC_VAR = "";
-    final static private String FINAL_STATIC_PRIVATE_VAR = "";
-    final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+    private const FINAL_STATIC_PRIVATE_VAR = "";
+    protected const FINAL_STATIC_PROTECTED_VAR = "";
 
     public static String PUBLIC_STATIC_VAR = "";
     private static String PRIVATE_STATIC_VAR = "";
@@ -124,37 +124,37 @@ public class ConstTestData {
         const STATIC_PUBLIC_FINAL_VAR = "";
 
         @Deprecated
-        static private final String STATIC_PRIVATE_FINAL_VAR = "";
+        private const STATIC_PRIVATE_FINAL_VAR = "";
 
         @Deprecated
-        static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+        protected const STATIC_PROTECTED_FINAL_VAR = "";
 
         @Deprecated
         const STATIC_FINAL_PUBLIC_VAR = "";
 
         @Deprecated
-        static final private String STATIC_FINAL_PRIVATE_VAR = "";
+        private const STATIC_FINAL_PRIVATE_VAR = "";
 
         @Deprecated
-        static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+        protected const STATIC_FINAL_PROTECTED_VAR = "";
 
         @Deprecated
         const FINAL_PUBLIC_STATIC_VAR = "";
 
         @Deprecated
-        final private static String FINAL_PRIVATE_STATIC_VAR = "";
+        private const FINAL_PRIVATE_STATIC_VAR = "";
 
         @Deprecated
-        final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+        protected const FINAL_PROTECTED_STATIC_VAR = "";
 
         @Deprecated
         const FINAL_STATIC_PUBLIC_VAR = "";
 
         @Deprecated
-        final static private String FINAL_STATIC_PRIVATE_VAR = "";
+        private const FINAL_STATIC_PRIVATE_VAR = "";
 
         @Deprecated
-        final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+        protected const FINAL_STATIC_PROTECTED_VAR = "";
 
         @Deprecated
         public static String PUBLIC_STATIC_VAR = "";

--- a/testData/ConstTestData-all.java
+++ b/testData/ConstTestData-all.java
@@ -20,8 +20,8 @@ public class ConstTestData {
     <fold text='default econst' expand='false'>static final</fold> EOrder ENUM_STATIC_IMPORT = SECOND;
 
     <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
-    protected <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
+    <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
+    <fold text='protected const' expand='false'>protected static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
     <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> DEFAULT_STATIC_FINAL_VAR = "";
 
     <fold text='const' expand='false'>public static final</fold> String STRING_JOINER = "<fold text='' expand='false'>" + "</fold>1";
@@ -30,24 +30,24 @@ public class ConstTestData {
     <fold text='const' expand='false'>public static final</fold> String STRING_JOINER4 = DEFAULT_STATIC_FINAL_VAR + PROTECTED_STATIC_FINAL_VAR + PUBLIC_STATIC_FINAL_VAR;
 
     <fold text='const' expand='false'>public final static </fold><fold text='' expand='false'>String</fold> PUBLIC_FINAL_STATIC_VAR = "";
-    private <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
-    protected <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
+    <fold text='private const' expand='false'>private final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
+    <fold text='protected const' expand='false'>protected final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
 
     <fold text='const' expand='false'>static public final </fold><fold text='' expand='false'>String</fold> STATIC_PUBLIC_FINAL_VAR = "";
-    static private final String STATIC_PRIVATE_FINAL_VAR = "";
-    static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+    <fold text='private const' expand='false'>static private final </fold><fold text='' expand='false'>String</fold> STATIC_PRIVATE_FINAL_VAR = "";
+    <fold text='protected const' expand='false'>static protected final </fold><fold text='' expand='false'>String</fold> STATIC_PROTECTED_FINAL_VAR = "";
 
     <fold text='const' expand='false'>static final public </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PUBLIC_VAR = "";
-    static final private String STATIC_FINAL_PRIVATE_VAR = "";
-    static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+    <fold text='private const' expand='false'>static final private </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PRIVATE_VAR = "";
+    <fold text='protected const' expand='false'>static final protected </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PROTECTED_VAR = "";
 
     <fold text='const' expand='false'>final public static </fold><fold text='' expand='false'>String</fold> FINAL_PUBLIC_STATIC_VAR = "";
-    final private static String FINAL_PRIVATE_STATIC_VAR = "";
-    final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+    <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_PRIVATE_STATIC_VAR = "";
+    <fold text='protected const' expand='false'>final protected static </fold><fold text='' expand='false'>String</fold> FINAL_PROTECTED_STATIC_VAR = "";
 
     <fold text='const' expand='false'>final static public </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PUBLIC_VAR = "";
-    final static private String FINAL_STATIC_PRIVATE_VAR = "";
-    final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+    <fold text='private const' expand='false'>final static private </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PRIVATE_VAR = "";
+    <fold text='protected const' expand='false'>final static protected </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PROTECTED_VAR = "";
 
     public static String PUBLIC_STATIC_VAR = "";
     private static String PRIVATE_STATIC_VAR = "";
@@ -91,10 +91,10 @@ public class ConstTestData {
         <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
 
         @Deprecated
-        private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
+        <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
 
         @Deprecated
-        protected <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
+        <fold text='protected const' expand='false'>protected static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
 
         @Deprecated
         <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> DEFAULT_STATIC_FINAL_VAR = "";
@@ -115,46 +115,46 @@ public class ConstTestData {
         <fold text='const' expand='false'>public final static </fold><fold text='' expand='false'>String</fold> PUBLIC_FINAL_STATIC_VAR = "";
 
         @Deprecated
-        private <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
+        <fold text='private const' expand='false'>private final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
 
         @Deprecated
-        protected <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
+        <fold text='protected const' expand='false'>protected final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>static public final </fold><fold text='' expand='false'>String</fold> STATIC_PUBLIC_FINAL_VAR = "";
 
         @Deprecated
-        static private final String STATIC_PRIVATE_FINAL_VAR = "";
+        <fold text='private const' expand='false'>static private final </fold><fold text='' expand='false'>String</fold> STATIC_PRIVATE_FINAL_VAR = "";
 
         @Deprecated
-        static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+        <fold text='protected const' expand='false'>static protected final </fold><fold text='' expand='false'>String</fold> STATIC_PROTECTED_FINAL_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>static final public </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PUBLIC_VAR = "";
 
         @Deprecated
-        static final private String STATIC_FINAL_PRIVATE_VAR = "";
+        <fold text='private const' expand='false'>static final private </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PRIVATE_VAR = "";
 
         @Deprecated
-        static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+        <fold text='protected const' expand='false'>static final protected </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PROTECTED_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>final public static </fold><fold text='' expand='false'>String</fold> FINAL_PUBLIC_STATIC_VAR = "";
 
         @Deprecated
-        final private static String FINAL_PRIVATE_STATIC_VAR = "";
+        <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_PRIVATE_STATIC_VAR = "";
 
         @Deprecated
-        final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+        <fold text='protected const' expand='false'>final protected static </fold><fold text='' expand='false'>String</fold> FINAL_PROTECTED_STATIC_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>final static public </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PUBLIC_VAR = "";
 
         @Deprecated
-        final static private String FINAL_STATIC_PRIVATE_VAR = "";
+        <fold text='private const' expand='false'>final static private </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PRIVATE_VAR = "";
 
         @Deprecated
-        final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+        <fold text='protected const' expand='false'>final static protected </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PROTECTED_VAR = "";
 
         @Deprecated
         public static String PUBLIC_STATIC_VAR = "";

--- a/testData/ConstTestData.java
+++ b/testData/ConstTestData.java
@@ -20,8 +20,8 @@ public class ConstTestData {
     <fold text='default econst' expand='false'>static final</fold> EOrder ENUM_STATIC_IMPORT = SECOND;
 
     <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
-    protected <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
+    <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
+    <fold text='protected const' expand='false'>protected static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
     <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> DEFAULT_STATIC_FINAL_VAR = "";
 
     <fold text='const' expand='false'>public static final</fold> String STRING_JOINER = "" + "1";
@@ -30,24 +30,24 @@ public class ConstTestData {
     <fold text='const' expand='false'>public static final</fold> String STRING_JOINER4 = DEFAULT_STATIC_FINAL_VAR + PROTECTED_STATIC_FINAL_VAR + PUBLIC_STATIC_FINAL_VAR;
 
     <fold text='const' expand='false'>public final static </fold><fold text='' expand='false'>String</fold> PUBLIC_FINAL_STATIC_VAR = "";
-    private <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
-    protected <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
+    <fold text='private const' expand='false'>private final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
+    <fold text='protected const' expand='false'>protected final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
 
     <fold text='const' expand='false'>static public final </fold><fold text='' expand='false'>String</fold> STATIC_PUBLIC_FINAL_VAR = "";
-    static private final String STATIC_PRIVATE_FINAL_VAR = "";
-    static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+    <fold text='private const' expand='false'>static private final </fold><fold text='' expand='false'>String</fold> STATIC_PRIVATE_FINAL_VAR = "";
+    <fold text='protected const' expand='false'>static protected final </fold><fold text='' expand='false'>String</fold> STATIC_PROTECTED_FINAL_VAR = "";
 
     <fold text='const' expand='false'>static final public </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PUBLIC_VAR = "";
-    static final private String STATIC_FINAL_PRIVATE_VAR = "";
-    static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+    <fold text='private const' expand='false'>static final private </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PRIVATE_VAR = "";
+    <fold text='protected const' expand='false'>static final protected </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PROTECTED_VAR = "";
 
     <fold text='const' expand='false'>final public static </fold><fold text='' expand='false'>String</fold> FINAL_PUBLIC_STATIC_VAR = "";
-    final private static String FINAL_PRIVATE_STATIC_VAR = "";
-    final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+    <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_PRIVATE_STATIC_VAR = "";
+    <fold text='protected const' expand='false'>final protected static </fold><fold text='' expand='false'>String</fold> FINAL_PROTECTED_STATIC_VAR = "";
 
     <fold text='const' expand='false'>final static public </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PUBLIC_VAR = "";
-    final static private String FINAL_STATIC_PRIVATE_VAR = "";
-    final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+    <fold text='private const' expand='false'>final static private </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PRIVATE_VAR = "";
+    <fold text='protected const' expand='false'>final static protected </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PROTECTED_VAR = "";
 
     public static String PUBLIC_STATIC_VAR = "";
     private static String PRIVATE_STATIC_VAR = "";
@@ -91,10 +91,10 @@ public class ConstTestData {
         <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
 
         @Deprecated
-        private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
+        <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>String</fold> PRIVATE_STATIC_FINAL_VAR = "";
 
         @Deprecated
-        protected <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
+        <fold text='protected const' expand='false'>protected static final </fold><fold text='' expand='false'>String</fold> PROTECTED_STATIC_FINAL_VAR = "";
 
         @Deprecated
         <fold text='default const' expand='false'>static final </fold><fold text='' expand='false'>String</fold> DEFAULT_STATIC_FINAL_VAR = "";
@@ -115,46 +115,46 @@ public class ConstTestData {
         <fold text='const' expand='false'>public final static </fold><fold text='' expand='false'>String</fold> PUBLIC_FINAL_STATIC_VAR = "";
 
         @Deprecated
-        private <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
+        <fold text='private const' expand='false'>private final static </fold><fold text='' expand='false'>String</fold> PRIVATE_FINAL_STATIC_VAR = "";
 
         @Deprecated
-        protected <fold text='const' expand='false'>final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
+        <fold text='protected const' expand='false'>protected final static </fold><fold text='' expand='false'>String</fold> PROTECTED_FINAL_STATIC_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>static public final </fold><fold text='' expand='false'>String</fold> STATIC_PUBLIC_FINAL_VAR = "";
 
         @Deprecated
-        static private final String STATIC_PRIVATE_FINAL_VAR = "";
+        <fold text='private const' expand='false'>static private final </fold><fold text='' expand='false'>String</fold> STATIC_PRIVATE_FINAL_VAR = "";
 
         @Deprecated
-        static protected final String STATIC_PROTECTED_FINAL_VAR = "";
+        <fold text='protected const' expand='false'>static protected final </fold><fold text='' expand='false'>String</fold> STATIC_PROTECTED_FINAL_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>static final public </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PUBLIC_VAR = "";
 
         @Deprecated
-        static final private String STATIC_FINAL_PRIVATE_VAR = "";
+        <fold text='private const' expand='false'>static final private </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PRIVATE_VAR = "";
 
         @Deprecated
-        static final protected String STATIC_FINAL_PROTECTED_VAR = "";
+        <fold text='protected const' expand='false'>static final protected </fold><fold text='' expand='false'>String</fold> STATIC_FINAL_PROTECTED_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>final public static </fold><fold text='' expand='false'>String</fold> FINAL_PUBLIC_STATIC_VAR = "";
 
         @Deprecated
-        final private static String FINAL_PRIVATE_STATIC_VAR = "";
+        <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_PRIVATE_STATIC_VAR = "";
 
         @Deprecated
-        final protected static String FINAL_PROTECTED_STATIC_VAR = "";
+        <fold text='protected const' expand='false'>final protected static </fold><fold text='' expand='false'>String</fold> FINAL_PROTECTED_STATIC_VAR = "";
 
         @Deprecated
         <fold text='const' expand='false'>final static public </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PUBLIC_VAR = "";
 
         @Deprecated
-        final static private String FINAL_STATIC_PRIVATE_VAR = "";
+        <fold text='private const' expand='false'>final static private </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PRIVATE_VAR = "";
 
         @Deprecated
-        final static protected String FINAL_STATIC_PROTECTED_VAR = "";
+        <fold text='protected const' expand='false'>final static protected </fold><fold text='' expand='false'>String</fold> FINAL_STATIC_PROTECTED_VAR = "";
 
         @Deprecated
         public static String PUBLIC_STATIC_VAR = "";

--- a/testData/ConstructorReferenceNotationTestData-all.java
+++ b/testData/ConstructorReferenceNotationTestData-all.java
@@ -12,16 +12,16 @@ public class ConstructorReferenceNotationTestData {
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_SUB_ANN = new SubConstClass() <fold text='{...}' expand='true'>{
         }</fold>;
 
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold></fold><fold text='' expand='true'>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP3 = new HashMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP4 = Map.of();
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold></fold><fold text='' expand='true'>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP3 = new HashMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP4 = Map.of();
 
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST = <fold text='[]' expand='false'>new ArrayList<>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST2 = List.of();
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_SINGLE = List.of("1");
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_LINKED = new LinkedList<>();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST = <fold text='[]' expand='false'>new ArrayList<>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST2 = List.of();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_SINGLE = List.of("1");
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_LINKED = new LinkedList<>();
 
 
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_PARAM_1 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>ConstClass</fold>(true);

--- a/testData/ConstructorReferenceNotationWithConstTestData-all.java
+++ b/testData/ConstructorReferenceNotationWithConstTestData-all.java
@@ -12,16 +12,16 @@ public class ConstructorReferenceNotationWithConstTestData {
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_SUB_ANN = new SubConstClass() <fold text='{...}' expand='true'>{
         }</fold>;
 
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold></fold><fold text='' expand='true'>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP3 = new HashMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP4 = Map.of();
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold></fold><fold text='' expand='true'>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP3 = new HashMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP4 = Map.of();
 
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST = <fold text='[]' expand='false'>new ArrayList<>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST2 = List.of();
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_SINGLE = List.of("1");
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_LINKED = new LinkedList<>();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST = <fold text='[]' expand='false'>new ArrayList<>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST2 = List.of();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_SINGLE = List.of("1");
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_LINKED = new LinkedList<>();
 
 
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_PARAM_1 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>ConstClass</fold>(true);

--- a/testData/ConstructorReferenceNotationWithConstTestData.java
+++ b/testData/ConstructorReferenceNotationWithConstTestData.java
@@ -12,16 +12,16 @@ public class ConstructorReferenceNotationWithConstTestData {
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_SUB_ANN = new SubConstClass() <fold text='{...}' expand='true'>{
         }</fold>;
 
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold><fold text='' expand='true'></fold>()</fold>;
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP3 = new HashMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
-        private <fold text='const' expand='false'>static final</fold> Map<String, String> MAP4 = Map.of();
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<></fold><fold text='' expand='true'>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> HashMap<String, String> MAP2 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>HashMap<fold text='<~>' expand='false'><String, String></fold><fold text='' expand='true'></fold>()</fold>;
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP3 = new HashMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP_TREE = new TreeMap<>();
+        <fold text='private const' expand='false'>private static final</fold> Map<String, String> MAP4 = Map.of();
 
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST = new ArrayList<>();
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST2 = List.of();
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_SINGLE = List.of("1");
-        private <fold text='const' expand='false'>static final</fold> List<String> LIST_LINKED = new LinkedList<>();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST = new ArrayList<>();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST2 = List.of();
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_SINGLE = List.of("1");
+        <fold text='private const' expand='false'>private static final</fold> List<String> LIST_LINKED = new LinkedList<>();
 
 
         <fold text='const' expand='false'>public static final</fold> ConstClass SELF_PARAM_1 =<fold text=' ::' expand='true'> </fold>new<fold text='' expand='true'> </fold><fold text='' expand='true'>ConstClass</fold>(true);

--- a/testData/FinalEmojiTestData-all.java
+++ b/testData/FinalEmojiTestData-all.java
@@ -3,7 +3,7 @@ package data;
 public class FinalEmojiTestData {
 
     <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
-    final private static String FINAL_FIRST_MANY = "";
+    <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_FIRST_MANY = "";
     final String ONLY_FINAL = "";
 
     public <fold text='' expand='false'>final</fold> String m() <fold text='{...}' expand='true'>{

--- a/testData/FinalRemovalTestData-all.java
+++ b/testData/FinalRemovalTestData-all.java
@@ -3,7 +3,7 @@ package data;
 public class FinalRemovalTestData {
 
     <fold text='const' expand='false'>public static final </fold><fold text='' expand='false'>String</fold> PUBLIC_STATIC_FINAL_VAR = "";
-    final private static String FINAL_FIRST_MANY = "";
+    <fold text='private const' expand='false'>final private static </fold><fold text='' expand='false'>String</fold> FINAL_FIRST_MANY = "";
     final String ONLY_FINAL = "";
 
     public <fold text='' expand='false'>final</fold> String m() <fold text='{...}' expand='true'>{

--- a/testData/LogBrackets-all.java
+++ b/testData/LogBrackets-all.java
@@ -13,8 +13,8 @@ import java.util.Formatter;</fold>
 @SuppressWarnings("ALL")
 <fold text='@Log p' expand='false'>p</fold>ublic class LogBrackets {<fold text='' expand='false'>
 
-    </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Logger</fold> log = LoggerFactory.getLogger(LogBrackets.class);</fold>
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Marker</fold> MY_MARKER = MarkerFactory.getMarker("MY_MARKER");
+    </fold><fold text='private const' expand='false'><fold text='' expand='false'>private static final </fold><fold text='' expand='false'>Logger</fold> log = LoggerFactory.getLogger(LogBrackets.class);</fold>
+    <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>Marker</fold> MY_MARKER = MarkerFactory.getMarker("MY_MARKER");
 
     public Data logPrintfStyle(Data data) <fold text='{...}' expand='true'>{
         <fold text='val' expand='false'>String</fold> name = "John";

--- a/testData/LogFoldingTextBlocksTestData-all.java
+++ b/testData/LogFoldingTextBlocksTestData-all.java
@@ -13,9 +13,9 @@ import java.util.Formatter;</fold>
 @SuppressWarnings("ALL")
 <fold text='@Log p' expand='false'>p</fold>ublic class LogFoldingTextBlocksTestData {<fold text='' expand='false'>
 
-    </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Logger</fold> log = LoggerFactory.getLogger(LogFoldingTextBlocksTestData.class);</fold>
+    </fold><fold text='private const' expand='false'><fold text='' expand='false'>private static final </fold><fold text='' expand='false'>Logger</fold> log = LoggerFactory.getLogger(LogFoldingTextBlocksTestData.class);</fold>
 
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Marker</fold> MY_MARKER = MarkerFactory.getMarker("MY_MARKER");
+    <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>Marker</fold> MY_MARKER = MarkerFactory.getMarker("MY_MARKER");
 
     public LogBrackets.Data logPrintfStyle(LogBrackets.Data data) <fold text='{...}' expand='true'>{
         <fold text='val' expand='false'>String</fold> name = "John";

--- a/testData/LombokPatternOffNegativeTestData-all.java
+++ b/testData/LombokPatternOffNegativeTestData-all.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;</fold>
 @SuppressWarnings("ALL")
 <fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokPatternOffNegativeTestData {<fold text='' expand='false'>
 
-    </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
+    </fold><fold text='private const' expand='false'><fold text='' expand='false'>private static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
 
     LombokPatternOffNegativeTestData data;
     boolean ok;

--- a/testData/LombokPatternOffTestData-all.java
+++ b/testData/LombokPatternOffTestData-all.java
@@ -18,7 +18,7 @@ import java.util.logging.Logger;</fold>
 @SuppressWarnings("ALL")
 public class LombokPatternOffTestData {
 
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;
+    <fold text='private const' expand='false'>private static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;
 
     LombokPatternOffTestData data;
     boolean ok;

--- a/testData/LombokTestData-all.java
+++ b/testData/LombokTestData-all.java
@@ -17,7 +17,7 @@ import java.util.logging.Logger;</fold>
 @SuppressWarnings("ALL")
 <fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokTestData {<fold text='' expand='false'>
 
-    </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
+    </fold><fold text='private const' expand='false'><fold text='' expand='false'>private static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
 
     LombokTestData data;
     boolean ok;


### PR DESCRIPTION
## Summary
- normalize `FieldConstExpression` folding detection so private/protected modifiers are handled regardless of position
- expand `ConstTestData` (and folded output) plus constructor reference fixtures to cover the new const permutations
- refresh Lombok, log, and final `-all` suites so const expectations match the new placeholders

## Testing
- ./gradlew test --console=plain --no-parallel --no-build-cache

------
https://chatgpt.com/codex/tasks/task_e_68d1af00d868832e9b0dddaa0cc549cf