### PR TITLE
Add folding diagnostics tool window

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,6 +40,11 @@
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+
+        <toolWindow id="Advanced Folding"
+                    anchor="right"
+                    factoryClass="com.intellij.advancedExpressionFolding.view.FoldingDescriptorsToolWindowFactory"
+                    icon="AllIcons.Actions.Preview"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/FoldingEditorCreatedListener.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingEditorCreatedListener.kt
@@ -1,9 +1,12 @@
 package com.intellij.advancedExpressionFolding
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.editor.Editor
+import com.intellij.util.messages.Topic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -13,15 +16,33 @@ import kotlin.time.Duration.Companion.seconds
 
 class FoldingEditorCreatedListener : EditorFactoryListener {
 
+    interface Listener {
+        fun editorCreated(editor: Editor) = Unit
+        fun editorReleased(editor: Editor) = Unit
+    }
+
+    companion object {
+        val TOPIC: Topic<Listener> = Topic.create(
+            "advanced.expression.folding.editor.lifecycle",
+            Listener::class.java
+        )
+    }
+
     override fun editorCreated(event: EditorFactoryEvent) {
         CoroutineScope(Dispatchers.EDT).launch {
             delay(1.seconds)
             runWriteAction {
                 FoldingService.get().fold(event.editor, true)
             }
+            ApplicationManager.getApplication().messageBus.syncPublisher(TOPIC)
+                .editorCreated(event.editor)
         }
     }
 
-    override fun editorReleased(event: EditorFactoryEvent) = FoldingService.get().clearAllKeys(event.editor)
+    override fun editorReleased(event: EditorFactoryEvent) {
+        FoldingService.get().clearAllKeys(event.editor)
+        ApplicationManager.getApplication().messageBus.syncPublisher(TOPIC)
+            .editorReleased(event.editor)
+    }
 
 }

