### PR TITLE
Introduce persona profiles with UI switcher and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 - Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+- Introduce persona-aware folding profiles with toolbar switcher, audit log, and conflict detection
 
 ## [4.2.0] - 2025-09-20
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ For more clarity, you may try to adjust your color scheme: go to **Settings** | 
 
 To disable certain types of folding, go to **Settings** | **Editor** |
 **General** | **Code Folding**.
+
+## Persona-aware onboarding
+
+Advanced Expression Folding now ships with curated personas that package folding presets, keyboard shortcuts, and color themes for common workflows:
+
+| Persona | Focus | Quick toggle |
+| --- | --- | --- |
+| Core Persona | Balanced defaults for general refactoring sessions. | `Alt+Shift+0` |
+| Analyst Persona | Keeps Optional/nullable folds visible while relaxing logging folds. | `Alt+Shift+1` |
+| Logger Persona | Aggressively collapses log statements (including text blocks) to let control flow pop. | `Alt+Shift+2` |
+| Reviewer Persona | Disables Lombok folding so generated code stays visible during code reviews. | `Alt+Shift+3` |
+
+Open **Settings | Editor | Code Folding | Advanced Expression Folding 2** to switch personas, preview diffs, and review audit history before applying changes. The settings dialog now surfaces persona-specific onboarding tips and example files that can be checked into your workspace.
+
+See [Multi-persona best practices](docs/multi-persona-best-practices.md) for guidance on mixing personas within a team and troubleshooting conflict warnings.
 <!-- Plugin description end -->
 
 

--- a/docs/multi-persona-best-practices.md
+++ b/docs/multi-persona-best-practices.md
@@ -1,0 +1,29 @@
+# Multi-persona best practices
+
+The Advanced Expression Folding persona system lets teams share folding preferences without overwriting one another. Each persona captures a snapshot of the folding state, audit metadata, and an optional folded-text color.
+
+## Switching and auditing
+
+* Use the toolbar **Folding Personas** menu or the keyboard shortcuts listed below to jump between personas without opening Settings.
+* The Settings panel now records audit entries every time a persona is activated or updated. Review the "Recent persona activity" panel before applying changes to avoid surprises.
+* Conflict warnings appear when you stage a change that would overwrite a previously saved persona value. Review the diff preview to confirm the conflict is intentional before applying.
+
+## Default shortcuts
+
+| Persona | Shortcut |
+| --- | --- |
+| Core | `Alt+Shift+0` |
+| Analyst | `Alt+Shift+1` |
+| Logger | `Alt+Shift+2` |
+| Reviewer | `Alt+Shift+3` |
+
+## Collaboration tips
+
+* Capture persona-specific examples with the download link in Settings so each developer can try the folds locally.
+* Use the persona audit log as a lightweight changelog during code reviews; it records who changed a persona and when.
+* Keep personas focused. Instead of toggling dozens of settings, create a new persona when a workflow needs a radically different configuration.
+
+## Troubleshooting
+
+* If the folded text color looks wrong after switching personas, press the "Apply folded color" button in Settings to reset to theme-aware defaults.
+* Persona shortcuts rely on the default keymap. If they conflict with your custom keymap, edit them under **Settings | Keymap | Advanced Expression Folding**.

--- a/examples/data/PersonaAnalystExample.java
+++ b/examples/data/PersonaAnalystExample.java
@@ -1,0 +1,10 @@
+import java.util.Optional;
+
+public class PersonaAnalystExample {
+    String normalize(Optional<String> source) {
+        return source
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .orElse("<missing>");
+    }
+}

--- a/examples/data/PersonaCoreExample.java
+++ b/examples/data/PersonaCoreExample.java
@@ -1,0 +1,10 @@
+public class PersonaCoreExample {
+    void baseline(String value) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("value");
+        }
+        for (int i = 0; i < value.length(); i++) {
+            System.out.println(value.charAt(i));
+        }
+    }
+}

--- a/examples/data/PersonaLoggerExample.java
+++ b/examples/data/PersonaLoggerExample.java
@@ -1,0 +1,10 @@
+import java.util.logging.Logger;
+
+public class PersonaLoggerExample {
+    private static final Logger LOG = Logger.getLogger(PersonaLoggerExample.class.getName());
+
+    void log(String userId, String message) {
+        LOG.info(() -> "user=" + userId + " message=" + message);
+        LOG.fine(() -> "payload=" + message.strip());
+    }
+}

