### PR TITLE
Add folding telemetry and metrics UI

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/core/BuildExpressionExt.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/BuildExpressionExt.java
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding.processor.core;
 import com.intellij.advancedExpressionFolding.expression.Expression;
 import com.intellij.advancedExpressionFolding.expression.SyntheticExpressionImpl;
 import com.intellij.advancedExpressionFolding.processor.util.Helper;
+import com.intellij.advancedExpressionFolding.telemetry.FoldingTelemetry;
 import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.IndexNotReadyException;
@@ -61,6 +62,8 @@ public class BuildExpressionExt {
             //TODO: add to allDescriptors list instead of creating temporary arrays
             FoldingDescriptor[] descriptors = expression.buildFoldRegions(expression.getElement(), document, null);
             if (descriptors.length > 0) {
+                String ruleId = expression.getClass().getSimpleName();
+                FoldingTelemetry.tagElement(expression.getElement(), ruleId);
                 allDescriptors.addAll(Arrays.asList(descriptors));
             }
         }

--- a/src/com/intellij/advancedExpressionFolding/settings/IConfig.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/IConfig.kt
@@ -3,4 +3,5 @@ package com.intellij.advancedExpressionFolding.settings
 interface IConfig {
     var globalOn: Boolean
     val memoryImprovement: Boolean
+    var telemetryEnabled: Boolean
 }

--- a/src/com/intellij/advancedExpressionFolding/telemetry/FoldingTelemetry.kt
+++ b/src/com/intellij/advancedExpressionFolding/telemetry/FoldingTelemetry.kt
@@ -1,0 +1,22 @@
+package com.intellij.advancedExpressionFolding.telemetry
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+
+object FoldingTelemetry {
+    private const val RULE_KEY = "AdvancedExpressionFolding.RuleId"
+
+    @JvmField
+    val RULE_ID_KEY: Key<String> = Key.create(RULE_KEY)
+
+    const val UNKNOWN_RULE_ID: String = "Unknown"
+
+    @JvmStatic
+    fun tagElement(element: PsiElement, ruleId: String) {
+        element.putUserData(RULE_ID_KEY, ruleId)
+    }
+
+    fun FoldingDescriptor.telemetryRuleId(): String =
+        element?.getUserData(RULE_ID_KEY) ?: UNKNOWN_RULE_ID
+}

--- a/test/com/intellij/advancedExpressionFolding/TelemetryFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/TelemetryFoldingTest.kt
@@ -1,0 +1,80 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.TestDynamicDataProvider
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KMutableProperty0
+
+class TelemetryFoldingTest : BaseTest() {
+    private val settings: AdvancedExpressionFoldingSettings
+        get() = AdvancedExpressionFoldingSettings.getInstance()
+    private val state
+        get() = settings.state
+    private var telemetryEnabledBefore: Boolean = false
+
+    @BeforeEach
+    fun setUpTelemetry() {
+        telemetryEnabledBefore = settings.state.telemetryEnabled
+        settings.clearTelemetry()
+    }
+
+    @AfterEach
+    fun tearDownTelemetry() {
+        settings.state.telemetryEnabled = telemetryEnabledBefore
+        settings.clearTelemetry()
+    }
+
+    @Test
+    fun telemetryOptOutDoesNotCollectData() {
+        settings.state.telemetryEnabled = false
+        runFolding(
+            state::concatenationExpressionsCollapse,
+            state::optional,
+            state::streamSpread,
+        )
+        val snapshot = settings.telemetrySnapshot()
+        assertEquals(0L, snapshot.totalFoldRegions)
+        assertTrue(snapshot.perRule.isEmpty())
+    }
+
+    @Test
+    fun telemetryOptInCollectsData() {
+        settings.state.telemetryEnabled = true
+        runFolding(
+            state::concatenationExpressionsCollapse,
+            state::optional,
+            state::streamSpread,
+        )
+        val snapshot = settings.telemetrySnapshot()
+        assertTrue(snapshot.totalFoldRegions > 0)
+        assertTrue(snapshot.perRule.values.any { it > 0 })
+    }
+
+    @Test
+    fun telemetryClearResetsCounters() {
+        settings.state.telemetryEnabled = true
+        runFolding(
+            state::concatenationExpressionsCollapse,
+            state::optional,
+            state::streamSpread,
+        )
+        assertTrue(settings.telemetrySnapshot().totalFoldRegions > 0)
+
+        settings.clearTelemetry()
+        val cleared = settings.telemetrySnapshot()
+        assertEquals(0L, cleared.totalFoldRegions)
+        assertTrue(cleared.perRule.isEmpty())
+    }
+
+    private fun runFolding(vararg properties: KMutableProperty0<Boolean>) {
+        settings.disableAll()
+        properties.forEach { it.set(true) }
+        MethodCallFactory.initialize(TestDynamicDataProvider())
+        super.doFoldingTest("ConcatenationTestData")
+    }
+}


### PR DESCRIPTION
## Summary
- add opt-in telemetry state with persistent counters for recorded fold regions
- tag folding descriptors with rule identifiers and record counts when telemetry is enabled
- expose telemetry metrics in a new settings tab with opt-in toggle and clear button
- add telemetry-focused folding tests that verify opt-in/out and clearing behavior

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1aea39f48832e8c77fd1bc392ccda