### PR TITLE
Persist folding status metrics across sessions

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
         <!-- Application-level service that persists plugin settings -->
         <applicationService
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.settings.FoldingMetricsSettings"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->
@@ -35,6 +37,9 @@
                 id="editor.folding.advanced.expression"
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
+
+        <statusBarWidgetFactory
+                implementation="com.intellij.advancedExpressionFolding.view.FoldingStatusBarWidgetFactory"/>
 
         <!-- Suggests the pseudo-annotation @Main used by the plugin -->
         <completion.contributor

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -21,8 +21,16 @@ import com.intellij.psi.PsiJavaFile
 
 class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance().state) : FoldingBuilderEx(), IConfig by config {
     override fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        return store.store(computeFoldDescriptors(element, document, quick), document)
+    }
+
+    fun computeFoldDescriptors(
+        element: PsiElement,
+        document: Document,
+        quick: Boolean
+    ): Array<FoldingDescriptor> {
         if (!globalOn || isFoldingFile(element)) {
-            return store.store(Expression.EMPTY_ARRAY, document)
+            return Expression.EMPTY_ARRAY
         }
         if (debugFolding) {
             preview(element, document)
@@ -36,8 +44,13 @@ class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance
         if (memoryImprovement && !quick && cachedDescriptors !== foldingDescriptors) {
             writeCache(element, foldingDescriptors)
         }
-        return store.store(foldingDescriptors, document)
+        return foldingDescriptors
     }
+
+    fun computeFoldDescriptors(
+        element: PsiElement,
+        document: Document
+    ): Array<FoldingDescriptor> = computeFoldDescriptors(element, document, quick = false)
 
     private fun isFoldingFile(element: PsiElement) =
         element.asInstance<PsiJavaFile>()?.name?.endsWith("-folded.java") == true

--- a/src/com/intellij/advancedExpressionFolding/metrics/FoldingMetrics.kt
+++ b/src/com/intellij/advancedExpressionFolding/metrics/FoldingMetrics.kt
@@ -1,0 +1,68 @@
+package com.intellij.advancedExpressionFolding.metrics
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+
+/**
+ * Represents aggregated folding metrics for a file.
+ */
+data class FoldingMetrics(
+    val foldCount: Int,
+    val linesSaved: Int,
+    val charactersSaved: Int
+)
+
+/**
+ * Lightweight descriptor information required for computing folding metrics.
+ */
+data class FoldingDescriptorInfo(
+    val textRange: TextRange,
+    val placeholderText: String?
+)
+
+object FoldingMetricsCalculator {
+    fun calculate(document: Document, descriptors: Array<out FoldingDescriptor>): FoldingMetrics {
+        return calculate(
+            document,
+            descriptors.map { descriptor -> FoldingDescriptorInfo(descriptor.range, descriptor.placeholderText) }
+        )
+    }
+
+    fun calculate(document: Document, descriptors: Collection<FoldingDescriptorInfo>): FoldingMetrics {
+        if (descriptors.isEmpty()) {
+            return FoldingMetrics(0, 0, 0)
+        }
+
+        var foldCount = 0
+        var totalLinesSaved = 0
+        var totalCharactersSaved = 0
+        val content = document.charsSequence
+        val textLength = document.textLength
+
+        descriptors.forEach { info ->
+            val range = info.textRange
+            if (range.isEmpty || range.startOffset < 0 || range.endOffset > textLength || range.startOffset >= range.endOffset) {
+                return@forEach
+            }
+
+            foldCount++
+
+            val placeholder = info.placeholderText.orEmpty()
+            val original = content.subSequence(range.startOffset, range.endOffset)
+            val originalLineBreaks = original.count { it == '\n' }
+            val placeholderLineBreaks = placeholder.count { it == '\n' }
+            val lineDiff = originalLineBreaks - placeholderLineBreaks
+            if (lineDiff > 0) {
+                totalLinesSaved += lineDiff
+            }
+
+            val characterDiff = range.length - placeholder.length
+            if (characterDiff > 0) {
+                totalCharactersSaved += characterDiff
+            }
+        }
+
+        return FoldingMetrics(foldCount, totalLinesSaved, totalCharactersSaved)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/FoldingMetricsSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/FoldingMetricsSettings.kt
@@ -1,0 +1,85 @@
+package com.intellij.advancedExpressionFolding.settings
+
+import com.intellij.advancedExpressionFolding.metrics.FoldingMetrics
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+@State(name = "AdvancedExpressionFoldingMetrics", storages = [Storage("advancedExpressionFoldingMetrics.xml")])
+class FoldingMetricsSettings : PersistentStateComponent<FoldingMetricsSettings.State> {
+
+    data class MetricsState(
+        var foldCount: Int = 0,
+        var linesSaved: Int = 0,
+        var charactersSaved: Int = 0
+    ) {
+        fun toMetrics(): FoldingMetrics = FoldingMetrics(foldCount, linesSaved, charactersSaved)
+
+        companion object {
+            fun from(metrics: FoldingMetrics) = MetricsState(metrics.foldCount, metrics.linesSaved, metrics.charactersSaved)
+        }
+    }
+
+    data class Entry(
+        var fileUrl: String = "",
+        var metrics: MetricsState = MetricsState()
+    )
+
+    data class State(
+        var entries: MutableList<Entry> = mutableListOf()
+    )
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state.deepCopy()
+    }
+
+    fun updateMetrics(fileUrl: String, metrics: FoldingMetrics) {
+        if (fileUrl.isBlank()) {
+            return
+        }
+        val entries = state.entries
+        val metricsState = MetricsState.from(metrics)
+        val existingIndex = entries.indexOfFirst { it.fileUrl == fileUrl }
+        if (existingIndex >= 0) {
+            val entry = entries.removeAt(existingIndex)
+            entry.metrics = metricsState
+            entries.add(entry)
+        } else {
+            entries.add(Entry(fileUrl, metricsState))
+        }
+        ensureCapacity(entries)
+    }
+
+    fun getMetrics(fileUrl: String): FoldingMetrics? {
+        if (fileUrl.isBlank()) {
+            return null
+        }
+        return state.entries.firstOrNull { it.fileUrl == fileUrl }?.metrics?.toMetrics()
+    }
+
+    private fun State.deepCopy(): State {
+        val copiedEntries = entries.map { entry ->
+            entry.copy(metrics = entry.metrics.copy())
+        }.toMutableList()
+        return State(copiedEntries)
+    }
+
+    private fun ensureCapacity(entries: MutableList<Entry>) {
+        while (entries.size > MAX_ENTRIES) {
+            entries.removeAt(0)
+        }
+    }
+
+    companion object {
+        private const val MAX_ENTRIES = 50
+
+        @JvmStatic
+        fun getInstance(): FoldingMetricsSettings =
+            ApplicationManager.getApplication().getService(FoldingMetricsSettings::class.java)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/FoldingStatusBarWidget.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/FoldingStatusBarWidget.kt
@@ -1,0 +1,211 @@
+package com.intellij.advancedExpressionFolding.view
+
+import com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder
+import com.intellij.advancedExpressionFolding.FoldingService
+import com.intellij.advancedExpressionFolding.metrics.FoldingMetrics
+import com.intellij.advancedExpressionFolding.metrics.FoldingMetricsCalculator
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.FoldingMetricsSettings
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.intellij.psi.PsiDocumentManager
+import java.awt.Component
+
+class FoldingStatusBarWidget(private val project: Project) :
+    StatusBarWidget,
+    StatusBarWidget.TextPresentation,
+    Disposable {
+
+    private var statusBar: StatusBar? = null
+    private var text: String = NO_EDITOR_TEXT
+    private var connection = project.messageBus.connect(this)
+    private val metricsSettings = FoldingMetricsSettings.getInstance()
+
+    private val foldListener = FoldingService.FoldUpdateListener { editor ->
+        if (editor.project == project) {
+            scheduleUpdate(editor)
+        }
+    }
+
+    override fun ID(): String = WIDGET_ID
+
+    override fun getPresentation(): StatusBarWidget.WidgetPresentation = this
+
+    override fun install(statusBar: StatusBar) {
+        this.statusBar = statusBar
+        connection.subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            object : FileEditorManagerListener {
+                override fun selectionChanged(event: FileEditorManagerEvent) {
+                    val newEditor = (event.newEditor as? TextEditor)?.editor
+                    scheduleUpdate(newEditor)
+                }
+            }
+        )
+        FoldingService.get().addFoldUpdateListener(foldListener)
+        scheduleUpdate(FileEditorManager.getInstance(project).selectedTextEditor)
+    }
+
+    override fun dispose() {
+        FoldingService.get().removeFoldUpdateListener(foldListener)
+        connection.dispose()
+        statusBar = null
+    }
+
+    override fun getText(): String = text
+
+    override fun getTooltipText(): String = TOOLTIP
+
+    override fun getAlignment(): Float = Component.CENTER_ALIGNMENT
+
+    private fun scheduleUpdate(editor: Editor?) {
+        val application = ApplicationManager.getApplication()
+        val runnable = Runnable {
+            val targetEditor = editor ?: FileEditorManager.getInstance(project).selectedTextEditor
+            updateForEditor(targetEditor)
+        }
+        if (application.isDispatchThread) {
+            runnable.run()
+        } else {
+            application.invokeLater(runnable)
+        }
+    }
+
+    private fun updateForEditor(editor: Editor?) {
+        if (project.isDisposed) {
+            return
+        }
+        val settings = AdvancedExpressionFoldingSettings.getInstance().state
+        if (!settings.globalOn) {
+            updateText(DISABLED_TEXT)
+            return
+        }
+        if (editor == null || editor.isDisposed || editor.project != project) {
+            updateText(NO_EDITOR_TEXT)
+            return
+        }
+
+        val cachedMetrics = getCachedMetrics(editor)
+
+        when (val computation = computeMetrics(editor)) {
+            MetricsComputation.Unavailable -> {
+                if (cachedMetrics != null) {
+                    updateText(formatMetrics(cachedMetrics))
+                } else {
+                    updateText(NO_DATA_TEXT)
+                }
+            }
+            MetricsComputation.Updating -> {
+                if (cachedMetrics != null) {
+                    updateText(formatMetrics(cachedMetrics))
+                } else {
+                    updateText(UPDATING_TEXT)
+                }
+            }
+            is MetricsComputation.Available -> {
+                storeMetrics(editor, computation.metrics)
+                updateText(formatMetrics(computation.metrics))
+            }
+        }
+    }
+
+    private fun computeMetrics(editor: Editor): MetricsComputation {
+        val project = editor.project ?: return MetricsComputation.Unavailable
+        if (project.isDisposed || editor.isDisposed) {
+            return MetricsComputation.Unavailable
+        }
+
+        return try {
+            runReadAction {
+                val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document)
+                    ?: return@runReadAction MetricsComputation.Unavailable
+                val descriptors = AdvancedExpressionFoldingBuilder().computeFoldDescriptors(psiFile, editor.document)
+                MetricsComputation.Available(FoldingMetricsCalculator.calculate(editor.document, descriptors))
+            }
+        } catch (_: IndexNotReadyException) {
+            MetricsComputation.Updating
+        }
+    }
+
+    private fun updateText(value: String) {
+        if (text != value) {
+            text = value
+            statusBar?.updateWidget(WIDGET_ID)
+        }
+    }
+
+    private fun getCachedMetrics(editor: Editor): FoldingMetrics? {
+        val fileUrl = resolveFile(editor)?.url ?: return null
+        return metricsSettings.getMetrics(fileUrl)
+    }
+
+    private fun storeMetrics(editor: Editor, metrics: FoldingMetrics) {
+        val fileUrl = resolveFile(editor)?.url ?: return
+        metricsSettings.updateMetrics(fileUrl, metrics)
+    }
+
+    private fun resolveFile(editor: Editor): VirtualFile? =
+        FileDocumentManager.getInstance().getFile(editor.document)
+
+    private fun formatMetrics(metrics: FoldingMetrics): String {
+        val foldText = formatUnit(metrics.foldCount, "fold")
+        val lineText = formatApproxUnit(metrics.linesSaved, "line")
+        val charText = formatApproxUnit(metrics.charactersSaved, "char")
+        return "AEF: $foldText ($lineText, $charText)"
+    }
+
+    private fun formatUnit(value: Int, unit: String): String {
+        val suffix = if (value == 1) unit else unit + "s"
+        return "$value $suffix"
+    }
+
+    private fun formatApproxUnit(value: Int, unit: String): String {
+        val suffix = if (value == 1) unit else unit + "s"
+        return "~$value $suffix saved"
+    }
+
+    private sealed class MetricsComputation {
+        object Unavailable : MetricsComputation()
+        object Updating : MetricsComputation()
+        class Available(val metrics: FoldingMetrics) : MetricsComputation()
+    }
+
+    companion object {
+        const val WIDGET_ID = "advancedExpressionFoldingStatus"
+        private const val TOOLTIP = "Advanced Expression Folding savings"
+        private const val NO_EDITOR_TEXT = "AEF: no editor"
+        private const val DISABLED_TEXT = "AEF: disabled"
+        private const val NO_DATA_TEXT = "AEF: n/a"
+        private const val UPDATING_TEXT = "AEF: updating..."
+    }
+}
+
+class FoldingStatusBarWidgetFactory : StatusBarWidgetFactory, DumbAware {
+    override fun getId(): String = FoldingStatusBarWidget.WIDGET_ID
+
+    override fun getDisplayName(): String = "Advanced Expression Folding"
+
+    override fun isAvailable(project: Project): Boolean = true
+
+    override fun createWidget(project: Project): StatusBarWidget = FoldingStatusBarWidget(project)
+
+    override fun disposeWidget(widget: StatusBarWidget) {
+        widget.dispose()
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
+}

--- a/test/com/intellij/advancedExpressionFolding/settings/FoldingMetricsSettingsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/FoldingMetricsSettingsTest.kt
@@ -1,0 +1,32 @@
+package com.intellij.advancedExpressionFolding.settings
+
+import com.intellij.advancedExpressionFolding.metrics.FoldingMetrics
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class FoldingMetricsSettingsTest {
+
+    @Test
+    fun `stores and retrieves metrics by file url`() {
+        val settings = FoldingMetricsSettings()
+        val url = "file://sample.java"
+        val metrics = FoldingMetrics(10, 5, 120)
+
+        settings.updateMetrics(url, metrics)
+
+        assertEquals(metrics, settings.getMetrics(url))
+    }
+
+    @Test
+    fun `evicts oldest entries when capacity exceeded`() {
+        val settings = FoldingMetricsSettings()
+
+        (0 until 60).forEach { index ->
+            settings.updateMetrics("file://$index", FoldingMetrics(index, index + 1, index + 2))
+        }
+
+        assertNull(settings.getMetrics("file://0"))
+        assertEquals(FoldingMetrics(59, 60, 61), settings.getMetrics("file://59"))
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/view/FoldingMetricsCalculatorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/view/FoldingMetricsCalculatorTest.kt
@@ -1,0 +1,27 @@
+package com.intellij.advancedExpressionFolding.view
+
+import com.intellij.advancedExpressionFolding.metrics.FoldingDescriptorInfo
+import com.intellij.advancedExpressionFolding.metrics.FoldingMetricsCalculator
+import com.intellij.openapi.editor.impl.DocumentImpl
+import com.intellij.openapi.util.TextRange
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldingMetricsCalculatorTest {
+    @Test
+    fun `calculates approximate savings from descriptors`() {
+        val content = "line1\nline2\nline3"
+        val document = DocumentImpl(content)
+
+        val descriptors = listOf(
+            FoldingDescriptorInfo(TextRange(0, 11), "..."),
+            FoldingDescriptorInfo(TextRange(12, content.length), "l3")
+        )
+
+        val metrics = FoldingMetricsCalculator.calculate(document, descriptors)
+
+        assertEquals(2, metrics.foldCount)
+        assertEquals(1, metrics.linesSaved)
+        assertEquals(11, metrics.charactersSaved)
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated folding metrics settings service and register it so cached values survive IDE restarts
- reuse the metrics model/calculator from a shared package and update the status bar widget to fall back to persisted values while refreshing live data
- cover the new settings behaviour with unit tests and adjust the calculator test to the relocated APIs

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1af293694832ea40b8e2e15b2cb1d