### PR TITLE
Document developer test toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ This project uses the Gradle wrapper. The most common commands are:
 
 Run these commands from the repository root. See the [Gradle build documentation](https://docs.gradle.org/current/userguide/command_line_interface.html) for more options.
 
+## Developer toggles
+
+The test suite exposes a few long-running or destructive behaviours behind environment variables so that routine `./gradlew test` executions stay fast and predictable.
+
+| Variable      | Supported values | Effect |
+|---------------|------------------|--------|
+| `dev-mode`    | `1`              | Enables the copy-on-write helper in [`BaseTest`](test/com/intellij/advancedExpressionFolding/BaseTest.kt), replacing fixtures under `testData/` with the matching sources from `examples/data/` before running a test. Disabled by default to prevent accidental overwrites of curated fixtures. |
+| `dev-mode`    | `2`              | Includes the behaviour above and additionally unlocks [`CrazyFoldingTest`](test/com/intellij/advancedExpressionFolding/CrazyFoldingTest.kt), an exhaustive stress test that takes many hours and writes commits for millions of permutations. This level stays disabled unless explicitly requested to avoid monopolising CI resources. |
+| `integration` | `1`              | Enables [`IntegrationTest`](test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt), which spins up a full IDE via the IntelliJ Driver, downloads dependencies, and interacts with real UI components. It is skipped by default to keep local and CI runs lightweight. |
+
+### Sample invocations
+
+```bash
+DEV_MODE=1 ./gradlew test
+integration=1 ./gradlew test IntegrationTest
+```
+
 ## License
 
 This project is licensed under the terms of the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
## Summary
- describe the developer-only environment toggles for dev-mode and integration
- explain which tests are gated by each toggle and why they default to off
- document example commands for enabling the guarded test suites

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f509b64980832e81bf7d4fede82a2a