### PR TITLE
Refine @Main completion defaults

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
@@ -86,6 +86,11 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
             "byte", "short", "int", "long" -> "0"
             "float" -> "0.0f"
             "double" -> "0.0"
+            "java.lang.String" -> "\"\""
+            "java.lang.StringBuilder" -> "new java.lang.StringBuilder()"
+            "java.lang.StringBuffer" -> "new java.lang.StringBuffer()"
+            "java.math.BigDecimal" -> "java.math.BigDecimal.ZERO"
+            "java.math.BigInteger" -> "java.math.BigInteger.ZERO"
             "java.util.Date" -> "new java.util.Date()"
             "java.time.LocalDate" -> "java.time.LocalDate.now()"
             "java.time.LocalDateTime" -> "java.time.LocalDateTime.now()"
@@ -94,6 +99,21 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
         }
 
         return if (isEllipsis) "new ${effectiveType.presentableText}[]{}" else base
+    }
+
+    private fun initializerValue(type: PsiType): String {
+        return if (type is PsiEllipsisType) {
+            val componentType = type.componentType
+            val elementDefault = defaultValue(componentType)
+            val arrayContents = if (elementDefault == "null") "" else elementDefault
+            if (arrayContents.isEmpty()) {
+                "new ${componentType.presentableText}[]{}"
+            } else {
+                "new ${componentType.presentableText}[]{${elementDefault}}"
+            }
+        } else {
+            defaultValue(type)
+        }
     }
 
     private fun generateMainCode(method: PsiMethod, ownerClass: PsiClass): String {
@@ -111,13 +131,13 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
             constructorParams.forEach {
                 val type = it.type
                 val typeText = if (type is PsiEllipsisType) type.componentType.presentableText + "[]" else type.presentableText
-                add("        $typeText ${it.name} = ${defaultValue(type)};")
+                add("        $typeText ${it.name} = ${initializerValue(type)};")
             }
             if (constructorParams.isNotEmpty()) add("")
             methodParams.forEach {
                 val type = it.type
                 val typeText = if (type is PsiEllipsisType) type.componentType.presentableText + "[]" else type.presentableText
-                add("        $typeText ${it.name} = ${defaultValue(type)};")
+                add("        $typeText ${it.name} = ${initializerValue(type)};")
             }
         }.joinToString("\n")
 

--- a/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
@@ -56,7 +56,7 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
                 expected = """
                 public class Test {
                     public static void main(String[] args) {
-                        String s = null;
+                        String s = "";
                         new Test().instanceMethod(s);
                     }
                 
@@ -102,20 +102,20 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
                     }
                 """.trimIndent(),
                 expected = """
-                public class Test {
-                    public static void main(String[] args) {
-                        int param = 0;
-                
-                        String s = null;
-                        new Test(param).testMethod(s);
+                    public class Test {
+                        public static void main(String[] args) {
+                            int param = 0;
+
+                            String s = "";
+                            new Test(param).testMethod(s);
+                        }
+
+                        public Test(int param) {
+                        }
+                    ${"    "}
+                        public void testMethod(String s) {
+                        }
                     }
-                
-                    public Test(int param) {
-                    }
-                    
-                    public void testMethod(String s) {
-                    }
-                }
                 """.trimIndent()
             )),
             
@@ -131,13 +131,56 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
                 expected = """
                 public class Test {
                     public static void main(String[] args) {
-                        String[] args = new String[]{};
+                        String[] args = new String[]{""};
                         new Test().stringVarargs(args);
                     }
-                
+
                     public void stringVarargs(String... args) {
                     }
                 }
+                """.trimIndent()
+            )),
+
+            Arguments.of(TestCase(
+                name = "Reference Defaults",
+                input = """
+                    import java.math.BigDecimal;
+                    import java.math.BigInteger;
+                    import java.time.LocalDate;
+                    import java.time.LocalDateTime;
+                    import java.time.ZonedDateTime;
+
+                    public class Test {
+                        @<caret>
+                        public void referenceParams(String s, StringBuilder sb, StringBuffer sbf, BigDecimal bd, BigInteger bi, java.util.Date date, LocalDate ld, LocalDateTime ldt, ZonedDateTime zdt) {
+                        }
+                    }
+                """.trimIndent(),
+                expected = """
+                    import java.math.BigDecimal;
+                    import java.math.BigInteger;
+                    import java.time.LocalDate;
+                    import java.time.LocalDateTime;
+                    import java.time.ZonedDateTime;
+                    import java.util.Date;
+
+                    public class Test {
+                        public static void main(String[] args) {
+                            String s = "";
+                            StringBuilder sb = new StringBuilder();
+                            StringBuffer sbf = new StringBuffer();
+                            BigDecimal bd = BigDecimal.ZERO;
+                            BigInteger bi = BigInteger.ZERO;
+                            Date date = new Date();
+                            LocalDate ld = LocalDate.now();
+                            LocalDateTime ldt = LocalDateTime.now();
+                            ZonedDateTime zdt = ZonedDateTime.now();
+                            new Test().referenceParams(s, sb, sbf, bd, bi, date, ld, ldt, zdt);
+                        }
+
+                        public void referenceParams(String s, StringBuilder sb, StringBuffer sbf, BigDecimal bd, BigInteger bi, java.util.Date date, LocalDate ld, LocalDateTime ldt, ZonedDateTime zdt) {
+                        }
+                    }
                 """.trimIndent()
             )),
 
@@ -153,10 +196,10 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
                 expected = """
                 public class Test {
                     public static void main(String[] args) {
-                        int[] values = new int[]{};
+                        int[] values = new int[]{0};
                         new Test().numbers(values);
                     }
-                
+
                     public void numbers(int... values) {
                     }
                 }


### PR DESCRIPTION
## Summary
- add string and numeric reference defaults for generated @Main scaffolding
- ensure varargs initializers reuse element defaults via a dedicated helper
- expand completion tests with new expectations for reference types and non-null strings

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f526a7fa04832eaf2b34794309b54a