--- a/examples/data/PersonaReviewerExample.java
+++ b/examples/data/PersonaReviewerExample.java
@@ -1,0 +1,14 @@
+import lombok.Data;
+
+@Data
+public class PersonaReviewerExample {
+    private String name;
+    private int age;
+
+    public static PersonaReviewerExample from(String name, int age) {
+        PersonaReviewerExample example = new PersonaReviewerExample();
+        example.setName(name);
+        example.setAge(age);
+        return example;
+    }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -78,6 +78,33 @@
             <keyboard-shortcut first-keystroke="alt Y" keymap="Mac OS X 10.5+" replace-all="true"/>
         </action>
 
+        <group id="com.intellij.advancedExpressionFolding.action.PersonaSwitchActionGroup"
+               class="com.intellij.advancedExpressionFolding.action.PersonaSwitchActionGroup"
+               popup="true" text="Folding Personas">
+            <add-to-group group-id="MainToolbarRight" anchor="last"/>
+            <add-to-group group-id="CodeMenu" anchor="last"/>
+        </group>
+
+        <action id="com.intellij.advancedExpressionFolding.action.ActivateCorePersonaAction"
+                class="com.intellij.advancedExpressionFolding.action.ActivateCorePersonaAction">
+            <keyboard-shortcut first-keystroke="alt shift 0" keymap="$default" replace-all="true"/>
+        </action>
+
+        <action id="com.intellij.advancedExpressionFolding.action.ActivateAnalystPersonaAction"
+                class="com.intellij.advancedExpressionFolding.action.ActivateAnalystPersonaAction">
+            <keyboard-shortcut first-keystroke="alt shift 1" keymap="$default" replace-all="true"/>
+        </action>
+
+        <action id="com.intellij.advancedExpressionFolding.action.ActivateLoggerPersonaAction"
+                class="com.intellij.advancedExpressionFolding.action.ActivateLoggerPersonaAction">
+            <keyboard-shortcut first-keystroke="alt shift 2" keymap="$default" replace-all="true"/>
+        </action>
+
+        <action id="com.intellij.advancedExpressionFolding.action.ActivateReviewerPersonaAction"
+                class="com.intellij.advancedExpressionFolding.action.ActivateReviewerPersonaAction">
+            <keyboard-shortcut first-keystroke="alt shift 3" keymap="$default" replace-all="true"/>
+        </action>
+
         <!-- Hidden action invoked from settings to refresh folded text colors -->
         <action id="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"
                 class="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"/>

--- a/src/com/intellij/advancedExpressionFolding/action/PersonaActions.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/PersonaActions.kt
@@ -1,0 +1,87 @@
+package com.intellij.advancedExpressionFolding.action
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.project.DumbAware
+
+class PersonaSwitchActionGroup : ActionGroup(), DumbAware {
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        val descriptors = settings.personaDescriptors()
+        if (descriptors.isEmpty()) {
+            return AnAction.EMPTY_ARRAY
+        }
+        return descriptors.map { PersonaQuickSwitchAction(it.id) }.toTypedArray()
+    }
+}
+
+private class PersonaQuickSwitchAction(private val personaId: String) : ToggleAction(), DumbAware {
+    override fun isSelected(e: AnActionEvent): Boolean {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        return settings.state.activePersonaId == personaId
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        if (!state) return
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.setActivePersona(personaId, user = "toolbar:${e.place}")
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        val persona = settings.personaDescriptors().firstOrNull { it.id == personaId }
+        e.presentation.isEnabledAndVisible = persona != null
+        if (persona != null) {
+            e.presentation.text = persona.displayName
+            e.presentation.description = "Activate persona ${persona.displayName}"
+        }
+    }
+}
+
+abstract class BaseActivatePersonaAction : ToggleAction(), DumbAware {
+    protected abstract val personaId: String
+    protected abstract val fallbackText: String
+
+    override fun isSelected(e: AnActionEvent): Boolean {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        return settings.state.activePersonaId == personaId
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        if (!state) return
+        AdvancedExpressionFoldingSettings.getInstance().setActivePersona(personaId, user = "shortcut:${e.place}")
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        val persona = settings.personaDescriptors().firstOrNull { it.id == personaId }
+        e.presentation.text = persona?.displayName ?: fallbackText
+        e.presentation.description = "Activate persona ${persona?.displayName ?: fallbackText}"
+        e.presentation.isEnabled = persona != null
+    }
+}
+
+class ActivateCorePersonaAction : BaseActivatePersonaAction() {
+    override val personaId: String = AdvancedExpressionFoldingSettings.PersonaProfileState.DEFAULT_ID
+    override val fallbackText: String = "Activate Core Persona"
+}
+
+class ActivateAnalystPersonaAction : BaseActivatePersonaAction() {
+    override val personaId: String = "analyst"
+    override val fallbackText: String = "Activate Analyst Persona"
+}
+
+class ActivateLoggerPersonaAction : BaseActivatePersonaAction() {
+    override val personaId: String = "logger"
+    override val fallbackText: String = "Activate Logger Persona"
+}
+
+class ActivateReviewerPersonaAction : BaseActivatePersonaAction() {
+    override val personaId: String = "reviewer"
+    override val fallbackText: String = "Activate Reviewer Persona"
+}

