### PR TITLE
Handle dumb mode and cancellation during folding

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/core/BuildExpressionExt.java
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/BuildExpressionExt.java
@@ -5,6 +5,8 @@ import com.intellij.advancedExpressionFolding.expression.SyntheticExpressionImpl
 import com.intellij.advancedExpressionFolding.processor.util.Helper;
 import com.intellij.lang.folding.FoldingDescriptor;
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.IndexNotReadyException;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.Contract;
@@ -49,6 +51,9 @@ public class BuildExpressionExt {
     @SuppressWarnings("WeakerAccess")
     @Nullable
     public static Expression getNonSyntheticExpression(@NotNull PsiElement element, @Nullable Document document) throws IndexNotReadyException {
+        if (DumbService.isDumb(element.getProject())) {
+            return null;
+        }
         //noinspection ConstantConditions
         return getExpression(element, document, false);
     }
@@ -66,6 +71,7 @@ public class BuildExpressionExt {
         }
         if (expression == null || (unique && expression.isNested())) {
             for (PsiElement child : element.getChildren()) {
+                ProgressManager.checkCanceled();
                 collectFoldRegionsRecursively(child, document, uniqueSet, allDescriptors);
             }
         }

--- a/test/com/intellij/advancedExpressionFolding/DumbModeCancellationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/DumbModeCancellationTest.kt
@@ -1,0 +1,59 @@
+package com.intellij.advancedExpressionFolding
+
+import com.google.common.collect.Sets
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.testFramework.DumbModeTestUtils
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.ArrayList
+
+class DumbModeCancellationTest : BaseTest() {
+
+    @Test
+    fun `get non synthetic expression does not index during dumb mode`() {
+        val psiFile = fixture.configureByText("DumbMode.java", "class DumbMode { int value; }")
+        val document = fixture.editor.document
+
+        DumbModeTestUtils.runInDumbModeSynchronously(fixture.project) {
+            assertDoesNotThrow {
+                runReadAction {
+                    BuildExpressionExt.getNonSyntheticExpression(psiFile, document)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `collect fold regions checks cancellation`() {
+        val psiFile = fixture.configureByText("Cancellation.java", "class Cancellation { void test() {} }")
+        val document = fixture.editor.document
+
+        val indicator = EmptyProgressIndicator()
+
+        val unique = Sets.newIdentityHashSet<Expression>()
+        val descriptors = ArrayList<FoldingDescriptor>()
+        var canceled = false
+
+        ProgressManager.getInstance().runProcess({
+            indicator.cancel()
+            assertDoesNotThrow {
+                try {
+                    runReadAction {
+                        BuildExpressionExt.collectFoldRegionsRecursively(psiFile, document, unique, descriptors)
+                    }
+                } catch (e: ProcessCanceledException) {
+                    canceled = true
+                }
+            }
+        }, indicator)
+
+        assertTrue(canceled)
+    }
+}


### PR DESCRIPTION
## Summary
- short-circuit `BuildExpressionExt.getNonSyntheticExpression` during dumb mode to avoid hitting indexes while they are unavailable
- call `ProgressManager.checkCanceled()` before descending into child PSI to honor cancellation requests
- add a light fixture test that exercises dumb mode and cancellation paths to ensure no unexpected exceptions are raised

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68daf71d117c832ea27d29199af408c0