### PR TITLE
Improve collapsed-by-default lookup by reusing cached expressions

### DIFF
--- a/folded/CollapsedByDefaultTestData-folded.java
+++ b/folded/CollapsedByDefaultTestData-folded.java
@@ -1,0 +1,12 @@
+package data;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CollapsedByDefaultTestData {
+    public List<String> upperCase(String[] args) {
+        return args*.toUpperCase()
+            .toList();
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
@@ -221,6 +221,14 @@ open class FoldingTest : BaseTest() {
     }
 
     /**
+     * [data.CollapsedByDefaultTestData]
+     */
+    @Test
+    open fun collapsedByDefaultTestData() {
+        doFoldingTest(state::concatenationExpressionsCollapse, state::optional, state::streamSpread)
+    }
+
+    /**
      * [data.OptionalTestData]
      */
     @Test

--- a/testData/CollapsedByDefaultTestData-all.java
+++ b/testData/CollapsedByDefaultTestData-all.java
@@ -1,0 +1,13 @@
+package data;
+
+import <fold text='...' expand='false'>java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;</fold>
+
+public class CollapsedByDefaultTestData {
+    public List<String> upperCase(String[] args) <fold text='{...}' expand='true'>{<fold text=' ' expand='true'>
+        </fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold><fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>
+            .map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold>
+            <fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold><fold text='' expand='true'>;</fold><fold text=' ' expand='true'>
+    </fold>}</fold>
+}

--- a/testData/CollapsedByDefaultTestData.java
+++ b/testData/CollapsedByDefaultTestData.java
@@ -1,0 +1,13 @@
+package data;
+
+import <fold text='...' expand='false'>java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;</fold>
+
+public class CollapsedByDefaultTestData {
+    public List<String> upperCase(String[] args) <fold text='{...}' expand='true'>{
+        return <fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>
+            .map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold>
+            <fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold>;
+    }</fold>
+}


### PR DESCRIPTION
## Summary
- expose a cache-aware helper in CacheExt to reuse existing expression instances
- update AdvancedExpressionFoldingBuilder.isCollapsedByDefault to consult cached expressions before rebuilding and to use the file view provider document

## Testing
- ./gradlew --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68daf8be1068832eaf71afd2376f3701