### PR TITLE
Align NullableExt reference comment spacing

### DIFF
--- a/testData/NullableAnnotationTestData-all.java
+++ b/testData/NullableAnnotationTestData-all.java
@@ -10,7 +10,7 @@ import java.util.HashMap;</fold>
 <fold text='/** {@link com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingSettings.IState#getNullable()} ...*/' expand='true'>/**
  * {@link com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingSettings.IState#getNullable()}
  * <p>
- *  {@link com.intellij.advancedExpressionFolding.extension.NullableExt#createExpression(com.intellij.psi.PsiMethod)}
+ * {@link com.intellij.advancedExpressionFolding.processor.language.kotlin.NullableExt#createExpression(com.intellij.psi.PsiMethod)}
  * <p>
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testNullableAnnotationTestData()}
  */</fold>


### PR DESCRIPTION
## Summary
- align the NullableExt link in the nullable annotation fixture comment with the -all formatting

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f522b4a2cc832ea2e0437850f5a9f2