### PR TITLE
Add quick documentation for folded expressions

### DIFF
--- a/examples/data/GetterSetterTestData.java
+++ b/examples/data/GetterSetterTestData.java
@@ -1,5 +1,7 @@
 package data;
 
+// Quick Doc screenshot: docs/images/getter-quick-doc.png
+
 public class GetterSetterTestData {
     public static void main(String[] args) {
         GetterSetterTestData d = new GetterSetterTestData();

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,6 +50,7 @@
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.pseudo.TracingLoggableAnnotationCompletionContributor"/>
+        <documentationProvider implementation="com.intellij.advancedExpressionFolding.documentation.FoldingDocumentationProvider"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/documentation/DocumentationLinks.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/DocumentationLinks.kt
@@ -1,0 +1,54 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+object DocumentationLinks {
+    private const val BASE_URL = "https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki"
+
+    private val anchors = mapOf(
+        "getSetExpressionsCollapse" to "#getsetexpressionscollapse",
+        "varExpressionsCollapse" to "#varexpressionscollapse",
+        "compactControlFlowSyntaxCollapse" to "#compactcontrolflowsyntaxcollapse",
+        "getExpressionsCollapse" to "#getexpressionscollapse",
+        "concatenationExpressionsCollapse" to "#concatenationexpressionscollapse",
+        "slicingExpressionsCollapse" to "#slicingexpressionscollapse",
+        "comparingExpressionsCollapse" to "#comparingexpressionscollapse",
+        "comparingLocalDatesCollapse" to "#comparinglocaldatescollapse",
+        "localDateLiteralCollapse" to "#localdateliteralcollapse",
+        "localDateLiteralPostfixCollapse" to "#localdateliteralpostfixcollapse",
+        "castExpressionsCollapse" to "#castexpressionscollapse",
+        "rangeExpressionsCollapse" to "#rangeexpressionscollapse",
+        "checkExpressionsCollapse" to "#checkexpressionscollapse",
+        "ifNullSafe" to "#ifnullsafe",
+        "kotlinQuickReturn" to "#kotlinquickreturn",
+        "assertsCollapse" to "#asserts",
+        "optional" to "#optional",
+        "streamSpread" to "#streamspread",
+        "logFolding" to "#logfolding",
+        "fieldShift" to "#fieldshift",
+        "destructuring" to "#destructuring",
+        "println" to "#println",
+        "controlFlowSingleStatementCodeBlockCollapse" to "#controlflowsinglestatementcodeblockcollapse",
+        "controlFlowMultiStatementCodeBlockCollapse" to "#controlflowmultistatementcodeblockcollapse",
+        "semicolonsCollapse" to "#semicolonscollapse",
+        "const" to "#const",
+        "nullable" to "#nullable",
+        "finalRemoval" to "#finalremoval",
+        "finalEmoji" to "#finalemoji",
+        "lombok" to "#lombok",
+        "lombokDirtyOff" to "#lombokdirtyoff",
+        "expressionFunc" to "#expressionfunc",
+        "dynamic" to "#dynamic",
+        "arithmeticExpressions" to "#arithmeticexpressions",
+        "emojify" to "#emojify",
+        "interfaceExtensionProperties" to "#interfaceextensionproperties",
+        "patternMatchingInstanceof" to "#patternmatchinginstanceof",
+        "summaryParentOverride" to "#summaryparentoverride",
+        "constructorReferenceNotation" to "#constructorReferenceNotation",
+        "methodDefaultParameters" to "#methodDefaultParameters",
+        "overrideHide" to "#overrideHide",
+        "suppressWarningsHide" to "#suppressWarningsHide",
+        "pseudoAnnotations" to "#pseudoAnnotations",
+        "experimental" to "#experimental"
+    )
+
+    fun urlFor(settingKey: String): String? = anchors[settingKey]?.let { BASE_URL + it }
+}

--- a/src/com/intellij/advancedExpressionFolding/documentation/ExpressionSettingLocator.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/ExpressionSettingLocator.kt
@@ -1,0 +1,99 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.expression.VariableDeclarationImpl
+import com.intellij.advancedExpressionFolding.expression.controlflow.AbstractControlFlowCodeBlock
+import com.intellij.advancedExpressionFolding.expression.controlflow.CompactControlFlowExpression
+import com.intellij.advancedExpressionFolding.expression.controlflow.ControlFlowMultiStatementCodeBlockExpression
+import com.intellij.advancedExpressionFolding.expression.controlflow.ControlFlowSingleStatementCodeBlockExpression
+import com.intellij.advancedExpressionFolding.expression.controlflow.ElvisExpression
+import com.intellij.advancedExpressionFolding.expression.controlflow.ForEachIndexedStatement
+import com.intellij.advancedExpressionFolding.expression.controlflow.ForEachStatement
+import com.intellij.advancedExpressionFolding.expression.controlflow.ForStatement
+import com.intellij.advancedExpressionFolding.expression.controlflow.SemicolonExpression
+import com.intellij.advancedExpressionFolding.expression.controlflow.ShortElvisExpression
+import com.intellij.advancedExpressionFolding.expression.literal.LocalDateLiteral
+import com.intellij.advancedExpressionFolding.expression.operation.FieldShiftMethod
+import com.intellij.advancedExpressionFolding.expression.operation.Get
+import com.intellij.advancedExpressionFolding.expression.operation.basic.Append
+import com.intellij.advancedExpressionFolding.expression.operation.basic.TypeCast
+import com.intellij.advancedExpressionFolding.expression.operation.collection.ArrayGet
+import com.intellij.advancedExpressionFolding.expression.operation.collection.ArrayStream
+import com.intellij.advancedExpressionFolding.expression.operation.collection.Collect
+import com.intellij.advancedExpressionFolding.expression.operation.collection.Put
+import com.intellij.advancedExpressionFolding.expression.operation.collection.Range
+import com.intellij.advancedExpressionFolding.expression.operation.collection.Slice
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalMapCall
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalMapSafeCall
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalMapSafeCallParam
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalNotNullAssertionGet
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalOf
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalOfNullable
+import com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalOrElseElvis
+import com.intellij.advancedExpressionFolding.expression.operation.stream.StreamExpression
+import com.intellij.advancedExpressionFolding.expression.operation.stream.StreamFilterNotNull
+import com.intellij.advancedExpressionFolding.expression.operation.stream.StreamMapCallParam
+import com.intellij.advancedExpressionFolding.expression.operation.stream.StringExpression
+import com.intellij.advancedExpressionFolding.expression.operation.stream.StringOperation
+import com.intellij.advancedExpressionFolding.expression.property.Getter
+import com.intellij.advancedExpressionFolding.expression.property.GetterRecord
+import com.intellij.advancedExpressionFolding.expression.property.Setter
+import com.intellij.advancedExpressionFolding.expression.semantic.BuilderShiftExpression
+import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.IfNullSafeExpression
+import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.LetReturnIt
+import kotlin.reflect.KClass
+
+object ExpressionSettingLocator {
+    private val keysByClass: Map<KClass<out Expression>, Set<String>> = mapOf(
+        Getter::class to setOf("getSetExpressionsCollapse"),
+        Setter::class to setOf("getSetExpressionsCollapse"),
+        GetterRecord::class to setOf("getSetExpressionsCollapse"),
+        OptionalNotNullAssertionGet::class to setOf("getSetExpressionsCollapse", "optional"),
+        OptionalMapSafeCall::class to setOf("optional"),
+        OptionalMapSafeCallParam::class to setOf("optional"),
+        OptionalMapCall::class to setOf("optional"),
+        OptionalOf::class to setOf("optional"),
+        OptionalOfNullable::class to setOf("optional"),
+        OptionalOrElseElvis::class to setOf("optional"),
+        VariableDeclarationImpl::class to setOf("varExpressionsCollapse"),
+        Append::class to setOf("concatenationExpressionsCollapse"),
+        StringExpression::class to setOf("concatenationExpressionsCollapse"),
+        StringOperation::class to setOf("concatenationExpressionsCollapse"),
+        StreamExpression::class to setOf("concatenationExpressionsCollapse"),
+        StreamMapCallParam::class to setOf("concatenationExpressionsCollapse"),
+        StreamFilterNotNull::class to setOf("concatenationExpressionsCollapse"),
+        Collect::class to setOf("concatenationExpressionsCollapse"),
+        ArrayStream::class to setOf("concatenationExpressionsCollapse"),
+        Slice::class to setOf("slicingExpressionsCollapse"),
+        Range::class to setOf("rangeExpressionsCollapse"),
+        ForEachStatement::class to setOf("rangeExpressionsCollapse"),
+        ForEachIndexedStatement::class to setOf("rangeExpressionsCollapse"),
+        ForStatement::class to setOf("rangeExpressionsCollapse", "compactControlFlowSyntaxCollapse"),
+        CompactControlFlowExpression::class to setOf("compactControlFlowSyntaxCollapse"),
+        AbstractControlFlowCodeBlock::class to setOf("controlFlowSingleStatementCodeBlockCollapse"),
+        ControlFlowSingleStatementCodeBlockExpression::class to setOf("controlFlowSingleStatementCodeBlockCollapse"),
+        ControlFlowMultiStatementCodeBlockExpression::class to setOf("controlFlowMultiStatementCodeBlockCollapse"),
+        ElvisExpression::class to setOf("checkExpressionsCollapse"),
+        ShortElvisExpression::class to setOf("checkExpressionsCollapse"),
+        IfNullSafeExpression::class to setOf("ifNullSafe"),
+        LetReturnIt::class to setOf("kotlinQuickReturn"),
+        TypeCast::class to setOf("castExpressionsCollapse"),
+        SemicolonExpression::class to setOf("semicolonsCollapse"),
+        Get::class to setOf("getExpressionsCollapse"),
+        Put::class to setOf("getExpressionsCollapse"),
+        ArrayGet::class to setOf("getExpressionsCollapse"),
+        BuilderShiftExpression::class to setOf("fieldShift"),
+        FieldShiftMethod::class to setOf("fieldShift"),
+        LocalDateLiteral::class to setOf("localDateLiteralCollapse", "localDateLiteralPostfixCollapse")
+    )
+
+    fun settingKeysFor(expression: Expression): Set<String> {
+        val result = linkedSetOf<String>()
+        for ((clazz, keys) in keysByClass) {
+            if (clazz.java.isAssignableFrom(expression.javaClass)) {
+                result += keys
+            }
+        }
+        return result
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationProvider.kt
@@ -1,0 +1,104 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder
+import com.intellij.advancedExpressionFolding.isAdvancedExpressionFoldingGroup
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.openapi.util.TextRange
+import com.intellij.xml.util.XmlStringUtil
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+
+class FoldingDocumentationProvider : AbstractDocumentationProvider() {
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
+        val target = element ?: originalElement ?: return null
+        val project = target.project
+        val file = target.containingFile ?: return null
+        val document = PsiDocumentManager.getInstance(project).getDocument(file) ?: return null
+
+        return try {
+            val builder = AdvancedExpressionFoldingBuilder()
+            val descriptors = builder.buildFoldRegions(file, document, false)
+                .filter(FoldingDescriptor::isAdvancedExpressionFoldingGroup)
+            if (descriptors.isEmpty()) {
+                return null
+            }
+
+            val expression = BuildExpressionExt.getNonSyntheticExpression(target, document) ?: return null
+            if (!expression.textRange.contains(target.textRange)) {
+                return null
+            }
+            if (!expression.supportsFoldRegions(document, null)) {
+                return null
+            }
+
+            val expressionDescriptors = descriptors.filter { expression.textRange.contains(it.range) }
+            if (expressionDescriptors.isEmpty()) {
+                return null
+            }
+
+            val before = document.getText(expression.textRange)
+            val after = applyPlaceholders(before, expression.textRange, expressionDescriptors)
+            if (after == before) {
+                return null
+            }
+
+            val settingKeys = ExpressionSettingLocator.settingKeysFor(expression)
+            if (settingKeys.isEmpty()) {
+                return null
+            }
+
+            renderDocumentation(settingKeys, before, after)
+        } catch (_: IndexNotReadyException) {
+            null
+        }
+    }
+
+    private fun applyPlaceholders(
+        originalText: String,
+        range: TextRange,
+        descriptors: List<FoldingDescriptor>
+    ): String {
+        if (descriptors.isEmpty()) {
+            return originalText
+        }
+        val builder = StringBuilder(originalText)
+        val relativeDescriptors = descriptors.sortedByDescending { it.range.startOffset }
+        for (descriptor in relativeDescriptors) {
+            val placeholder = descriptor.placeholderText ?: continue
+            val start = descriptor.range.startOffset - range.startOffset
+            val end = descriptor.range.endOffset - range.startOffset
+            if (start < 0 || end < start || end > builder.length) {
+                continue
+            }
+            builder.replace(start, end, placeholder)
+        }
+        return builder.toString()
+    }
+
+    private fun renderDocumentation(keys: Set<String>, before: String, after: String): String {
+        val label = if (keys.size > 1) "Settings" else "Setting"
+        val settingsHtml = keys.joinToString(separator = " ") { key ->
+            val link = DocumentationLinks.urlFor(key)
+            if (link != null) {
+                "<code>$key</code>&nbsp;<a href=\"$link\">docs</a>"
+            } else {
+                "<code>$key</code>"
+            }
+        }
+        val escapedBefore = XmlStringUtil.escapeString(before)
+        val escapedAfter = XmlStringUtil.escapeString(after)
+
+        val body = buildString {
+            append("<h3>Advanced Expression Folding</h3>")
+            append("<p>$label: $settingsHtml</p>")
+            append("<p>Before</p>")
+            append("<pre><code>$escapedBefore</code></pre>")
+            append("<p>After</p>")
+            append("<pre><code>$escapedAfter</code></pre>")
+        }
+        return XmlStringUtil.wrapInHtml(body)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -1,5 +1,6 @@
 package com.intellij.advancedExpressionFolding.settings.view
 
+import com.intellij.advancedExpressionFolding.documentation.DocumentationLinks
 import com.intellij.advancedExpressionFolding.processor.util.Consts.Emoji
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import com.intellij.openapi.application.ApplicationManager
@@ -24,12 +25,12 @@ abstract class CheckboxesProvider {
     fun Panel.initialize(state: State) {
         registerCheckbox(state::getSetExpressionsCollapse, "Getters and setters as properties") {
             example("GetterSetterTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getsetexpressionscollapse")
+            DocumentationLinks.urlFor("getSetExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::varExpressionsCollapse, "Variable declarations (var/val)") {
             example("VarTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#varexpressionscollapse")
+            DocumentationLinks.urlFor("varExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(
@@ -37,7 +38,7 @@ abstract class CheckboxesProvider {
             "Compact control flow condition syntax (Golang ifs)"
         ) {
             example("CompactControlFlowTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#compactcontrolflowsyntaxcollapse")
+            DocumentationLinks.urlFor("compactControlFlowSyntaxCollapse")?.let(::link)
         }
 
         registerCheckbox(
@@ -45,7 +46,7 @@ abstract class CheckboxesProvider {
             "List.get, List.set, Map.get and Map.put expressions, array and list literals"
         ) {
             example("GetSetPutTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#getexpressionscollapse")
+            DocumentationLinks.urlFor("getExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(
@@ -56,77 +57,77 @@ abstract class CheckboxesProvider {
             example("InterpolatedStringTestData.java", "Interpolate")
             example("AppendSetterInterpolatedStringTestData.java", "Append")
             example("ConcatenationTestData.java", "Concatenation")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#concatenationexpressionscollapse")
+            DocumentationLinks.urlFor("concatenationExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::slicingExpressionsCollapse, "List.subList and String.substring expressions") {
             example("SliceTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#slicingexpressionscollapse")
+            DocumentationLinks.urlFor("slicingExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::comparingExpressionsCollapse, "Object.equals and Comparable.compareTo expressions") {
             example("EqualsCompareTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparingexpressionscollapse")
+            DocumentationLinks.urlFor("comparingExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::comparingLocalDatesCollapse, "Java.time isBefore/isAfter expressions") {
             example("LocalDateTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#comparinglocaldatescollapse")
+            DocumentationLinks.urlFor("comparingLocalDatesCollapse")?.let(::link)
         }
 
         registerCheckbox(state::localDateLiteralCollapse, "LocalDate.of literals (e.g. 2018-02-12)") {
             example("LocalDateLiteralTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralcollapse")
+            DocumentationLinks.urlFor("localDateLiteralCollapse")?.let(::link)
         }
 
         registerCheckbox(state::localDateLiteralPostfixCollapse, "Postfix LocalDate literals (e.g. 2018Y-02M-12D)") {
             example("LocalDateLiteralPostfixTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#localdateliteralpostfixcollapse")
+            DocumentationLinks.urlFor("localDateLiteralPostfixCollapse")?.let(::link)
         }
 
         registerCheckbox(state::castExpressionsCollapse, "Type cast expressions") {
             example("TypeCastTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#castexpressionscollapse")
+            DocumentationLinks.urlFor("castExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::rangeExpressionsCollapse, "For loops, range expressions") {
             example("ForRangeTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#rangeexpressionscollapse")
+            DocumentationLinks.urlFor("rangeExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::checkExpressionsCollapse, "Null-safe calls") {
             example("ElvisTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#checkexpressionscollapse")
+            DocumentationLinks.urlFor("checkExpressionsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::ifNullSafe, "Extended null-safe ifs") {
             example("IfNullSafeData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#ifnullsafe")
+            DocumentationLinks.urlFor("ifNullSafe")?.let(::link)
         }
 
         registerCheckbox(state::kotlinQuickReturn, "Kotlin quick return") {
             example("LetReturnIt.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#kotlinquickreturn")
+            DocumentationLinks.urlFor("kotlinQuickReturn")?.let(::link)
         }
 
         registerCheckbox(state::assertsCollapse, "Asserts") {
             example("AssertTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#asserts")
+            DocumentationLinks.urlFor("assertsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::optional, "Display optional as Kotlin null-safe") {
             example("OptionalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#optional")
+            DocumentationLinks.urlFor("optional")?.let(::link)
         }
 
         registerCheckbox(state::streamSpread, "Display stream operations as Groovy's spread operator") {
             example("SpreadTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#streamspread")
+            DocumentationLinks.urlFor("streamSpread")?.let(::link)
         }
 
         registerCheckbox(state::logFolding, "Log folding") {
             example("LogBrackets.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#logfolding")
+            DocumentationLinks.urlFor("logFolding")?.let(::link)
         }
         registerCheckbox(state::logFoldingTextBlocks, "Log folding: collapse Text Blocks") {
             example("LogFoldingTextBlocksTestData.java")
@@ -139,18 +140,18 @@ abstract class CheckboxesProvider {
             example("FieldShiftBuilder.java", "builders")
             example("FieldShiftSetters.java", "setters")
             example("FieldShiftFields.java", "fields")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#fieldshift")
+            DocumentationLinks.urlFor("fieldShift")?.let(::link)
         }
 
         registerCheckbox(state::destructuring, "Destructuring assignment for array & list") {
             example("DestructuringAssignmentArrayTestData.java", "array")
             example("DestructuringAssignmentListTestData.java", "list")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#destructuring")
+            DocumentationLinks.urlFor("destructuring")?.let(::link)
         }
 
         registerCheckbox(state::println, "Simplify System.out.println to println") {
             example("PrintlnTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#println")
+            DocumentationLinks.urlFor("println")?.let(::link)
         }
 
         registerCheckbox(
@@ -158,7 +159,7 @@ abstract class CheckboxesProvider {
             "Control flow single-statement code block braces (read-only files)"
         ) {
             example("ControlFlowSingleStatementTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowsinglestatementcodeblockcollapse")
+            DocumentationLinks.urlFor("controlFlowSingleStatementCodeBlockCollapse")?.let(::link)
         }
 
         registerCheckbox(
@@ -166,43 +167,43 @@ abstract class CheckboxesProvider {
             "Control flow multi-statement code block braces (read-only files, deprecated)"
         ) {
             example("ControlFlowMultiStatementTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowmultistatementcodeblockcollapse")
+            DocumentationLinks.urlFor("controlFlowMultiStatementCodeBlockCollapse")?.let(::link)
         }
 
         registerCheckbox(state::semicolonsCollapse, "Semicolons (read-only files)") {
             example("SemicolonTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#semicolonscollapse")
+            DocumentationLinks.urlFor("semicolonsCollapse")?.let(::link)
         }
 
         registerCheckbox(state::const, "Simplify * static final to const") {
             example("ConstTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#const")
+            DocumentationLinks.urlFor("const")?.let(::link)
         }
 
         registerCheckbox(state::nullable, "Simplify @NotNull to Type!! and @Nullable to Type?") {
             example("NullableAnnotationTestData.java", "annotations")
             example("NullableAnnotationCheckNotNullTestData.java", "checkNotNull")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#nullable")
+            DocumentationLinks.urlFor("nullable")?.let(::link)
         }
 
         registerCheckbox(state::finalRemoval, "Remove the 'final' modifier from all elements except fields") {
             example("FinalRemovalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalremoval")
+            DocumentationLinks.urlFor("finalRemoval")?.let(::link)
         }
 
         registerCheckbox(state::finalEmoji, "Replace the 'final' modifier with ${Emoji.FINAL_LOCK}") {
             example("FinalEmojiTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#finalemoji")
+            DocumentationLinks.urlFor("finalEmoji")?.let(::link)
         }
 
         registerCheckbox(state::lombok, "Display Java bean as Lombok") {
             example("LombokTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombok")
+            DocumentationLinks.urlFor("lombok")?.let(::link)
         }
 
         registerCheckbox(state::lombokDirtyOff, "Don't fold Lombok dirty getters/setters") {
             example("LombokDirtyOffTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#lombokdirtyoff")
+            DocumentationLinks.urlFor("lombokDirtyOff")?.let(::link)
         }
 
         row {
@@ -214,22 +215,22 @@ abstract class CheckboxesProvider {
 
         registerCheckbox(state::expressionFunc, "Single-Expression Function") {
             example("ExpressionFuncTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#expressionfunc")
+            DocumentationLinks.urlFor("expressionFunc")?.let(::link)
         }
 
         registerCheckbox(state::dynamic, "Dynamic names for methods based on \$user.home/dynamic-ajf2.toml") {
             example("DynamicTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#dynamic")
+            DocumentationLinks.urlFor("dynamic")?.let(::link)
         }
 
         registerCheckbox(state::arithmeticExpressions, "BigDecimal, BigInteger and Math") {
             example("ArithmeticExpressionsTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#arithmeticexpressions")
+            DocumentationLinks.urlFor("arithmeticExpressions")?.let(::link)
         }
 
         registerCheckbox(state::emojify, "Emojify code") {
             example("EmojifyTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#emojify")
+            DocumentationLinks.urlFor("emojify")?.let(::link)
         }
 
         registerCheckbox(
@@ -237,12 +238,12 @@ abstract class CheckboxesProvider {
             "Converts traditional getter and setter methods in interfaces into extension properties"
         ) {
             example("InterfaceExtensionPropertiesTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#interfaceextensionproperties")
+            DocumentationLinks.urlFor("interfaceExtensionProperties")?.let(::link)
         }
 
         registerCheckbox(state::patternMatchingInstanceof, "Pattern Matching for instanceof (JEP 394)") {
             example("PatternMatchingInstanceofTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#patternmatchinginstanceof")
+            DocumentationLinks.urlFor("patternMatchingInstanceof")?.let(::link)
         }
 
         registerCheckbox(
@@ -250,7 +251,7 @@ abstract class CheckboxesProvider {
             "Displays a folded summary of overridden methods from parent classes and interfaces."
         ) {
             example("SummaryParentOverrideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#summaryparentoverride")
+            DocumentationLinks.urlFor("summaryParentOverride")?.let(::link)
         }
 
         registerCheckbox(
@@ -258,30 +259,30 @@ abstract class CheckboxesProvider {
             "Constructor reference notation ::new and compact field initialization"
         ) {
             example("ConstructorReferenceNotationTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#constructorReferenceNotation")
+            DocumentationLinks.urlFor("constructorReferenceNotation")?.let(::link)
         }
 
         registerCheckbox(state::methodDefaultParameters, "Default parameter values inline for overloaded method") {
             example("MethodDefaultParametersTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#methodDefaultParameters")
+            DocumentationLinks.urlFor("methodDefaultParameters")?.let(::link)
         }
         registerCheckbox(state::overrideHide, "Hide @Override annotation") {
             example("OverrideHideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#overrideHide")
+            DocumentationLinks.urlFor("overrideHide")?.let(::link)
         }
         registerCheckbox(state::suppressWarningsHide, "Hide @SuppressWarnings annotation") {
             example("SuppressWarningsHideTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
+            DocumentationLinks.urlFor("suppressWarningsHide")?.let(::link)
         }
         registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Loggable") {
             example("PseudoAnnotationsMainTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
+            DocumentationLinks.urlFor("pseudoAnnotations")?.let(::link)
         }
         // NEW OPTION
         registerCheckbox(state::memoryImprovement, "Memory improvements")
         registerCheckbox(state::experimental, "Experimental features") {
             example("ExperimentalTestData.java")
-            link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#experimental")
+            DocumentationLinks.urlFor("experimental")?.let(::link)
         }
     }
 

--- a/test/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationProviderTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationProviderTest.kt
@@ -1,0 +1,45 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.openapi.application.ReadAction
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.util.PsiTreeUtil
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FoldingDocumentationProviderTest : BaseTest() {
+    @Test
+    fun getterDocumentationRendersBeforeAfter() {
+        fixture.configureByText(
+            "GetterDoc.java",
+            """
+            class GetterDoc {
+                String name;
+                String getName() { return name; }
+                void test(GetterDoc doc) {
+                    doc.getName();
+                }
+            }
+            """.trimIndent()
+        )
+
+        val offset = fixture.editor.document.text.indexOf("getName();")
+        assertTrue(offset >= 0)
+        val call = ReadAction.compute<PsiMethodCallExpression, RuntimeException> {
+            val element = fixture.file.findElementAt(offset)
+            PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression::class.java)
+        }!!
+
+        val provider = FoldingDocumentationProvider()
+        val documentation = ReadAction.compute<String?, RuntimeException> {
+            provider.generateDoc(call, call)
+        }
+
+        assertNotNull(documentation)
+        val html = documentation!!
+        assertTrue(html.contains("doc.getName()"))
+        assertTrue(html.contains("doc.name"))
+        assertTrue(html.contains("getSetExpressionsCollapse"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a documentation provider that shows before/after snippets for folded expressions and links to the controlling setting
- share documentation URLs between settings and documentation rendering through new helpers
- add unit coverage for getter quick docs and reference the screenshot in the getter example data

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f505406e38832e8b51d06a12e0c911