### PR TITLE
Add settings preview editor with live folding updates

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -77,6 +77,7 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
         override var experimental: Boolean = false,
 
         override var globalOn: Boolean = true,
+        var previewSnippet: String = FoldingPreviewDefaults.DEFAULT_SNIPPET,
 
         ) : IState, IConfig
 

--- a/src/com/intellij/advancedExpressionFolding/settings/FoldingPreviewDefaults.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/FoldingPreviewDefaults.kt
@@ -1,0 +1,21 @@
+package com.intellij.advancedExpressionFolding.settings
+
+object FoldingPreviewDefaults {
+    const val FILE_NAME = "PreviewSnippet.java"
+
+    val DEFAULT_SNIPPET: String = """
+        import java.util.Optional;
+
+        public class PreviewSample {
+            private String name;
+
+            public void demonstrate(String input) {
+                System.out.println("Hello " + input);
+            }
+
+            public void printName() {
+                System.out.println(name);
+            }
+        }
+    """.trimIndent()
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/StateDelegate.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/StateDelegate.kt
@@ -1,3 +1,40 @@
 package com.intellij.advancedExpressionFolding.settings
 
-open class StateDelegate(private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.Companion.getInstance().state) : IState by state
+import java.lang.reflect.Proxy
+
+open class StateDelegate(
+    private val defaultState: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.Companion.getInstance().state
+) : IState by stateProxy(defaultState) {
+
+    companion object {
+        private val overrideState = ThreadLocal<AdvancedExpressionFoldingSettings.State?>()
+
+        fun <T> withState(state: AdvancedExpressionFoldingSettings.State, block: () -> T): T {
+            val previous = overrideState.get()
+            overrideState.set(state)
+            return try {
+                block()
+            } finally {
+                if (previous == null) {
+                    overrideState.remove()
+                } else {
+                    overrideState.set(previous)
+                }
+            }
+        }
+
+        private fun currentState(defaultState: AdvancedExpressionFoldingSettings.State): AdvancedExpressionFoldingSettings.State {
+            return overrideState.get() ?: defaultState
+        }
+
+        private fun stateProxy(defaultState: AdvancedExpressionFoldingSettings.State): IState {
+            val provider = { currentState(defaultState) }
+            return Proxy.newProxyInstance(
+                IState::class.java.classLoader,
+                arrayOf(IState::class.java)
+            ) { _, method, args ->
+                method.invoke(provider(), *(args ?: emptyArray()))
+            } as IState
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/FoldingPreviewPanel.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/FoldingPreviewPanel.kt
@@ -1,0 +1,249 @@
+package com.intellij.advancedExpressionFolding.settings.view
+
+import com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder
+import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorEx
+import com.intellij.advancedExpressionFolding.diff.FoldingTemporaryEditor
+import com.intellij.advancedExpressionFolding.diff.Range
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.FoldingPreviewDefaults
+import com.intellij.advancedExpressionFolding.settings.StateDelegate
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.util.Disposer
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.PsiJavaFile
+import com.intellij.ui.EditorTextField
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import org.jetbrains.annotations.TestOnly
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.datatransfer.StringSelection
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.Box
+
+class FoldingPreviewPanel(
+    initialState: AdvancedExpressionFoldingSettings.State,
+    initialSnippet: String,
+    private val onSnippetChanged: (String) -> Unit,
+    private val defaultSnippetProvider: () -> String = { FoldingPreviewDefaults.DEFAULT_SNIPPET },
+    project: Project = ProjectManager.getInstance().defaultProject
+) : Disposable {
+    val component: JComponent get() = rootPanel
+    val previewText: String get() = latestPreview
+
+    private val project: Project = project
+    private val snippetDocument = EditorFactory.getInstance().createDocument(initialSnippet)
+    private val resultDocument = EditorFactory.getInstance().createDocument("")
+    private val snippetField = PreviewEditorTextField(snippetDocument, project, JavaLanguage.INSTANCE.associatedFileType!!, false, false)
+    private val resultField = PreviewEditorTextField(resultDocument, project, JavaLanguage.INSTANCE.associatedFileType!!, true, false).apply {
+        setViewer(true)
+    }
+    private val rootPanel = JPanel(BorderLayout())
+    private var listenersEnabled = true
+    private var currentState = initialState.copy()
+    private var latestPreview: String = ""
+    private var lastDescriptorCount: Int = 0
+    private var lastPlaceholders: List<String?> = emptyList()
+    private val disposable = Disposer.newDisposable("FoldingPreviewPanel")
+
+    init {
+        Disposer.register(disposable, snippetField)
+        Disposer.register(disposable, resultField)
+        configureSnippetField()
+        configureResultField()
+        MethodCallFactory.initialize()
+        rootPanel.border = JBUI.Borders.empty(8, 0, 0, 0)
+        rootPanel.add(createContentPanel(), BorderLayout.CENTER)
+        rootPanel.add(createActionsPanel(), BorderLayout.SOUTH)
+        rebuildPreview()
+    }
+
+    fun updatePreview(state: AdvancedExpressionFoldingSettings.State) {
+        currentState = state.copy()
+        rebuildPreview()
+    }
+
+    fun setSnippet(snippet: String, trackModification: Boolean) {
+        listenersEnabled = false
+        snippetField.text = snippet
+        listenersEnabled = true
+        if (trackModification) {
+            onSnippetChanged(snippet)
+        }
+        rebuildPreview()
+    }
+
+    private fun configureSnippetField() {
+        snippetField.border = JBUI.Borders.empty()
+        snippetField.setOneLineMode(false)
+        snippetField.preferredSize = Dimension(0, 180)
+        snippetField.document.addDocumentListener(object : DocumentListener {
+            override fun documentChanged(event: DocumentEvent) {
+                if (!listenersEnabled) {
+                    return
+                }
+                val text = event.document.text
+                onSnippetChanged(text)
+                rebuildPreview(text)
+            }
+        })
+    }
+
+    private fun configureResultField() {
+        resultField.border = JBUI.Borders.empty()
+        resultField.setOneLineMode(false)
+        resultField.preferredSize = Dimension(0, 180)
+    }
+
+    private fun createContentPanel(): JComponent {
+        val sections = JPanel()
+        sections.layout = javax.swing.BoxLayout(sections, javax.swing.BoxLayout.Y_AXIS)
+        sections.border = JBUI.Borders.empty()
+        sections.add(createSection("Preview snippet", snippetField))
+        sections.add(Box.createVerticalStrut(JBUI.scale(8)))
+        sections.add(createSection("Folded preview", resultField))
+        return sections
+    }
+
+    private fun createActionsPanel(): JComponent {
+        val panel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(5), 0))
+        val resetButton = JButton("Reset snippet")
+        resetButton.addActionListener {
+            setSnippet(defaultSnippetProvider(), trackModification = true)
+        }
+        val copyButton = JButton("Copy result")
+        copyButton.addActionListener {
+            CopyPasteManager.getInstance().setContents(StringSelection(previewText))
+        }
+        panel.add(resetButton)
+        panel.add(copyButton)
+        return panel
+    }
+
+    private fun createSection(title: String, field: EditorTextField): JComponent {
+        val panel = JPanel(BorderLayout())
+        panel.border = JBUI.Borders.empty()
+        panel.add(JBLabel(title), BorderLayout.NORTH)
+        panel.add(JBScrollPane(field), BorderLayout.CENTER)
+        return panel
+    }
+
+    private fun rebuildPreview(snippet: String = snippetField.text) {
+        val preview = if (snippet.isBlank()) {
+            ""
+        } else {
+            runCatching { computePreview(snippet, currentState.copy()) }.getOrElse { snippet }
+        }
+        latestPreview = preview
+        resultField.text = preview
+        resultField.editor?.caretModel?.moveToOffset(0)
+    }
+
+    private fun computePreview(
+        snippet: String,
+        state: AdvancedExpressionFoldingSettings.State
+    ): String {
+        val project = this.project
+        return StateDelegate.withState(state) {
+            val (document, descriptors) = ApplicationManager.getApplication().runReadAction(Computable {
+                val psiFile = PsiFileFactory.getInstance(project)
+                    .createFileFromText(
+                        FoldingPreviewDefaults.FILE_NAME,
+                        JavaLanguage.INSTANCE,
+                        snippet,
+                        true,
+                        false
+                    ) as PsiJavaFile
+                val documentManager = PsiDocumentManager.getInstance(project)
+                val document = documentManager.getDocument(psiFile) ?: return@Computable null
+                documentManager.commitDocument(document)
+                val builder = AdvancedExpressionFoldingBuilder(state)
+                val foldingDescriptors = builder.buildFoldRegions(psiFile, document, false)
+                val foldingGroupSet = mutableSetOf<FoldingGroup>()
+                val converted = foldingDescriptors.mapIndexed { index, descriptor ->
+                    descriptor.group?.let { foldingGroupSet += it }
+                    FoldingDescriptorEx(
+                        index,
+                        document.getText(descriptor.range),
+                        descriptor.placeholderText,
+                        Range(
+                            descriptor.range.startOffset,
+                            descriptor.range.endOffset,
+                            descriptor.range.length
+                        ),
+                        descriptor.group?.toSimpleString(),
+                        foldingGroupSet.size - 1
+                    )
+                }
+                lastDescriptorCount = converted.size
+                lastPlaceholders = converted.map { it.placeholder }
+                document to converted
+            }) ?: return@withState snippet
+
+            ApplicationManager.getApplication().runWriteAction(Computable {
+                FoldingTemporaryEditor.foldInEditor(document.text, descriptors)
+            })
+        }
+    }
+
+    private fun FoldingGroup?.toSimpleString(): String? {
+        return this?.toString()?.let {
+            val dotIndex = it.lastIndexOf('.')
+            if (dotIndex >= 0 && dotIndex < it.length - 1) {
+                it.substring(dotIndex + 1)
+            } else {
+                it
+            }
+        }
+    }
+
+    @TestOnly
+    internal fun descriptorCountForTests(): Int = lastDescriptorCount
+
+    @TestOnly
+    internal fun placeholdersForTests(): List<String?> = lastPlaceholders
+
+    override fun dispose() {
+        Disposer.dispose(disposable)
+    }
+}
+
+private class PreviewEditorTextField(
+    document: Document,
+    project: Project,
+    fileType: FileType,
+    isViewer: Boolean,
+    oneLineMode: Boolean
+) : EditorTextField(document, project, fileType, isViewer, oneLineMode), Disposable {
+
+    private val createdEditors = mutableSetOf<EditorEx>()
+
+    override fun createEditor(): EditorEx {
+        return super.createEditor().also { createdEditors += it }
+    }
+
+    override fun dispose() {
+        val factory = EditorFactory.getInstance()
+        createdEditors.forEach { factory.releaseEditor(it) }
+        createdEditors.clear()
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/settings/SettingsPreviewIntegrationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/SettingsPreviewIntegrationTest.kt
@@ -1,0 +1,54 @@
+package com.intellij.advancedExpressionFolding.settings
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.advancedExpressionFolding.settings.view.SettingsConfigurable
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.testFramework.runInEdtAndGet
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.util.ui.UIUtil
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SettingsPreviewIntegrationTest : BaseTest() {
+
+    @Test
+    fun previewUpdatesWhenTogglingPrintln() {
+        val configurable = object : SettingsConfigurable() {
+            override fun currentProjectOrDefault() = this@SettingsPreviewIntegrationTest.fixture.project
+        }
+        val dialogPanel: DialogPanel = runInEdtAndGet { configurable.createComponent() }
+
+        try {
+            val initialPreview = runInEdtAndGet { configurable.previewTextForTests() }
+            assertTrue(initialPreview.isNotBlank())
+            val initialDescriptorCount = runInEdtAndGet { configurable.previewDescriptorCountForTests() }
+            assertTrue(initialDescriptorCount > 0)
+
+            val checkbox = runInEdtAndGet {
+                UIUtil.findComponentsOfType(dialogPanel, JBCheckBox::class.java)
+                    .first { it.text.contains("System.out.println") }
+            }
+
+            runInEdtAndGet { checkbox.doClick() }
+
+            val updatedPreview = runInEdtAndGet { configurable.previewTextForTests() }
+            val updatedDescriptorCount = runInEdtAndGet { configurable.previewDescriptorCountForTests() }
+            assertTrue(updatedPreview.contains("System.out.println"))
+            assertTrue(updatedDescriptorCount < initialDescriptorCount)
+            assertNotEquals(initialPreview, updatedPreview)
+        } finally {
+            runInEdtAndGet {
+                val factory = EditorFactory.getInstance()
+                factory.allEditors
+                    .filter { editor ->
+                        val text = editor.document.text
+                        text.contains("PreviewSample") || text.isBlank()
+                    }
+                    .forEach { factory.releaseEditor(it) }
+                configurable.disposeUIResources()
+            }
+        }
+    }
+}


### PR DESCRIPTION

<img width="1318" height="948" alt="Screenshot 2025-10-25 at 20 00 43" src="https://github.com/user-attachments/assets/b3ebf250-2c92-48ef-8aeb-a5cb82f9ea4d" />


## Summary
- add a reusable FoldingPreviewPanel that hosts snippet/result editors and rebuilds folds via AdvancedExpressionFoldingBuilder
- persist the preview snippet in settings, disable caching for preview builds, and route StateDelegate through a thread-local override
- refresh the settings UI to drive the preview on checkbox toggles and cover the flow with an integration test

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d1aeb366c8832e9e2579a14d8ed9ea