### PR TITLE
Add grouped settings UI with search filtering

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -10,7 +10,9 @@ import com.intellij.openapi.editor.highlighter.EditorHighlighterFactory
 import com.intellij.openapi.ui.ComponentValidator
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.dsl.builder.CollapsibleRow
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.Row
 import org.intellij.lang.regexp.RegExpFileType
 import java.awt.Dimension
 import java.util.function.Supplier
@@ -19,269 +21,354 @@ import kotlin.reflect.KMutableProperty0
 
 abstract class CheckboxesProvider {
 
+    protected enum class GroupType {
+        GROUP,
+        COLLAPSIBLE
+    }
+
+    protected data class GroupInfo(
+        val title: String,
+        val type: GroupType,
+        val parent: GroupInfo?,
+        var headerRow: Row? = null,
+        var collapsibleRow: CollapsibleRow? = null,
+        val properties: MutableSet<KMutableProperty0<Boolean>> = mutableSetOf()
+    )
+
+    private val groupStack = ArrayDeque<GroupInfo>()
+    private val groupDefinitions = mutableListOf<GroupInfo>()
+
+    protected fun Panel.settingsGroup(title: String, init: Panel.() -> Unit) {
+        val groupInfo = GroupInfo(title, GroupType.GROUP, groupStack.lastOrNull())
+        groupStack.addLast(groupInfo)
+        val headerRow = try {
+            group(title) {
+                init()
+            }
+        } finally {
+            groupStack.removeLast()
+        }
+        groupInfo.headerRow = headerRow
+        groupDefinitions += groupInfo
+    }
+
+    protected fun Panel.settingsCollapsibleGroup(
+        title: String,
+        collapsed: Boolean = false,
+        init: Panel.() -> Unit
+    ) {
+        val groupInfo = GroupInfo(title, GroupType.COLLAPSIBLE, groupStack.lastOrNull())
+        groupStack.addLast(groupInfo)
+        val collapsibleRow = try {
+            collapsibleGroup(title) {
+                init()
+            }
+        } finally {
+            groupStack.removeLast()
+        }
+        collapsibleRow.expanded = !collapsed
+        groupInfo.collapsibleRow = collapsibleRow
+        groupDefinitions += groupInfo
+    }
+
+    protected fun currentGroupPath(): List<GroupInfo> = groupStack.toList()
+
+    protected fun allGroups(): List<GroupInfo> = groupDefinitions
+
+    protected fun registerAdditionalRow(property: KMutableProperty0<Boolean>, row: Row) {
+        onAdditionalRowRegistered(property, row)
+    }
+
+    protected open fun onAdditionalRowRegistered(property: KMutableProperty0<Boolean>, row: Row) = Unit
+
     @Suppress("DEPRECATION")
     @CheckboxDsl
     fun Panel.initialize(state: State) {
-        registerCheckbox(state::getSetExpressionsCollapse, "Getters and setters as properties") {
-            example("GetterSetterTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getsetexpressionscollapse")
+        settingsGroup("Properties and Accessors") {
+            registerCheckbox(state::getSetExpressionsCollapse, "Getters and setters as properties") {
+                example("GetterSetterTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getsetexpressionscollapse")
+            }
+
+            registerCheckbox(state::varExpressionsCollapse, "Variable declarations (var/val)") {
+                example("VarTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#varexpressionscollapse")
+            }
+
+            registerCheckbox(
+                state::interfaceExtensionProperties,
+                "Converts traditional getter and setter methods in interfaces into extension properties"
+            ) {
+                example("InterfaceExtensionPropertiesTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#interfaceextensionproperties")
+            }
+
+            registerCheckbox(state::methodDefaultParameters, "Default parameter values inline for overloaded method") {
+                example("MethodDefaultParametersTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#methodDefaultParameters")
+            }
+
+            registerCheckbox(
+                state::summaryParentOverride,
+                "Displays a folded summary of overridden methods from parent classes and interfaces."
+            ) {
+                example("SummaryParentOverrideTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#summaryparentoverride")
+            }
+
+            registerCheckbox(
+                state::constructorReferenceNotation,
+                "Constructor reference notation ::new and compact field initialization"
+            ) {
+                example("ConstructorReferenceNotationTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#constructorReferenceNotation")
+            }
+
+            registerCheckbox(
+                state::fieldShift,
+                "Display mapping of field with same name as << (for builders, setters and assignments)"
+            ) {
+                example("FieldShiftBuilder.java", "builders")
+                example("FieldShiftSetters.java", "setters")
+                example("FieldShiftFields.java", "fields")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#fieldshift")
+            }
         }
 
-        registerCheckbox(state::varExpressionsCollapse, "Variable declarations (var/val)") {
-            example("VarTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#varexpressionscollapse")
+        settingsGroup("Collections and Streams") {
+            registerCheckbox(
+                state::getExpressionsCollapse,
+                "List.get, List.set, Map.get and Map.put expressions, array and list literals"
+            ) {
+                example("GetSetPutTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getexpressionscollapse")
+            }
+
+            registerCheckbox(
+                state::concatenationExpressionsCollapse,
+                "StringBuilder.append and Collection.add/remove expressions, interpolated Strings and Stream expressions"
+            ) {
+                example("StringBuilderTestData.java", "StringBuilder")
+                example("InterpolatedStringTestData.java", "Interpolate")
+                example("AppendSetterInterpolatedStringTestData.java", "Append")
+                example("ConcatenationTestData.java", "Concatenation")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#concatenationexpressionscollapse")
+            }
+
+            registerCheckbox(state::slicingExpressionsCollapse, "List.subList and String.substring expressions") {
+                example("SliceTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#slicingexpressionscollapse")
+            }
+
+            registerCheckbox(state::rangeExpressionsCollapse, "For loops, range expressions") {
+                example("ForRangeTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#rangeexpressionscollapse")
+            }
+
+            registerCheckbox(state::destructuring, "Destructuring assignment for array & list") {
+                example("DestructuringAssignmentArrayTestData.java", "array")
+                example("DestructuringAssignmentListTestData.java", "list")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#destructuring")
+            }
+
+            registerCheckbox(state::streamSpread, "Display stream operations as Groovy's spread operator") {
+                example("SpreadTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#streamspread")
+            }
+
+            registerCheckbox(state::println, "Simplify System.out.println to println") {
+                example("PrintlnTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#println")
+            }
         }
 
-        registerCheckbox(
-            state::compactControlFlowSyntaxCollapse,
-            "Compact control flow condition syntax (Golang ifs)"
-        ) {
-            example("CompactControlFlowTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#compactcontrolflowsyntaxcollapse")
+        settingsGroup("Null Safety and Optionality") {
+            registerCheckbox(state::checkExpressionsCollapse, "Null-safe calls") {
+                example("ElvisTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#checkexpressionscollapse")
+            }
+
+            registerCheckbox(state::ifNullSafe, "Extended null-safe ifs") {
+                example("IfNullSafeData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#ifnullsafe")
+            }
+
+            registerCheckbox(state::optional, "Display optional as Kotlin null-safe") {
+                example("OptionalTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#optional")
+            }
+
+            registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Loggable") {
+                example("PseudoAnnotationsMainTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
+            }
+
+            registerCheckbox(state::nullable, "Simplify @NotNull to Type!! and @Nullable to Type?") {
+                example("NullableAnnotationTestData.java", "annotations")
+                example("NullableAnnotationCheckNotNullTestData.java", "checkNotNull")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#nullable")
+            }
         }
 
-        registerCheckbox(
-            state::getExpressionsCollapse,
-            "List.get, List.set, Map.get and Map.put expressions, array and list literals"
-        ) {
-            example("GetSetPutTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getexpressionscollapse")
+        settingsGroup("Control Flow and Expressions") {
+            registerCheckbox(
+                state::compactControlFlowSyntaxCollapse,
+                "Compact control flow condition syntax (Golang ifs)"
+            ) {
+                example("CompactControlFlowTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#compactcontrolflowsyntaxcollapse")
+            }
+
+            registerCheckbox(state::kotlinQuickReturn, "Kotlin quick return") {
+                example("LetReturnIt.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#kotlinquickreturn")
+            }
+
+            registerCheckbox(state::expressionFunc, "Single-Expression Function") {
+                example("ExpressionFuncTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#expressionfunc")
+            }
+
+            registerCheckbox(state::assertsCollapse, "Asserts") {
+                example("AssertTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#asserts")
+            }
+
+            registerCheckbox(state::comparingExpressionsCollapse, "Object.equals and Comparable.compareTo expressions") {
+                example("EqualsCompareTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparingexpressionscollapse")
+            }
         }
 
-        registerCheckbox(
-            state::concatenationExpressionsCollapse,
-            "StringBuilder.append and Collection.add/remove expressions, interpolated Strings and Stream expressions"
-        ) {
-            example("StringBuilderTestData.java", "StringBuilder")
-            example("InterpolatedStringTestData.java", "Interpolate")
-            example("AppendSetterInterpolatedStringTestData.java", "Append")
-            example("ConcatenationTestData.java", "Concatenation")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#concatenationexpressionscollapse")
+        settingsGroup("Dates and Time") {
+            registerCheckbox(state::comparingLocalDatesCollapse, "Java.time isBefore/isAfter expressions") {
+                example("LocalDateTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparinglocaldatescollapse")
+            }
+
+            registerCheckbox(state::localDateLiteralCollapse, "LocalDate.of literals (e.g. 2018-02-12)") {
+                example("LocalDateLiteralTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralcollapse")
+            }
+
+            registerCheckbox(state::localDateLiteralPostfixCollapse, "Postfix LocalDate literals (e.g. 2018Y-02M-12D)") {
+                example("LocalDateLiteralPostfixTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralpostfixcollapse")
+            }
         }
 
-        registerCheckbox(state::slicingExpressionsCollapse, "List.subList and String.substring expressions") {
-            example("SliceTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#slicingexpressionscollapse")
+        settingsGroup("Code Style Adjustments") {
+            registerCheckbox(state::castExpressionsCollapse, "Type cast expressions") {
+                example("TypeCastTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#castexpressionscollapse")
+            }
+
+            registerCheckbox(
+                state::controlFlowSingleStatementCodeBlockCollapse,
+                "Control flow single-statement code block braces (read-only files)"
+            ) {
+                example("ControlFlowSingleStatementTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowsinglestatementcodeblockcollapse")
+            }
+
+            registerCheckbox(
+                state::controlFlowMultiStatementCodeBlockCollapse,
+                "Control flow multi-statement code block braces (read-only files, deprecated)"
+            ) {
+                example("ControlFlowMultiStatementTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowmultistatementcodeblockcollapse")
+            }
+
+            registerCheckbox(state::semicolonsCollapse, "Semicolons (read-only files)") {
+                example("SemicolonTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#semicolonscollapse")
+            }
+
+            registerCheckbox(state::const, "Simplify * static final to const") {
+                example("ConstTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#const")
+            }
+
+            registerCheckbox(state::finalRemoval, "Remove the 'final' modifier from all elements except fields") {
+                example("FinalRemovalTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalremoval")
+            }
+
+            registerCheckbox(state::finalEmoji, "Replace the 'final' modifier with ${Emoji.FINAL_LOCK}") {
+                example("FinalEmojiTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalemoji")
+            }
+
+            registerCheckbox(state::overrideHide, "Hide @Override annotation") {
+                example("OverrideHideTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#overrideHide")
+            }
+
+            registerCheckbox(state::suppressWarningsHide, "Hide @SuppressWarnings annotation") {
+                example("SuppressWarningsHideTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
+            }
         }
 
-        registerCheckbox(state::comparingExpressionsCollapse, "Object.equals and Comparable.compareTo expressions") {
-            example("EqualsCompareTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparingexpressionscollapse")
+        settingsCollapsibleGroup("Logging") {
+            registerCheckbox(state::logFolding, "Log folding") {
+                example("LogBrackets.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#logfolding")
+            }
+            registerCheckbox(state::logFoldingTextBlocks, "Log folding: collapse Text Blocks") {
+                example("LogFoldingTextBlocksTestData.java")
+            }
         }
 
-        registerCheckbox(state::comparingLocalDatesCollapse, "Java.time isBefore/isAfter expressions") {
-            example("LocalDateTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparinglocaldatescollapse")
+        settingsCollapsibleGroup("Lombok") {
+            registerCheckbox(state::lombok, "Display Java bean as Lombok") {
+                example("LombokTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombok")
+            }
+
+            registerCheckbox(state::lombokDirtyOff, "Don't fold Lombok dirty getters/setters") {
+                example("LombokDirtyOffTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombokdirtyoff")
+            }
+
+            registerAdditionalRow(
+                state::lombok,
+                row {
+                    cell(JBLabel("Regex to disable Lombok folding (matched classes won’t be folded)"))
+                }
+            )
+            registerAdditionalRow(state::lombok, row {
+                cell(createEditor(state::lombokPatternOff).component)
+            })
         }
 
-        registerCheckbox(state::localDateLiteralCollapse, "LocalDate.of literals (e.g. 2018-02-12)") {
-            example("LocalDateLiteralTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralcollapse")
-        }
+        settingsCollapsibleGroup("Advanced Features", collapsed = true) {
+            registerCheckbox(state::dynamic, "Dynamic names for methods based on \$user.home/dynamic-ajf2.toml") {
+                example("DynamicTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#dynamic")
+            }
 
-        registerCheckbox(state::localDateLiteralPostfixCollapse, "Postfix LocalDate literals (e.g. 2018Y-02M-12D)") {
-            example("LocalDateLiteralPostfixTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralpostfixcollapse")
-        }
+            registerCheckbox(state::arithmeticExpressions, "BigDecimal, BigInteger and Math") {
+                example("ArithmeticExpressionsTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#arithmeticexpressions")
+            }
 
-        registerCheckbox(state::castExpressionsCollapse, "Type cast expressions") {
-            example("TypeCastTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#castexpressionscollapse")
-        }
+            registerCheckbox(state::emojify, "Emojify code") {
+                example("EmojifyTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#emojify")
+            }
 
-        registerCheckbox(state::rangeExpressionsCollapse, "For loops, range expressions") {
-            example("ForRangeTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#rangeexpressionscollapse")
-        }
+            registerCheckbox(state::patternMatchingInstanceof, "Pattern Matching for instanceof (JEP 394)") {
+                example("PatternMatchingInstanceofTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#patternmatchinginstanceof")
+            }
 
-        registerCheckbox(state::checkExpressionsCollapse, "Null-safe calls") {
-            example("ElvisTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#checkexpressionscollapse")
-        }
+            registerCheckbox(state::memoryImprovement, "Memory improvements")
 
-        registerCheckbox(state::ifNullSafe, "Extended null-safe ifs") {
-            example("IfNullSafeData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#ifnullsafe")
-        }
-
-        registerCheckbox(state::kotlinQuickReturn, "Kotlin quick return") {
-            example("LetReturnIt.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#kotlinquickreturn")
-        }
-
-        registerCheckbox(state::assertsCollapse, "Asserts") {
-            example("AssertTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#asserts")
-        }
-
-        registerCheckbox(state::optional, "Display optional as Kotlin null-safe") {
-            example("OptionalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#optional")
-        }
-
-        registerCheckbox(state::streamSpread, "Display stream operations as Groovy's spread operator") {
-            example("SpreadTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#streamspread")
-        }
-
-        registerCheckbox(state::logFolding, "Log folding") {
-            example("LogBrackets.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#logfolding")
-        }
-        registerCheckbox(state::logFoldingTextBlocks, "Log folding: collapse Text Blocks") {
-            example("LogFoldingTextBlocksTestData.java")
-        }
-
-        registerCheckbox(
-            state::fieldShift,
-            "Display mapping of field with same name as << (for builders, setters and assignments)"
-        ) {
-            example("FieldShiftBuilder.java", "builders")
-            example("FieldShiftSetters.java", "setters")
-            example("FieldShiftFields.java", "fields")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#fieldshift")
-        }
-
-        registerCheckbox(state::destructuring, "Destructuring assignment for array & list") {
-            example("DestructuringAssignmentArrayTestData.java", "array")
-            example("DestructuringAssignmentListTestData.java", "list")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#destructuring")
-        }
-
-        registerCheckbox(state::println, "Simplify System.out.println to println") {
-            example("PrintlnTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#println")
-        }
-
-        registerCheckbox(
-            state::controlFlowSingleStatementCodeBlockCollapse,
-            "Control flow single-statement code block braces (read-only files)"
-        ) {
-            example("ControlFlowSingleStatementTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowsinglestatementcodeblockcollapse")
-        }
-
-        registerCheckbox(
-            state::controlFlowMultiStatementCodeBlockCollapse,
-            "Control flow multi-statement code block braces (read-only files, deprecated)"
-        ) {
-            example("ControlFlowMultiStatementTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowmultistatementcodeblockcollapse")
-        }
-
-        registerCheckbox(state::semicolonsCollapse, "Semicolons (read-only files)") {
-            example("SemicolonTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#semicolonscollapse")
-        }
-
-        registerCheckbox(state::const, "Simplify * static final to const") {
-            example("ConstTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#const")
-        }
-
-        registerCheckbox(state::nullable, "Simplify @NotNull to Type!! and @Nullable to Type?") {
-            example("NullableAnnotationTestData.java", "annotations")
-            example("NullableAnnotationCheckNotNullTestData.java", "checkNotNull")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#nullable")
-        }
-
-        registerCheckbox(state::finalRemoval, "Remove the 'final' modifier from all elements except fields") {
-            example("FinalRemovalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalremoval")
-        }
-
-        registerCheckbox(state::finalEmoji, "Replace the 'final' modifier with ${Emoji.FINAL_LOCK}") {
-            example("FinalEmojiTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalemoji")
-        }
-
-        registerCheckbox(state::lombok, "Display Java bean as Lombok") {
-            example("LombokTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombok")
-        }
-
-        registerCheckbox(state::lombokDirtyOff, "Don't fold Lombok dirty getters/setters") {
-            example("LombokDirtyOffTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombokdirtyoff")
-        }
-
-        row {
-            cell(JBLabel("Regex to disable Lombok folding (matched classes won’t be folded)"))
-        }
-        row {
-            cell(createEditor(state::lombokPatternOff).component)
-        }
-
-        registerCheckbox(state::expressionFunc, "Single-Expression Function") {
-            example("ExpressionFuncTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#expressionfunc")
-        }
-
-        registerCheckbox(state::dynamic, "Dynamic names for methods based on \$user.home/dynamic-ajf2.toml") {
-            example("DynamicTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#dynamic")
-        }
-
-        registerCheckbox(state::arithmeticExpressions, "BigDecimal, BigInteger and Math") {
-            example("ArithmeticExpressionsTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#arithmeticexpressions")
-        }
-
-        registerCheckbox(state::emojify, "Emojify code") {
-            example("EmojifyTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#emojify")
-        }
-
-        registerCheckbox(
-            state::interfaceExtensionProperties,
-            "Converts traditional getter and setter methods in interfaces into extension properties"
-        ) {
-            example("InterfaceExtensionPropertiesTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#interfaceextensionproperties")
-        }
-
-        registerCheckbox(state::patternMatchingInstanceof, "Pattern Matching for instanceof (JEP 394)") {
-            example("PatternMatchingInstanceofTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#patternmatchinginstanceof")
-        }
-
-        registerCheckbox(
-            state::summaryParentOverride,
-            "Displays a folded summary of overridden methods from parent classes and interfaces."
-        ) {
-            example("SummaryParentOverrideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#summaryparentoverride")
-        }
-
-        registerCheckbox(
-            state::constructorReferenceNotation,
-            "Constructor reference notation ::new and compact field initialization"
-        ) {
-            example("ConstructorReferenceNotationTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#constructorReferenceNotation")
-        }
-
-        registerCheckbox(state::methodDefaultParameters, "Default parameter values inline for overloaded method") {
-            example("MethodDefaultParametersTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#methodDefaultParameters")
-        }
-        registerCheckbox(state::overrideHide, "Hide @Override annotation") {
-            example("OverrideHideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#overrideHide")
-        }
-        registerCheckbox(state::suppressWarningsHide, "Hide @SuppressWarnings annotation") {
-            example("SuppressWarningsHideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
-        }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Loggable") {
-            example("PseudoAnnotationsMainTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
-        }
-        // NEW OPTION
-        registerCheckbox(state::memoryImprovement, "Memory improvements")
-        registerCheckbox(state::experimental, "Experimental features") {
-            example("ExperimentalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#experimental")
+            registerCheckbox(state::experimental, "Experimental features") {
+                example("ExperimentalTestData.java")
+                link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#experimental")
+            }
         }
     }
 

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -18,15 +18,20 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.encoding.EncodingProjectManager
 import com.intellij.ui.JBColor
+import com.intellij.ui.SearchTextField
 import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.panel
 import java.awt.Color.decode
 import java.awt.FlowLayout
 import java.net.URI
 import javax.swing.JButton
 import javax.swing.JPanel
+import javax.swing.event.DocumentEvent
 import kotlin.reflect.KMutableProperty0
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.full.memberProperties
@@ -36,7 +41,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     private lateinit var panel: DialogPanel
     private val allExampleFiles = mutableSetOf<ExampleFile>()
     private val pendingChanges = mutableMapOf<KMutableProperty0<Boolean>, Boolean>()
-    private val propertyToCheckbox = mutableMapOf<KMutableProperty0<Boolean>, JBCheckBox>()
+    private val propertyToEntry = mutableMapOf<KMutableProperty0<Boolean>, CheckboxEntry>()
     private val stateBooleanProperties: Map<String, KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>> =
         AdvancedExpressionFoldingSettings.State::class.memberProperties
             .filterIsInstance<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>>()
@@ -102,7 +107,22 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         return actionLink
     }
 
+    private var filterText: String = ""
+
     override fun createComponent() = panel {
+        row {
+            val searchField = SearchTextField()
+            searchField.textEditor.emptyText.text = "Filter options"
+            searchField.addDocumentListener(object : DocumentAdapter() {
+                override fun textChanged(event: DocumentEvent) {
+                    filterText = searchField.text.trim()
+                    applyFilter(filterText)
+                }
+            })
+            cell(searchField)
+                .align(AlignX.FILL)
+                .resizableColumn()
+        }
         row {
             val button =
                 JButton("Apply folded color: ${if (!JBColor.isBright()) "soft blue" else "dark navy"}")
@@ -137,6 +157,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         initialize(state)
     }.also {
         panel = it
+        applyFilter(filterText)
     }
 
     override fun isModified(): Boolean {
@@ -154,9 +175,10 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
 
     override fun reset() {
         pendingChanges.clear()
-        propertyToCheckbox.forEach { (property, checkbox) ->
-            checkbox.isSelected = property.get()
+        propertyToEntry.forEach { (property, entry) ->
+            entry.checkbox.isSelected = property.get()
         }
+        applyFilter(filterText)
     }
 
     private fun firstSourceRoot(project: Project): VirtualFile? {
@@ -223,7 +245,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     ) {
         val builder = CheckboxBuilder()
         block?.invoke(builder)
-        
+
         val checkbox = JBCheckBox(title)
         checkbox.isSelected = property.get()
         checkbox.addActionListener {
@@ -238,19 +260,30 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
                 pendingChanges[property] = value
             }
         }
-        propertyToCheckbox[property] = checkbox
-        
-        row {
+        val currentGroups = currentGroupPath()
+        currentGroups.forEach { it.properties += property }
+
+        val checkboxRow = row {
             cell(checkbox)
         }
-        
+
         val definition = builder.build(property, title)
-        if (definition.exampleLinkMap != null || definition.docLink != null) {
+        val exampleRow = if (definition.exampleLinkMap != null || definition.docLink != null) {
             row {
                 cell(createExamplePanel(definition.exampleLinkMap, definition.docLink))
             }
+        } else {
+            null
         }
 
+        propertyToEntry[property] = CheckboxEntry(
+            checkbox = checkbox,
+            labelText = title,
+            checkboxRow = checkboxRow,
+            exampleRow = exampleRow,
+            groups = currentGroups,
+            additionalRows = mutableListOf()
+        )
     }
 
     private fun applyBulkChange(action: AdvancedExpressionFoldingSettings.() -> Unit) {
@@ -262,10 +295,10 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
 
         bulkUpdateInProgress = true
         try {
-            propertyToCheckbox.forEach { (property, checkbox) ->
+            propertyToEntry.forEach { (property, entry) ->
                 val stateProperty = stateBooleanProperties[property.name] ?: return@forEach
                 val newValue = stateProperty.get(updatedState)
-                checkbox.isSelected = newValue
+                entry.checkbox.isSelected = newValue
                 if (property.get() == newValue) {
                     pendingChanges.remove(property)
                 } else {
@@ -275,5 +308,52 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         } finally {
             bulkUpdateInProgress = false
         }
+    }
+
+    override fun onAdditionalRowRegistered(property: KMutableProperty0<Boolean>, row: Row) {
+        propertyToEntry[property]?.additionalRows?.add(row)
+    }
+
+    private fun applyFilter(rawText: String) {
+        val filter = rawText.lowercase()
+        val visibleProperties = mutableSetOf<KMutableProperty0<Boolean>>()
+
+        propertyToEntry.forEach { (property, entry) ->
+            val matches = filter.isBlank() || entry.labelText.lowercase().contains(filter)
+            entry.checkboxRow.setVisibility(matches)
+            entry.exampleRow?.setVisibility(matches)
+            entry.additionalRows.forEach { it.setVisibility(matches) }
+            if (matches) {
+                visibleProperties += property
+            }
+        }
+
+        allGroups().forEach { group ->
+            val groupVisible = group.properties.any { it in visibleProperties }
+            group.headerRow?.setVisibility(groupVisible)
+            group.collapsibleRow?.setVisibility(groupVisible)
+        }
+
+        if (::panel.isInitialized) {
+            panel.revalidate()
+            panel.repaint()
+        }
+    }
+
+    private data class CheckboxEntry(
+        val checkbox: JBCheckBox,
+        val labelText: String,
+        val checkboxRow: Row,
+        val exampleRow: Row?,
+        val groups: List<GroupInfo>,
+        val additionalRows: MutableList<Row>
+    )
+
+    private fun Row.setVisibility(isVisible: Boolean) {
+        val method = javaClass.methods.firstOrNull { candidate ->
+            candidate.name == "visible" && candidate.parameterCount == 1 &&
+                candidate.parameterTypes[0] == Boolean::class.javaPrimitiveType
+        }
+        method?.invoke(this, isVisible)
     }
 }


### PR DESCRIPTION

<img width="1204" height="843" alt="Screenshot 2025-10-26 at 06 45 20" src="https://github.com/user-attachments/assets/96d87f17-e62a-432f-810e-69545d5bd642" />


## Summary
- restructure the settings checkboxes into themed groups, including collapsible sections for logging, Lombok, and advanced options
- add a search field that filters checkboxes and their auxiliary rows across groups using reflective row visibility updates
- keep example rows and Lombok regex controls synchronized with checkbox filtering and existing bulk actions

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68f50a040dd8832ea8fe930c9ea11d3d