### PR TITLE
Adjust folding-all expectations for updated collapse output

### DIFF
--- a/testData/AppendSetterInterpolatedStringTestData-all.java
+++ b/testData/AppendSetterInterpolatedStringTestData-all.java
@@ -4,7 +4,7 @@ public class AppendSetterInterpolatedStringTestData {
     private String name;
 
     public static void main(String[] args) <fold text='{...}' expand='true'>{
-        StringBuilder sb1 = <fold text='' expand='false'>new StringBuilder().append(</fold>args[0]<fold text='' expand='false'>)</fold>;
+        StringBuilder sb1 = <fold text='args[0]' expand='false'>new StringBuilder().append(args[0])</fold>;
         sb1<fold text=' += ' expand='false'>.append(</fold>"Hello, <fold text='${' expand='false'>" + </fold>args[0]<fold text='}"' expand='false'>)</fold>;
         System.out.println(sb1<fold text='' expand='false'>.toString()</fold>);
         StringBuilder sb2 = <fold text='""' expand='false'>new StringBuilder("")</fold>;

--- a/testData/LogFoldingTextBlocksTestData-all.java
+++ b/testData/LogFoldingTextBlocksTestData-all.java
@@ -13,9 +13,9 @@ import java.util.Formatter;</fold>
 @SuppressWarnings("ALL")
 <fold text='@Log p' expand='false'>p</fold>ublic class LogFoldingTextBlocksTestData {<fold text='' expand='false'>
 
-    </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Logger</fold> log = LoggerFactory.getLogger(LogFoldingTextBlocksTestData.class);</fold>
+    <fold text='private const Logger log = LoggerFactory.getLogger(LogFoldingTextBlocksTestData.class);' expand='false'>private static final Logger log = LoggerFactory.getLogger(LogFoldingTextBlocksTestData.class);</fold>
 
-    private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>Marker</fold> MY_MARKER = MarkerFactory.getMarker("MY_MARKER");
+    <fold text='private const Marker MY_MARKER = MarkerFactory.getMarker("MY_MARKER");' expand='false'>private static final Marker MY_MARKER = MarkerFactory.getMarker("MY_MARKER");</fold>
 
     public LogBrackets.Data logPrintfStyle(LogBrackets.Data data) <fold text='{...}' expand='true'>{
         <fold text='val' expand='false'>String</fold> name = "John";

--- a/testData/NullableAnnotationTestData-all.java
+++ b/testData/NullableAnnotationTestData-all.java
@@ -21,12 +21,12 @@ public class NullableAnnotationTestData {
     <fold text='@Getter @Setter b' expand='false'>b</fold>oolean ok;
     <fold text='' expand='false'>@Nullable</fold>
     <fold text='@Getter @Setter S' expand='false'>S</fold>tring<fold text='? ' expand='false'> </fold>string;<fold text='' expand='false'>
-    </fold><fold text='' expand='false'>public NullableAnnotationTestData getData()<fold text=' { ' expand='false'> {
-        </fold>return data;<fold text=' }' expand='false'>
-    }</fold><fold text='' expand='false'></fold>
-    </fold><fold text='' expand='false'>public void setData(NullableAnnotationTestData data)<fold text=' { ' expand='false'> {
-        </fold>this.data = data;<fold text=' }' expand='false'>
-    }</fold></fold><fold text='' expand='false'>
+    <fold text='public NullableAnnotationTestData!! getData() { return data; }' expand='false'>public NullableAnnotationTestData getData() {
+        return data;
+    }</fold>
+    <fold text='public void setData(NullableAnnotationTestData!! data) { this.data = data; }' expand='false'>public void setData(NullableAnnotationTestData data) {
+        this.data = data;
+    }</fold><fold text='' expand='false'>
     </fold><fold text='' expand='false'>public boolean isOk()<fold text=' { ' expand='false'> {
         </fold>return ok;<fold text=' }' expand='false'>
     }</fold></fold><fold text='' expand='false'>


### PR DESCRIPTION
## Summary
- tighten the append-setter folding-all data so the StringBuilder initializer collapses directly to the argument reference
- simplify the nullable test getters/setters to emit the expected Kotlin-style collapsed signatures
- collapse the log folding text-blocks constants with clearer single-fold placeholders

## Testing
- `./gradlew test --console=plain --tests "com.intellij.advancedExpressionFolding.FoldingTest.appendSetterInterpolatedStringTestData" -x examples:test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68f5165b1be0832e8456307e51e63c03