--- a/src/com/intellij/advancedExpressionFolding/view/FoldingDescriptorsToolWindowFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/FoldingDescriptorsToolWindowFactory.kt
@@ -1,0 +1,234 @@
+package com.intellij.advancedExpressionFolding.view
+
+import com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener
+import com.intellij.advancedExpressionFolding.FoldingService
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ScrollType
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.content.ContentFactory
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.concurrency.AppExecutorUtil
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.ui.tree.TreeUtil
+import java.awt.BorderLayout
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.util.concurrent.atomic.AtomicLong
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.KeyStroke
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+import javax.swing.tree.TreePath
+import javax.swing.tree.TreeSelectionModel
+
+class FoldingDescriptorsToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = FoldingDescriptorsPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel.component, "", false)
+        toolWindow.contentManager.addContent(content)
+        Disposer.register(content, panel)
+    }
+}
+
+private class FoldingDescriptorsPanel(private val project: Project) : Disposable {
+
+    private val tree = Tree(DefaultMutableTreeNode("root"))
+    private val updateRequestId = AtomicLong()
+
+    private val applicationConnection: MessageBusConnection
+    private val projectConnection: MessageBusConnection
+
+    private var currentEditor: Editor? = null
+
+    val component: JComponent = JPanel(BorderLayout()).apply {
+        add(JBScrollPane(tree), BorderLayout.CENTER)
+    }
+
+    init {
+        configureTree()
+
+        applicationConnection = ApplicationManager.getApplication().messageBus.connect(this)
+        applicationConnection.subscribe(
+            FoldingEditorCreatedListener.TOPIC,
+            object : FoldingEditorCreatedListener.Listener {
+                override fun editorCreated(editor: Editor) {
+                    if (editor.project == project && editor == FileEditorManager.getInstance(project).selectedTextEditor) {
+                        scheduleUpdate(editor, force = true)
+                    }
+                }
+
+                override fun editorReleased(editor: Editor) {
+                    if (editor == currentEditor) {
+                        clear()
+                    }
+                }
+            }
+        )
+
+        projectConnection = project.messageBus.connect(this)
+        projectConnection.subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            object : FileEditorManagerListener {
+                override fun selectionChanged(event: FileEditorManagerEvent) {
+                    val editor = (event.newEditor as? TextEditor)?.editor
+                    if (editor != null) {
+                        scheduleUpdate(editor)
+                    } else {
+                        clear()
+                    }
+                }
+            }
+        )
+
+        FileEditorManager.getInstance(project).selectedTextEditor?.let(::scheduleUpdate)
+    }
+
+    private fun configureTree() {
+        tree.isRootVisible = false
+        tree.showsRootHandles = true
+        tree.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+        tree.emptyText.text = "Select an editor to inspect folding"
+        tree.cellRenderer = object : ColoredTreeCellRenderer() {
+            override fun customizeCellRenderer(
+                tree: javax.swing.JTree,
+                value: Any?,
+                selected: Boolean,
+                expanded: Boolean,
+                leaf: Boolean,
+                row: Int,
+                hasFocus: Boolean
+            ) {
+                val node = value as? DefaultMutableTreeNode ?: return
+                when (val data = node.userObject) {
+                    is FoldingPreviewGroup -> {
+                        append(data.name, SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
+                    }
+                    is FoldingPreviewEntry -> {
+                        val placeholder = data.placeholderText ?: "<no placeholder>"
+                        append(placeholder, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                        append("  ", SimpleTextAttributes.GRAYED_SMALL_ATTRIBUTES)
+                        append(data.codeSnippet, SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                    }
+                }
+            }
+        }
+
+        tree.addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (e.clickCount == 2 && !e.isConsumed) {
+                    navigateToSelected()
+                }
+            }
+        })
+        tree.registerKeyboardAction(
+            { navigateToSelected() },
+            KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+            JComponent.WHEN_FOCUSED
+        )
+    }
+
+    private fun scheduleUpdate(editor: Editor, force: Boolean = false) {
+        if (editor.isDisposed) {
+            return
+        }
+        if (!force && currentEditor == editor) {
+            return
+        }
+        currentEditor = editor
+        showLoading()
+        val requestId = updateRequestId.incrementAndGet()
+        ReadAction.nonBlocking<List<FoldingDescriptor>> {
+            FoldingService.get().descriptorsFor(editor)
+        }
+            .finishOnUiThread(ModalityState.NON_MODAL) { descriptors ->
+                if (updateRequestId.get() != requestId) {
+                    return@finishOnUiThread
+                }
+                if (editor.isDisposed || currentEditor != editor) {
+                    return@finishOnUiThread
+                }
+                val groups = FoldingPreviewViewModelBuilder.fromDescriptors(editor.document, descriptors)
+                applyGroups(groups)
+            }
+            .submit(AppExecutorUtil.getAppExecutorService())
+    }
+
+    private fun showLoading() {
+        tree.emptyText.text = "Loading folding descriptors..."
+        applyGroups(emptyList(), emptyMessage = null)
+    }
+
+    private fun applyGroups(groups: List<FoldingPreviewGroup>, emptyMessage: String? = "No folding descriptors") {
+        val newRoot = DefaultMutableTreeNode("root")
+        groups.forEach { group ->
+            val groupNode = GroupNode(group)
+            group.entries.forEach { entry ->
+                groupNode.add(DescriptorNode(entry))
+            }
+            newRoot.add(groupNode)
+        }
+        tree.model = DefaultTreeModel(newRoot)
+        TreeUtil.expandAll(tree)
+        if (groups.isEmpty()) {
+            emptyMessage?.let { tree.emptyText.text = it }
+        }
+    }
+
+    private fun navigateToSelected() {
+        val entry = selectedEntry() ?: return
+        val editor = currentEditor?.takeUnless(Editor::isDisposed) ?: return
+        val range = entry.range
+        editor.caretModel.moveToOffset(range.startOffset)
+        editor.selectionModel.setSelection(range.startOffset, range.endOffset)
+        editor.scrollingModel.scrollToCaret(ScrollType.CENTER)
+    }
+
+    private fun selectedEntry(): FoldingPreviewEntry? {
+        val path: TreePath = tree.selectionPath ?: return null
+        val node = path.lastPathComponent as? DefaultMutableTreeNode ?: return null
+        return node.userObject as? FoldingPreviewEntry
+    }
+
+    private fun clear() {
+        currentEditor = null
+        applyGroups(emptyList(), emptyMessage = "Select an editor to inspect folding")
+    }
+
+    override fun dispose() {
+        // message bus connections are disposed automatically
+    }
+
+    private class GroupNode(val group: FoldingPreviewGroup) : DefaultMutableTreeNode(group) {
+        init {
+            allowsChildren = true
+        }
+
+        override fun toString(): String = group.name
+    }
+
+    private class DescriptorNode(val entry: FoldingPreviewEntry) : DefaultMutableTreeNode(entry) {
+        init {
+            allowsChildren = false
+        }
+
+        override fun toString(): String = entry.placeholderText ?: entry.codeSnippet
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/FoldingDescriptorsViewModel.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/FoldingDescriptorsViewModel.kt
@@ -1,0 +1,68 @@
+package com.intellij.advancedExpressionFolding.view
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.util.TextRange
+
+data class FoldingPreviewEntry(
+    val groupName: String,
+    val placeholderText: String?,
+    val codeSnippet: String,
+    val range: TextRange
+)
+
+data class FoldingPreviewGroup(
+    val name: String,
+    val entries: List<FoldingPreviewEntry>
+)
+
+object FoldingPreviewViewModelBuilder {
+
+    fun fromDescriptors(document: Document, descriptors: List<FoldingDescriptor>): List<FoldingPreviewGroup> {
+        if (descriptors.isEmpty()) {
+            return emptyList()
+        }
+        val text = document.text
+        val entries = descriptors.map { descriptor ->
+            FoldingPreviewEntry(
+                descriptor.group.groupNameOrFeature(descriptor.placeholderText, descriptor.element?.javaClass?.simpleName),
+                descriptor.placeholderText?.takeUnless { it.isBlank() },
+                descriptor.range.substringSafe(text),
+                descriptor.range
+            )
+        }
+        return group(entries)
+    }
+
+    fun group(entries: List<FoldingPreviewEntry>): List<FoldingPreviewGroup> {
+        if (entries.isEmpty()) {
+            return emptyList()
+        }
+        return entries.groupBy { it.groupName }
+            .map { (groupName, descriptors) ->
+                val sorted = descriptors.sortedBy { it.range.startOffset }
+                val anchor = sorted.firstOrNull()?.range?.startOffset ?: Int.MAX_VALUE
+                anchor to FoldingPreviewGroup(groupName, sorted)
+            }
+            .sortedBy { it.first }
+            .map { it.second }
+    }
+
+    private fun TextRange.substringSafe(text: CharSequence): String {
+        val boundedStart = startOffset.coerceIn(0, text.length)
+        val boundedEnd = endOffset.coerceIn(boundedStart, text.length)
+        return text.subSequence(boundedStart, boundedEnd).toString()
+    }
+
+    private fun FoldingGroup?.groupNameOrFeature(placeholder: String?, featureName: String?): String {
+        val rawGroup = this?.toString()?.takeIf { it.isNotBlank() }
+        val simplifiedGroup = rawGroup?.substringAfterLast('.')
+        return when {
+            !simplifiedGroup.isNullOrBlank() -> simplifiedGroup
+            !featureName.isNullOrBlank() -> featureName
+            !placeholder.isNullOrBlank() -> placeholder
+            else -> "Ungrouped"
+        }
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/view/FoldingPreviewViewModelBuilderTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/view/FoldingPreviewViewModelBuilderTest.kt
@@ -1,0 +1,28 @@
+package com.intellij.advancedExpressionFolding.view
+
+import com.intellij.openapi.util.TextRange
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FoldingPreviewViewModelBuilderTest {
+
+    @Test
+    fun `groups entries by name and preserves ordering`() {
+        val entries = listOf(
+            FoldingPreviewEntry("GroupB", "b", "code b", TextRange(20, 25)),
+            FoldingPreviewEntry("GroupA", "a1", "code a1", TextRange(0, 5)),
+            FoldingPreviewEntry("GroupA", "a2", "code a2", TextRange(10, 15))
+        )
+
+        val groups = FoldingPreviewViewModelBuilder.group(entries)
+
+        assertEquals(listOf("GroupA", "GroupB"), groups.map { it.name })
+        assertEquals(listOf(TextRange(0, 5), TextRange(10, 15)), groups[0].entries.map { it.range })
+    }
+
+    @Test
+    fun `empty groups when descriptors missing`() {
+        val groups = FoldingPreviewViewModelBuilder.group(emptyList())
+        assertEquals(emptyList<FoldingPreviewGroup>(), groups)
+    }
+}


### PR DESCRIPTION
## Summary
- add a folding diagnostics tool window that tracks the active editor, displays grouped placeholder/code snippets, and supports double-click navigation
- expose folding descriptor collection through FoldingService and broadcast editor lifecycle events for listeners
- wire the tool window into plugin.xml and add lightweight tests for the descriptor grouping view model

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1af18c7e4832e8d95603a9610f31d