### PR TITLE
Refactor method name handling to use value class

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
@@ -74,5 +74,7 @@ abstract class AbstractMethodCall : BaseExtension() {
     ): Expression? = null
 
     open val methodNames: List<MethodName> by lazy { emptyList() }
+    protected fun methodName(name: String): MethodName = MethodName(name)
+    protected fun methodNames(vararg names: String): List<MethodName> = names.map(::MethodName)
     open val classNames: List<ClassName> by lazy { emptyList() }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/Context.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/Context.kt
@@ -6,7 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
 
 data class Context(
-    val methodName: String,
+    val methodName: MethodName,
     val className: String,
     val qualifierExprNullable: Expression?,
     val method: PsiMethod,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt
@@ -46,14 +46,14 @@ object MethodCallExpressionExt {
         element: PsiMethodCallExpression
     ): Expression? {
         val factory = MethodCallFoldingLoaderService.factory()
-        if (!factory.supportedMethods.contains(identifier.text)) {
+        if (!factory.supportedMethods.contains(MethodName(identifier.text))) {
             return null
         }
         val method = referenceExpression.resolve() as? PsiMethod ?: return null
         val psiClass = method.containingClass ?: return null
         val qualifiedName = psiClass.qualifiedName ?: return null
         val className = Helper.eraseGenerics(qualifiedName)
-        val supported = factory.supportedClasses.contains(className) || factory.classlessMethods.contains(method.name)
+        val supported = factory.supportedClasses.contains(className) || factory.classlessMethods.contains(MethodName(method.name))
         return if (supported) {
             onAnyExpression(element, document, qualifier, identifier, className, method)
         } else {
@@ -70,7 +70,7 @@ object MethodCallExpressionExt {
         method: PsiMethod
     ): Expression? {
         val qualifierExpression = qualifier?.let { BuildExpressionExt.getAnyExpression(it, document) }
-        val methodName = identifier.text
+        val methodName = MethodName(identifier.text)
         val factory = MethodCallFoldingLoaderService.factory()
         val methodCalls = factory.findByMethodName(methodName) ?: return null
         for (methodCall in methodCalls) {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
@@ -6,7 +6,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticAbsMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("abs") }
+    override val methodNames by lazy { methodNames("abs") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticAddMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("add") }
+    override val methodNames by lazy { methodNames("add") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticAndMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("and") }
+    override val methodNames by lazy { methodNames("and") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndNotMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndNotMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class ArithmeticAndNotMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("andNot") }
+    override val methodNames by lazy { methodNames("andNot") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticAtan2MethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("atan2") }
+    override val methodNames by lazy { methodNames("atan2") }
 
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticDivideMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("divide") }
+    override val methodNames by lazy { methodNames("divide") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticGcdMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("gcd") }
+    override val methodNames by lazy { methodNames("gcd") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticMaxMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("max") }
+    override val methodNames by lazy { methodNames("max") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMinMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMinMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticMinMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("min") }
+    override val methodNames by lazy { methodNames("min") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticMultiplyMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("multiply") }
+    override val methodNames by lazy { methodNames("multiply") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
@@ -6,7 +6,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticNegateMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("negate") }
+    override val methodNames by lazy { methodNames("negate") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
@@ -6,7 +6,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticNotMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("not") }
+    override val methodNames by lazy { methodNames("not") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticOrMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("or") }
+    override val methodNames by lazy { methodNames("or") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
@@ -5,7 +5,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticPlusMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("plus") }
+    override val methodNames by lazy { methodNames("plus") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticPowMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("pow") }
+    override val methodNames by lazy { methodNames("pow") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticRemainderMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("remainder", "mod") }
+    override val methodNames by lazy { methodNames("remainder", "mod") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticShiftLeftMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftLeft") }
+    override val methodNames by lazy { methodNames("shiftLeft") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticShiftRightMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftRight") }
+    override val methodNames by lazy { methodNames("shiftRight") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
@@ -6,7 +6,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticSignumMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("signum") }
+    override val methodNames by lazy { methodNames("signum") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticSubtractMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("subtract") }
+    override val methodNames by lazy { methodNames("subtract") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class ArithmeticXorMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("xor") }
+    override val methodNames by lazy { methodNames("xor") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt
@@ -14,7 +14,7 @@ import java.util.*
 class AppendMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("append") }
+    override val methodNames by lazy { methodNames("append") }
     
     override val classNames by lazy { listOf(
         "java.lang.StringBuilder", 

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/CharAtMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/CharAtMethodCall.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CharAtMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("charAt") }
+    override val methodNames by lazy { methodNames("charAt") }
     
     override val classNames by lazy { listOf("java.lang.String") }
     

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/EqualsMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/EqualsMethodCall.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class EqualsMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = comparingExpressionsCollapse
 
-    override val methodNames by lazy { listOf("equals") }
+    override val methodNames by lazy { methodNames("equals") }
     
     override val classNames by lazy { listOf(
         "java.lang.Object",

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/PrintlnMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/PrintlnMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class PrintlnMethodCall : AbstractMethodCall(), NeedsQualifier {
-    override val methodNames by lazy { listOf("println") }
+    override val methodNames by lazy { methodNames("println") }
     
     override val classNames by lazy { listOf("java.io.PrintStream") }
     

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/SubstringOrSubListMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/SubstringOrSubListMethodCall.kt
@@ -16,7 +16,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class SubstringOrSubListMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = slicingExpressionsCollapse
 
-    override val methodNames by lazy { listOf("substring", "subList") }
+    override val methodNames by lazy { methodNames("substring", "subList") }
     
     override val classNames by lazy { listOf(
         "java.lang.String",

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/ToStringMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/ToStringMethodCall.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiStatement
 
 class ToStringMethodCall : AbstractMethodCall(), NeedsQualifier {
-    override val methodNames by lazy { listOf("toString") }
+    override val methodNames by lazy { methodNames("toString") }
     
     override val classNames by lazy { listOf(
         "java.lang.Object",

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/ValueOfMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/ValueOfMethodCall.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiReferenceExpression
 
 class ValueOfMethodCall : AbstractMethodCall(), NeedsQualifier {
-    override val methodNames by lazy { listOf("valueOf") }
+    override val methodNames by lazy { methodNames("valueOf") }
     
     override val classNames by lazy { listOf(
         "java.lang.String",

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/ArraysListMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/ArraysListMethodCall.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class ArraysListMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = getExpressionsCollapse
 
-    override val methodNames by lazy { listOf("asList", "singletonList") }
+    override val methodNames by lazy { methodNames("asList", "singletonList") }
 
     override val classNames by lazy { listOf("java.util.Arrays", "java.util.Collections") }
 
@@ -21,7 +21,7 @@ class ArraysListMethodCall : AbstractMethodCall(), NeedsQualifier {
         context: Context,
         expressions: Array<PsiExpression>
     ): Expression? {
-        if (context.methodName != "asList" ||
+        if (context.methodName != methodName("asList") ||
             expressions.size != 1 ||
             expressions[0].type !is PsiArrayType
         ) {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CollectionAddAllMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("addAll") }
+    override val methodNames by lazy { methodNames("addAll") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddMethodCall.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiStatement
 class CollectionAddMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
     
-    override val methodNames by lazy { listOf("add") }
+    override val methodNames by lazy { methodNames("add") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionGetMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionGetMethodCall.kt
@@ -16,7 +16,7 @@ class CollectionGetMethodCall : AbstractMethodCall(), NeedsQualifier {
 
     override fun canExecute() = getExpressionsCollapse
 
-    override val methodNames by lazy { listOf("get", "getProperty", "getAttribute", "getValue") }
+    override val methodNames by lazy { methodNames("get", "getProperty", "getAttribute", "getValue") }
 
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveAllMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveAllMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CollectionRemoveAllMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("removeAll") }
+    override val methodNames by lazy { methodNames("removeAll") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveMethodCall.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiStatement
 class CollectionRemoveMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
     
-    override val methodNames by lazy { listOf("remove") }
+    override val methodNames by lazy { methodNames("remove") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionStreamMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionStreamMethodCall.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiReferenceExpression
 class CollectionStreamMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("stream") }
+    override val methodNames by lazy { methodNames("stream") }
     
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableListMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableListMethodCall.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CollectionsUnmodifiableListMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = getExpressionsCollapse
 
-    override val methodNames by lazy { listOf("unmodifiableList") }
+    override val methodNames by lazy { methodNames("unmodifiableList") }
     
     override val classNames by lazy { listOf("java.util.Collections") }
     

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableSetMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableSetMethodCall.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CollectionsUnmodifiableSetMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = getExpressionsCollapse
 
-    override val methodNames by lazy { listOf("unmodifiableSet") }
+    override val methodNames by lazy { methodNames("unmodifiableSet") }
     
     override val classNames by lazy { listOf("java.util.Collections") }
     

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt
@@ -14,7 +14,7 @@ class MapPutMethodCall : AbstractMethodCall(), NeedsQualifier {
 
     override fun canExecute() = getExpressionsCollapse
 
-    override val methodNames by lazy { listOf("set", "put", "setProperty", "setAttribute", "setValue") }
+    override val methodNames by lazy { methodNames("set", "put", "setProperty", "setAttribute", "setValue") }
 
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/AfterDateMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/AfterDateMethodCall.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class AfterDateMethodCall : AbstractMethodCall() {
     override fun canExecute() = comparingLocalDatesCollapse
 
-    override val methodNames by lazy { listOf("isAfter", "after") }
+    override val methodNames by lazy { methodNames("isAfter", "after") }
 
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/BeforeDateMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/BeforeDateMethodCall.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class BeforeDateMethodCall : AbstractMethodCall() {
     override fun canExecute() = comparingLocalDatesCollapse
 
-    override val methodNames by lazy { listOf("isBefore", "before") }
+    override val methodNames by lazy { methodNames("isBefore", "before") }
 
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiMethodCallExpression
 class CreateDateFactoryMethodCall : AbstractMethodCall() {
     override fun canExecute() = localDateLiteralCollapse || localDateLiteralPostfixCollapse
 
-    override val methodNames by lazy { listOf("of") }
+    override val methodNames by lazy { methodNames("of") }
 
     override val classNames by lazy { listOf("java.time.LocalDate") }
 

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt
@@ -34,7 +34,7 @@ class AddDynamicMethodFoldingIntention : IntentionAction {
         val element = file.findElementAt(editor.caretModel.offset)
         val methodCall = PsiTreeUtil.getParentOfType(element, PsiMethodCallExpression::class.java)
 
-        methodCall?.methodExpression?.referenceName?.let { methodName ->
+        methodCall?.methodExpression?.referenceName?.let(::MethodName)?.let { methodName ->
             when {
                 methodName.exists() -> {
                     val dialogResult = methodName.showRenameDialog()
@@ -68,14 +68,14 @@ class AddDynamicMethodFoldingIntention : IntentionAction {
         it is DynamicMethodCall
     } == true
 
-    private fun MethodName.getNewNameFromUser(): String? {
+    private fun MethodName.getNewNameFromUser(): MethodName? {
         return Messages.showInputDialog(
             "Enter new method name:",
             "Add Dynamic Method Folding",
             Messages.getQuestionIcon(),
-            this,
+            this.value,
             null
-        )
+        )?.let(::MethodName)
     }
 
     private fun MethodName.remove() = ConfigurationParser.remove(this)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
@@ -23,11 +23,11 @@ object ConfigurationParser : IDynamicDataProvider {
         val tomlMap = objectMapper.readTomlFile(filePath)
 
         val methodDetails = mutableMapOf(
-            "method" to methodName,
-            "newName" to newName
+            "method" to methodName.value,
+            "newName" to newName.value
         )
 
-        tomlMap[methodName] = methodDetails
+        tomlMap[methodName.value] = methodDetails
 
         objectMapper.writeTomlFile(filePath, tomlMap)
     }
@@ -38,7 +38,7 @@ object ConfigurationParser : IDynamicDataProvider {
         }
 
         val tomlMap = objectMapper.readTomlFile(filePath)
-        tomlMap.remove(methodName)
+        tomlMap.remove(methodName.value)
 
         objectMapper.writeTomlFile(filePath, tomlMap)
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt
@@ -15,7 +15,7 @@ fun MethodName.showRenameDialog(): Pair<Action, MethodName>? {
     var newMethodName: MethodName? = null
 
     val name = this
-    val textField = JBTextField(name, 20)
+    val textField = JBTextField(name.value, 20)
 
     val dialogWrapper = object : DialogWrapper(true) {
         init {
@@ -41,7 +41,7 @@ fun MethodName.showRenameDialog(): Pair<Action, MethodName>? {
 
         override fun doOKAction() {
             selectedAction = Action.RENAME
-            newMethodName = textField.text
+            newMethodName = MethodName(textField.text)
             super.doOKAction()
         }
 
@@ -55,7 +55,7 @@ fun MethodName.showRenameDialog(): Pair<Action, MethodName>? {
 
     return when (selectedAction) {
         Action.RENAME -> newMethodName?.takeIf {
-            it.isNotBlank()
+            it.value.isNotBlank()
         }?.let {
             Action.RENAME to it
         }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicExt.kt
@@ -6,14 +6,15 @@ import com.intellij.advancedExpressionFolding.processor.expr
 import com.intellij.advancedExpressionFolding.processor.exprWrap
 import com.intellij.advancedExpressionFolding.processor.identifier
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodName
 import com.intellij.psi.PsiMethod
 
 object DynamicExt {
     fun createExpression(method: PsiMethod): Expression? {
-        return MethodCallFactory.findByMethodName(method.name)?.mapNotNull {
+        return MethodCallFactory.findByMethodName(MethodName(method.name))?.mapNotNull {
             it.asInstance<DynamicMethodCall>()
         }?.map {
-            val newName = it.data.newName
+            val newName = it.data.newName.value
             method.identifier?.expr(newName)
         }?.run {
             exprWrap(method)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCall.kt
@@ -14,7 +14,7 @@ class DynamicMethodCall(val data: DynamicMethodCallData) : AbstractMethodCall() 
 
     override val methodNames by lazy { listOf(data.method) }
 
-    private val dynamicGroup: FoldingGroup by lazy { this::class.group(data.method) }
+    private val dynamicGroup: FoldingGroup by lazy { this::class.group(data.method.value) }
 
     override fun onAnyArguments(
         element: PsiMethodCallExpression,
@@ -23,7 +23,7 @@ class DynamicMethodCall(val data: DynamicMethodCallData) : AbstractMethodCall() 
     ): DynamicExpression {
         return DynamicExpression(
             context.identifier,
-            text = data.newName,
+            text = data.newName.value,
             children = context.getOperands(),
             group = dynamicGroup
         )

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt
@@ -3,6 +3,8 @@ package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodName
 
 data class DynamicMethodCallData(val map: Map<String, String>) {
-    val method: MethodName by map
-    val newName: MethodName by map
+    val method: MethodName
+        get() = MethodName(map.getValue("method"))
+    val newName: MethodName
+        get() = MethodName(map.getValue("newName"))
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAbsMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAbsMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathAbsMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("abs") }
+    override val methodNames by lazy { methodNames("abs") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAcosMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAcosMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathAcosMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("acos") }
+    override val methodNames by lazy { methodNames("acos") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAsinMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAsinMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathAsinMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("asin") }
+    override val methodNames by lazy { methodNames("asin") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAtanMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathAtanMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathAtanMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("atan") }
+    override val methodNames by lazy { methodNames("atan") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCbrtMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCbrtMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathCbrtMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("cbrt") }
+    override val methodNames by lazy { methodNames("cbrt") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCeilMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCeilMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathCeilMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("ceil") }
+    override val methodNames by lazy { methodNames("ceil") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCosMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCosMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathCosMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("cos") }
+    override val methodNames by lazy { methodNames("cos") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCoshMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathCoshMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathCoshMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("cosh") }
+    override val methodNames by lazy { methodNames("cosh") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathExpMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathExpMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathExpMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("exp") }
+    override val methodNames by lazy { methodNames("exp") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathFloorMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathFloorMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathFloorMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("floor") }
+    override val methodNames by lazy { methodNames("floor") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathLog10MethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathLog10MethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathLog10MethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("log10") }
+    override val methodNames by lazy { methodNames("log10") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathLogMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathLogMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathLogMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("log") }
+    override val methodNames by lazy { methodNames("log") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathMaxMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathMaxMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class MathMaxMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("max") }
+    override val methodNames by lazy { methodNames("max") }
     
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathMinMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathMinMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class MathMinMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("min") }
+    override val methodNames by lazy { methodNames("min") }
     
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathPowMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathPowMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class MathPowMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("pow") }
+    override val methodNames by lazy { methodNames("pow") }
     
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRandomMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRandomMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathRandomMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("random") }
+    override val methodNames by lazy { methodNames("random") }
 
     override fun onNoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRintMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRintMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathRintMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("rint") }
+    override val methodNames by lazy { methodNames("rint") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRoundMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRoundMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathRoundMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("round") }
+    override val methodNames by lazy { methodNames("round") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSinMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSinMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathSinMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("sin") }
+    override val methodNames by lazy { methodNames("sin") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSinhMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSinhMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathSinhMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("sinh") }
+    override val methodNames by lazy { methodNames("sinh") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSqrtMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathSqrtMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathSqrtMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("sqrt") }
+    override val methodNames by lazy { methodNames("sqrt") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathTanMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathTanMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathTanMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("tan") }
+    override val methodNames by lazy { methodNames("tan") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathTanhMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathTanhMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathTanhMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("tanh") }
+    override val methodNames by lazy { methodNames("tanh") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathToDegreesMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathToDegreesMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathToDegreesMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("toDegrees") }
+    override val methodNames by lazy { methodNames("toDegrees") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathToRadiansMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathToRadiansMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathToRadiansMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("toRadians") }
+    override val methodNames by lazy { methodNames("toRadians") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathUlpMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathUlpMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import java.util.*
 
 class MathUlpMethodCall : AbstractMathMethodCall() {
-    override val methodNames by lazy { listOf("ulp") }
+    override val methodNames by lazy { methodNames("ulp") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt
@@ -18,7 +18,7 @@ class CheckNotNullMethodCall : AbstractMethodCall() {
 
     override fun canExecute() = nullable
 
-    override val methodNames by lazy { listOf("checkNotNull") }
+    override val methodNames by lazy { methodNames("checkNotNull") }
 
     override fun onTwoArguments(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalGetMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalGetMethodCall.kt
@@ -6,7 +6,7 @@ import com.intellij.advancedExpressionFolding.processor.methodcall.NeedsQualifie
 import com.intellij.psi.PsiMethodCallExpression
 
 class OptionalGetMethodCall : AbstractOptionalMethodCall(), NeedsQualifier {
-    override val methodNames = listOf("get", "orElseThrow")
+    override val methodNames = methodNames("get", "orElseThrow")
 
     override fun onNoArguments(element: PsiMethodCallExpression, context: Context): OptionalNotNullAssertionGet? {
         return OptionalNotNullAssertionGet(

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalMapMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalMapMethodCall.kt
@@ -10,7 +10,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class OptionalMapMethodCall : AbstractOptionalMethodCall() {
-    override val methodNames by lazy { listOf("map", "flatMap") }
+    override val methodNames by lazy { methodNames("map", "flatMap") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,
@@ -19,7 +19,7 @@ class OptionalMapMethodCall : AbstractOptionalMethodCall() {
         argumentExpression: Expression
     ): Expression? {
         if (argumentExpression is OptionalMapSafeCallParam) {
-            val flatMap = context.methodName == "flatMap"
+            val flatMap = context.methodName == methodName("flatMap")
             val qualifier = context.qualifierExpr
             
             return if (qualifier is OptionalOf) {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfMethodCall.kt
@@ -7,7 +7,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class OptionalOfMethodCall : AbstractOptionalMethodCall() {
-    override val methodNames by lazy { listOf("of") }
+    override val methodNames by lazy { methodNames("of") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfNullableMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfNullableMethodCall.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class OptionalOfNullableMethodCall : AbstractOptionalMethodCall() {
-    override val methodNames by lazy { listOf("ofNullable") }
+    override val methodNames by lazy { methodNames("ofNullable") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOrElseMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOrElseMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiExpressionList
 import com.intellij.psi.PsiMethodCallExpression
 
 class OptionalOrElseMethodCall : AbstractOptionalMethodCall() {
-    override val methodNames by lazy { listOf("orElseGet", "orElse") }
+    override val methodNames by lazy { methodNames("orElseGet", "orElse") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamCollectMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamCollectMethodCall.kt
@@ -14,7 +14,7 @@ import java.util.Objects
 class StreamCollectMethodCall : AbstractStreamMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("collect") }
+    override val methodNames by lazy { methodNames("collect") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamFilterMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamFilterMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class StreamFilterMethodCall : AbstractStreamMethodCall() {
-    override val methodNames by lazy { listOf("filter") }
+    override val methodNames by lazy { methodNames("filter") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMapMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMapMethodCall.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
 class StreamMapMethodCall : AbstractStreamMethodCall() {
-    override val methodNames by lazy { listOf("map", "flatMap") }
+    override val methodNames by lazy { methodNames("map", "flatMap") }
     
     override fun onSingleArgument(
         element: PsiMethodCallExpression,
@@ -18,7 +18,7 @@ class StreamMapMethodCall : AbstractStreamMethodCall() {
         argumentExpression: Expression
     ): Expression? {
         if (argumentExpression is StreamMapCallParam) {
-            val flatMap = context.methodName == "flatMap"
+            val flatMap = context.methodName == methodName("flatMap")
             val textRange = TextRange(context.identifier.textRange.startOffset, 
                                      element.textRange.endOffset)
             

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMethodCall.kt
@@ -13,7 +13,7 @@ import com.intellij.psi.PsiReferenceExpression
 class StreamMethodCall : AbstractMethodCall(), NeedsQualifier {
     override fun canExecute() = concatenationExpressionsCollapse
 
-    override val methodNames by lazy { listOf("stream") }
+    override val methodNames by lazy { methodNames("stream") }
     
     override val classNames by lazy { listOf(
         "java.util.List", 


### PR DESCRIPTION
## Summary
- replace the string alias for method names with a MethodName value class and update the factory lookups
- convert call sites, helper utilities, and dynamic folding features to construct or unwrap MethodName instances
- adjust dynamic configuration serialization and UI flows so persisted TOML keys and dialog inputs continue to work with plain strings

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f53aa0142c832e8a4e0de7a3c0f12d