### PR TITLE
Run IDE integration tests in CI

### DIFF
--- a/.github/workflows/todo-integration-test.yml
+++ b/.github/workflows/todo-integration-test.yml
@@ -1,8 +1,13 @@
-name: TODO Run Integration Tests
+name: IDE Integration Tests
+
 permissions:
   contents: read
 
-on: [workflow_dispatch]
+on:
+  pull_request:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
 
 jobs:
   integrationTest:
@@ -16,7 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-java@v5
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 17
@@ -25,8 +32,37 @@ jobs:
         shell: bash
         run: ./gradlew buildPlugin
 
-      - name: Setup Display (Linux)
+      - name: Install UI test dependencies
         if: runner.os == 'Linux'
-        uses: coactions/setup-xvfb@v1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libxi6 \
+            libxtst6 \
+            libgtk-3-0 \
+            libdbus-glib-1-2 \
+            dbus-x11
+
+      - name: Start virtual display
+        if: runner.os == 'Linux'
+        run: |
+          Xvfb :99 -screen 0 1920x1080x24 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
+          sleep 3
+
+      - name: Run IDE integration tests
+        run: ./gradlew check --tests "*IntegrationTest"
+
+      - name: Upload integration artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          run: ./gradlew check
+          name: integration-test-artifacts-${{ matrix.os }}
+          path: |
+            out/ide-tests/logs
+            out/ide-tests/tests/**/log/**
+            out/ide-tests/tests/**/screenRecording/**
+            out/ide-tests/tests/**/screenshots/**
+            out/ide-tests/tests/**/driver/**
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- trigger the IDE integration workflow from pull requests, manual dispatch, and a nightly schedule
- install JetBrains UI test prerequisites and execute the integration test suite under Xvfb
- upload IDE logs, recordings, and screenshots to help diagnose failures

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f50842a338832ebf3307bf3e7081dd