--- a/src/com/intellij/advancedExpressionFolding/action/UpdateFoldedTextColorsAction.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/UpdateFoldedTextColorsAction.kt
@@ -13,10 +13,12 @@ class UpdateFoldedTextColorsAction : AnAction() {
 
     companion object {
 
-        fun changeFoldingColors() {
+        fun changeFoldingColors(colorHex: String? = null) {
             val scheme = EditorColorsManager.getInstance().globalScheme
             val textAttributes = scheme.getAttributes(EditorColors.FOLDED_TEXT_ATTRIBUTES)
-            val foregroundColor = if (!JBColor.isBright()) {
+            val foregroundColor = colorHex?.let {
+                runCatching { decode(it) }.getOrNull()
+            } ?: if (!JBColor.isBright()) {
                 decode("#7ca0bb")
             } else {
                 decode("#000091")

--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -4,6 +4,11 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.containers.ContainerUtil
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import org.jetbrains.annotations.NotNull
 import kotlin.reflect.KClass
 import kotlin.reflect.KMutableProperty
@@ -14,10 +19,17 @@ import kotlin.reflect.jvm.javaType
 @State(name = "AdvancedExpressionFoldingSettings", storages = [Storage("editor.codeinsight.xml")])
 class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpressionFoldingSettings.State> {
     private var myState = State()
+    private val logger = Logger.getInstance(AdvancedExpressionFoldingSettings::class.java)
+
+    init {
+        ensurePersonaProfiles()
+    }
+
     override fun getState(): State = myState
 
     override fun loadState(state: State) {
         myState = state.copy()
+        ensurePersonaProfiles()
     }
 
     data class State(
@@ -78,7 +90,33 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
 
         override var globalOn: Boolean = true,
 
+        var activePersonaId: String = PersonaProfileState.DEFAULT_ID,
+        var personaProfiles: MutableMap<String, PersonaProfileState> = linkedMapOf(),
+        var personaAuditTrail: MutableList<PersonaAuditEntry> = mutableListOf(),
+
         ) : IState, IConfig
+
+    data class PersonaProfileState(
+        var id: String = DEFAULT_ID,
+        var displayName: String = "",
+        var propertySnapshot: MutableMap<String, Any?> = linkedMapOf(),
+        var foldedTextColorHex: String? = null,
+        var preferredShortcut: String? = null,
+        var onboardingTip: String? = null,
+        var exampleFile: String? = null,
+        var lastModifiedBy: String? = null,
+        var lastModifiedAtMillis: Long = 0L,
+    ) {
+        companion object {
+            const val DEFAULT_ID = "core"
+        }
+    }
+
+    data class PersonaAuditEntry(
+        var personaId: String = PersonaProfileState.DEFAULT_ID,
+        var message: String = "",
+        var timestampMillis: Long = 0L,
+    )
 
     private fun updateAllState(value: Boolean, vararg excludeProperties: KMutableProperty<Boolean>) {
         val excluded = excludeProperties.map { it.toString() }
@@ -99,6 +137,240 @@ class AdvancedExpressionFoldingSettings : PersistentStateComponent<AdvancedExpre
 
     // used in integrationStubs
     fun enableEverything() = updateAllState(true, state::emojify, state::finalEmoji)
+
+    fun personaDescriptors(): List<PersonaProfileState> {
+        ensurePersonaProfiles()
+        return myState.personaProfiles.values.toList()
+    }
+
+    fun onboardingTip(personaId: String): String? {
+        ensurePersonaProfiles()
+        return myState.personaProfiles[personaId]?.onboardingTip
+    }
+
+    fun personaExample(personaId: String): String? {
+        ensurePersonaProfiles()
+        return myState.personaProfiles[personaId]?.exampleFile
+    }
+
+    fun setActivePersona(personaId: String, user: String? = null, applyColorScheme: Boolean = true) {
+        ensurePersonaProfiles()
+        if (!myState.personaProfiles.containsKey(personaId)) {
+            logger.warn("Attempted to activate unknown persona: $personaId")
+            return
+        }
+
+        val targetPersona = myState.personaProfiles.getValue(personaId)
+        if (personaId == myState.activePersonaId) {
+            if (applyColorScheme) {
+                applyPersonaColor(targetPersona)
+            }
+            return
+        }
+
+        captureActivePersonaSnapshot(user)
+        applySnapshot(targetPersona.propertySnapshot)
+        myState.activePersonaId = personaId
+        logAudit(
+            personaId,
+            "Activated persona '${targetPersona.displayName}'${user?.let { " by $it" } ?: ""}"
+        )
+
+        if (applyColorScheme) {
+            applyPersonaColor(targetPersona)
+        }
+    }
+
+    private fun applyPersonaColor(targetPersona: PersonaProfileState) {
+        targetPersona.foldedTextColorHex?.let { color ->
+            try {
+                com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction.changeFoldingColors(color)
+            } catch (t: Throwable) {
+                logger.warn("Unable to apply persona color $color", t)
+            }
+        }
+    }
+
+    fun captureActivePersonaSnapshot(user: String? = null) {
+        ensurePersonaProfiles()
+        val personaId = myState.activePersonaId
+        val persona = myState.personaProfiles.getOrPut(personaId) { defaultPersona(personaId) }
+        persona.propertySnapshot = snapshotState()
+        persona.lastModifiedBy = user
+        persona.lastModifiedAtMillis = System.currentTimeMillis()
+    }
+
+    fun commitPersonaChanges(personaId: String, changedProperties: Map<String, Boolean>, user: String?) {
+        ensurePersonaProfiles()
+        val persona = myState.personaProfiles.getOrPut(personaId) { defaultPersona(personaId) }
+        if (changedProperties.isNotEmpty()) {
+            val conflicts = detectConflicts(personaId, changedProperties)
+            conflicts.forEach { conflict ->
+                logAudit(personaId, conflict)
+            }
+            logAudit(
+                personaId,
+                "Updated ${changedProperties.size} setting${if (changedProperties.size == 1) "" else "s"}${user?.let { " by $it" } ?: ""}"
+            )
+        }
+        persona.propertySnapshot = snapshotState()
+        persona.lastModifiedBy = user
+        persona.lastModifiedAtMillis = System.currentTimeMillis()
+    }
+
+    fun detectConflicts(personaId: String, changedProperties: Map<String, Boolean>): List<String> {
+        ensurePersonaProfiles()
+        if (changedProperties.isEmpty()) return emptyList()
+        val persona = myState.personaProfiles[personaId] ?: return emptyList()
+        val snapshot = persona.propertySnapshot
+        val conflicts = mutableListOf<String>()
+        changedProperties.forEach { (propertyName, newValue) ->
+            val previousValue = snapshot[propertyName] as? Boolean
+            if (previousValue != null && previousValue != newValue) {
+                conflicts += "Conflict on $propertyName: was $previousValue now $newValue"
+            }
+            myState.personaProfiles
+                .filterKeys { it != personaId }
+                .forEach { (_, otherPersona) ->
+                    val otherValue = otherPersona.propertySnapshot[propertyName] as? Boolean
+                    if (otherValue != null && otherValue != newValue) {
+                        conflicts += "Differs from ${otherPersona.displayName}: $propertyName ${otherValue} vs $newValue"
+                    }
+                }
+        }
+        return conflicts
+    }
+
+    fun auditTrail(): List<PersonaAuditEntry> {
+        ensurePersonaProfiles()
+        return myState.personaAuditTrail.toList()
+    }
+
+    fun diffAgainstPersona(personaId: String): Map<String, Pair<Boolean, Boolean>> {
+        ensurePersonaProfiles()
+        val persona = myState.personaProfiles[personaId] ?: return emptyMap()
+        val diffs = LinkedHashMap<String, Pair<Boolean, Boolean>>()
+        val currentState = snapshotState()
+        allProperties().forEach { property ->
+            val name = property.name
+            val personaValue = persona.propertySnapshot[name] as? Boolean ?: return@forEach
+            val currentValue = currentState[name] as? Boolean ?: return@forEach
+            if (personaValue != currentValue) {
+                diffs[name] = personaValue to currentValue
+            }
+        }
+        return diffs
+    }
+
+    fun formatTimestamp(millis: Long): String = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+        .withZone(ZoneId.systemDefault())
+        .format(Instant.ofEpochMilli(millis))
+
+    private fun logAudit(personaId: String, message: String) {
+        val timestamp = System.currentTimeMillis()
+        myState.personaAuditTrail.add(
+            PersonaAuditEntry(personaId = personaId, message = message, timestampMillis = timestamp)
+        )
+        trimAuditTrail()
+    }
+
+    private fun trimAuditTrail(limit: Int = 100) {
+        if (myState.personaAuditTrail.size > limit) {
+            myState.personaAuditTrail = myState.personaAuditTrail.takeLast(limit).toMutableList()
+        }
+    }
+
+    private fun snapshotState(): MutableMap<String, Any?> = ContainerUtil.newLinkedHashMap<String, Any?>().apply {
+        allProperties().forEach { property ->
+            this[property.name] = property.getter.call(myState)
+        }
+    }
+
+    private fun applySnapshot(snapshot: Map<String, Any?>) {
+        allProperties().forEach { property ->
+            val rawValue = snapshot[property.name]
+            val value = when (rawValue) {
+                is Boolean -> rawValue
+                is String -> rawValue.toBooleanStrictOrNull()
+                else -> null
+            }
+            if (value != null) {
+                property.setter.call(myState, value)
+            }
+        }
+    }
+
+    private fun ensurePersonaProfiles() {
+        if (myState.personaProfiles.isEmpty()) {
+            myState.personaProfiles = defaultPersonaProfiles()
+        }
+        if (!myState.personaProfiles.containsKey(myState.activePersonaId)) {
+            myState.activePersonaId = PersonaProfileState.DEFAULT_ID
+        }
+    }
+
+    private fun defaultPersonaProfiles(): MutableMap<String, PersonaProfileState> {
+        val baseline = snapshotState()
+        val now = System.currentTimeMillis()
+        return linkedMapOf(
+            PersonaProfileState.DEFAULT_ID to PersonaProfileState(
+                id = PersonaProfileState.DEFAULT_ID,
+                displayName = "Core Persona",
+                propertySnapshot = baseline.toMutableMap(),
+                onboardingTip = "Balanced defaults for general refactoring sessions.",
+                exampleFile = "PersonaCoreExample.java",
+                lastModifiedAtMillis = now
+            ),
+            "analyst" to PersonaProfileState(
+                id = "analyst",
+                displayName = "Analyst Persona",
+                propertySnapshot = baseline.toMutableMap().apply {
+                    this["logFolding"] = false
+                    this["optional"] = true
+                    this["nullable"] = true
+                },
+                foldedTextColorHex = "#1b5e20",
+                preferredShortcut = "alt shift 1",
+                onboardingTip = "Focus on optional/nullable flows when reasoning about data.",
+                exampleFile = "PersonaAnalystExample.java",
+                lastModifiedAtMillis = now
+            ),
+            "logger" to PersonaProfileState(
+                id = "logger",
+                displayName = "Logger Persona",
+                propertySnapshot = baseline.toMutableMap().apply {
+                    this["logFolding"] = true
+                    this["logFoldingTextBlocks"] = true
+                },
+                foldedTextColorHex = "#0d47a1",
+                preferredShortcut = "alt shift 2",
+                onboardingTip = "Collapse noisy log statements to spotlight control flow.",
+                exampleFile = "PersonaLoggerExample.java",
+                lastModifiedAtMillis = now
+            ),
+            "reviewer" to PersonaProfileState(
+                id = "reviewer",
+                displayName = "Reviewer Persona",
+                propertySnapshot = baseline.toMutableMap().apply {
+                    this["lombok"] = false
+                    this["fieldShift"] = false
+                    this["destructuring"] = true
+                },
+                foldedTextColorHex = "#4a148c",
+                preferredShortcut = "alt shift 3",
+                onboardingTip = "Keep Lombok visible while folding advanced DSL helpers.",
+                exampleFile = "PersonaReviewerExample.java",
+                lastModifiedAtMillis = now
+            )
+        )
+    }
+
+    private fun defaultPersona(id: String): PersonaProfileState {
+        val displayName = id.replaceFirstChar { ch ->
+            if (ch.isLowerCase()) ch.titlecase() else ch.toString()
+        }
+        return PersonaProfileState(id = id, displayName = displayName)
+    }
 
     companion object {
         @JvmStatic

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -15,11 +15,17 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.encoding.EncodingProjectManager
+import com.intellij.ui.CollectionComboBoxModel
 import com.intellij.ui.JBColor
+import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBUI
 import java.awt.Color.decode
 import java.awt.FlowLayout
 import java.net.URI
@@ -28,7 +34,30 @@ import javax.swing.JPanel
 import kotlin.reflect.KMutableProperty0
 
 class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
-    private val state = AdvancedExpressionFoldingSettings.getInstance().state
+    private val settingsService = AdvancedExpressionFoldingSettings.getInstance()
+    private val state = settingsService.state
+    private var selectedPersonaId: String = state.activePersonaId
+    private val personaModel = CollectionComboBoxModel<AdvancedExpressionFoldingSettings.PersonaProfileState>()
+    private val personaTipLabel = JBLabel()
+    private val conflictLabel = JBLabel().apply { foreground = JBColor.RED }
+    private val diffPreview = JBTextArea(5, 60).apply {
+        lineWrap = true
+        wrapStyleWord = true
+        isEditable = false
+        border = JBUI.Borders.empty(4)
+        text = "No persona changes pending."
+    }
+    private val auditArea = JBTextArea(6, 60).apply {
+        lineWrap = true
+        wrapStyleWord = true
+        isEditable = false
+        border = JBUI.Borders.empty(4)
+        text = "No persona activity recorded yet."
+    }
+    private val personaExamplePanel = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0)).apply {
+        isOpaque = false
+    }
+    private val currentUser = System.getProperty("user.name") ?: "unknown"
     private lateinit var panel: DialogPanel
     private val allExampleFiles = mutableSetOf<ExampleFile>()
     private val pendingChanges = mutableMapOf<KMutableProperty0<Boolean>, Boolean>()
@@ -94,6 +123,33 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     }
 
     override fun createComponent() = panel {
+        row("Persona profile") {
+            refreshPersonaModel()
+            val renderer = SimpleListCellRenderer.create("", AdvancedExpressionFoldingSettings.PersonaProfileState::displayName)
+            val combo = comboBox(personaModel, renderer).component
+            combo.addActionListener { handlePersonaSelection() }
+        }
+        row {
+            cell(personaTipLabel)
+        }
+        row {
+            cell(JBScrollPane(diffPreview).apply { preferredSize = JBUI.size(420, 110) })
+        }
+        row {
+            cell(conflictLabel)
+        }
+        row {
+            label("Persona example kit:")
+        }
+        row {
+            cell(personaExamplePanel)
+        }
+        row {
+            label("Recent persona activity:")
+        }
+        row {
+            cell(JBScrollPane(auditArea).apply { preferredSize = JBUI.size(420, 120) })
+        }
         row {
             val button =
                 JButton("Apply folded color: ${if (!JBColor.isBright()) "soft blue" else "dark navy"}")
@@ -109,6 +165,10 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         initialize(state)
     }.also {
         panel = it
+        refreshPersonaMetadata()
+        refreshDiffPreview()
+        refreshConflictPreview()
+        refreshAuditArea()
     }
 
     override fun isModified(): Boolean {
@@ -116,12 +176,19 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     }
 
     override fun apply() {
+        val changeSet = pendingChanges.mapKeys { (property, _) -> property.name }
         pendingChanges.forEach { (property, value) ->
             property.set(value)
         }
         pendingChanges.clear()
-        
+
         panel.apply()
+        settingsService.commitPersonaChanges(selectedPersonaId, changeSet, currentUser)
+        refreshPersonaModel()
+        refreshPersonaMetadata()
+        refreshDiffPreview()
+        refreshConflictPreview()
+        refreshAuditArea()
     }
 
     override fun reset() {
@@ -129,6 +196,13 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         propertyToCheckbox.forEach { (property, checkbox) ->
             checkbox.isSelected = property.get()
         }
+        selectedPersonaId = state.activePersonaId
+        refreshPersonaModel()
+        settingsService.setActivePersona(selectedPersonaId, applyColorScheme = false)
+        refreshPersonaMetadata()
+        refreshDiffPreview()
+        refreshConflictPreview()
+        refreshAuditArea()
     }
 
     private fun firstSourceRoot(project: Project) =
@@ -164,6 +238,121 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         fileEditorManager.openFile(this, true)
     }
 
+    private fun refreshPersonaModel() {
+        val descriptors = settingsService.personaDescriptors()
+        personaModel.replaceAll(descriptors.toMutableList())
+        val selected = descriptors.firstOrNull { it.id == selectedPersonaId } ?: descriptors.firstOrNull()
+        personaModel.selectedItem = selected
+        selectedPersonaId = selected?.id ?: selectedPersonaId
+    }
+
+    private fun handlePersonaSelection() {
+        val persona = selectedPersona() ?: return
+        selectedPersonaId = persona.id
+        pendingChanges.clear()
+        settingsService.setActivePersona(selectedPersonaId, currentUser)
+        refreshCheckboxesFromState()
+        refreshPersonaMetadata()
+        refreshDiffPreview()
+        refreshConflictPreview()
+        refreshAuditArea()
+    }
+
+    private fun refreshCheckboxesFromState() {
+        propertyToCheckbox.forEach { (property, checkbox) ->
+            checkbox.isSelected = property.get()
+        }
+    }
+
+    private fun refreshPersonaMetadata() {
+        val persona = selectedPersona()
+        if (persona == null) {
+            personaTipLabel.text = "No persona available."
+            personaExamplePanel.removeAll()
+            personaExamplePanel.add(JBLabel("No persona examples registered."))
+        } else {
+            personaTipLabel.text = persona.onboardingTip ?: "No onboarding tip for ${persona.displayName}."
+            refreshPersonaExamples(persona)
+        }
+        personaExamplePanel.revalidate()
+        personaExamplePanel.repaint()
+    }
+
+    private fun refreshPersonaExamples(persona: AdvancedExpressionFoldingSettings.PersonaProfileState?) {
+        personaExamplePanel.removeAll()
+        val exampleFile = persona?.exampleFile
+        if (exampleFile != null) {
+            val examplePanel = createExamplePanel(mapOf(exampleFile to "(${persona.displayName})"))
+            personaExamplePanel.add(examplePanel)
+        } else {
+            personaExamplePanel.add(JBLabel("No persona examples registered."))
+        }
+    }
+
+    private fun refreshDiffPreview() {
+        val persona = selectedPersona()
+        if (persona == null) {
+            diffPreview.text = "No persona selected."
+            return
+        }
+        val baseline = persona.propertySnapshot
+        val previewState = baseline.toMutableMap()
+        for ((property, value) in pendingChanges) {
+            previewState[property.name] = value
+        }
+        val diffs = previewState.keys
+            .mapNotNull { name ->
+                val personaValue = baseline[name] as? Boolean ?: return@mapNotNull null
+                val previewValue = previewState[name] as? Boolean ?: return@mapNotNull null
+                if (personaValue != previewValue) name to (personaValue to previewValue) else null
+            }
+            .sortedBy { it.first }
+        diffPreview.text = if (diffs.isEmpty()) {
+            "No persona changes pending."
+        } else {
+            diffs.joinToString("\n") { (name, values) ->
+                "${persona.displayName}: $name ${values.first} → ${values.second}"
+            }
+        }
+        diffPreview.caretPosition = 0
+    }
+
+    private fun refreshConflictPreview() {
+        val persona = selectedPersona()
+        if (persona == null) {
+            conflictLabel.text = ""
+            conflictLabel.foreground = JBColor.GRAY
+            return
+        }
+        val conflicts = settingsService.detectConflicts(persona.id, pendingChangesAsMap())
+        if (conflicts.isEmpty()) {
+            conflictLabel.text = "No conflicts detected."
+            conflictLabel.foreground = JBColor.GRAY
+        } else {
+            conflictLabel.text = conflicts.joinToString("\n")
+            conflictLabel.foreground = JBColor.RED
+        }
+    }
+
+    private fun refreshAuditArea() {
+        val entries = settingsService.auditTrail()
+            .filter { it.personaId == selectedPersonaId }
+            .takeLast(10)
+        auditArea.text = if (entries.isEmpty()) {
+            "No persona activity recorded yet."
+        } else {
+            entries.joinToString("\n") {
+                "[${settingsService.formatTimestamp(it.timestampMillis)}] ${it.message}"
+            }
+        }
+        auditArea.caretPosition = 0
+    }
+
+    private fun pendingChangesAsMap(): Map<String, Boolean> = pendingChanges.mapKeys { (property, _) -> property.name }
+
+    private fun selectedPersona(): AdvancedExpressionFoldingSettings.PersonaProfileState? =
+        personaModel.selectedItem as? AdvancedExpressionFoldingSettings.PersonaProfileState
+
     companion object {
         private const val EXAMPLE_DIR = "data"
     }
@@ -180,7 +369,14 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         val checkbox = JBCheckBox(title)
         checkbox.isSelected = property.get()
         checkbox.addActionListener {
-            pendingChanges[property] = checkbox.isSelected
+            val selected = checkbox.isSelected
+            if (selected == property.get()) {
+                pendingChanges.remove(property)
+            } else {
+                pendingChanges[property] = selected
+            }
+            refreshDiffPreview()
+            refreshConflictPreview()
         }
         propertyToCheckbox[property] = checkbox
         

--- a/test/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingSettingsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingSettingsTest.kt
@@ -70,5 +70,36 @@ class AdvancedExpressionFoldingSettingsTest {
             }
         }
     }
+
+    @Test
+    fun personaProfilesInitializeWithDefaults() {
+        val settings = AdvancedExpressionFoldingSettings()
+
+        val personas = settings.personaDescriptors().associateBy { it.id }
+
+        assertTrue(personas.containsKey(AdvancedExpressionFoldingSettings.PersonaProfileState.DEFAULT_ID))
+        assertTrue(personas.containsKey("analyst"))
+        assertTrue(personas.containsKey("logger"))
+        assertTrue(personas.containsKey("reviewer"))
+    }
+
+    @Test
+    fun switchingPersonaChangesActiveId() {
+        val settings = AdvancedExpressionFoldingSettings()
+
+        settings.setActivePersona("logger", user = "test", applyColorScheme = false)
+
+        assertEquals("logger", settings.state.activePersonaId)
+    }
+
+    @Test
+    fun detectConflictsReportsCrossPersonaDifferences() {
+        val settings = AdvancedExpressionFoldingSettings()
+
+        settings.setActivePersona("analyst", user = "test", applyColorScheme = false)
+        val conflicts = settings.detectConflicts("analyst", mapOf("logFolding" to false))
+
+        assertTrue(conflicts.any { it.contains("Differs from Logger Persona") })
+    }
 }
 


### PR DESCRIPTION

<img width="1204" height="843" alt="Screenshot 2025-10-25 at 20 02 32" src="https://github.com/user-attachments/assets/0a5afd2b-8aba-4743-98b3-f0304da2c60c" />


## Summary
- add persona profile management with audit logging, conflict detection, and default personas in the settings service
- extend the settings UI with persona selection, diff previews, conflict warnings, audit log display, and persona example links
- add toolbar/shortcut actions, update folded color handling, and document persona workflows with sample example files

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68d9a9e4df34832ea54a3845d2907a17