### PR TITLE
Use configuration dir for dynamic renaming data files

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
@@ -1,11 +1,13 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.openapi.application.PathManager
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Comparator
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
@@ -13,14 +15,14 @@ class ConfigurationParserTest {
 
     @Test
     fun parseSkipsEntriesMissingRequiredKeys() {
-        withTemporaryHome { temporaryHome ->
-            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+        withTemporaryConfigDir {
+            val configPath = dynamicConfigPath()
             configPath.parent?.createDirectories()
             configPath.writeText(
                 """
                 [missingNewName]
                 method = "sourceMethod"
-                """.trimIndent()
+                """.trimIndent(),
             )
 
             val parsed = ConfigurationParser.parse()
@@ -34,7 +36,7 @@ class ConfigurationParserTest {
 
     @Test
     fun parseReturnsEmptyListWhenConfigFileMissing() {
-        withTemporaryHome {
+        withTemporaryConfigDir {
             val parsed = ConfigurationParser.parse()
             assertTrue(parsed.isEmpty(), "Expected empty list when dynamic configuration file is absent")
 
@@ -46,15 +48,15 @@ class ConfigurationParserTest {
 
     @Test
     fun parseSkipsEntriesWithBlankValues() {
-        withTemporaryHome { temporaryHome ->
-            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+        withTemporaryConfigDir {
+            val configPath = dynamicConfigPath()
             configPath.parent?.createDirectories()
             configPath.writeText(
                 """
                 [blankValues]
                 method = ""
                 newName = "   "
-                """.trimIndent()
+                """.trimIndent(),
             )
 
             val parsed = ConfigurationParser.parse()
@@ -66,21 +68,38 @@ class ConfigurationParserTest {
         }
     }
 
-    private fun withTemporaryHome(block: (Path) -> Unit) {
-        val originalUserHome = System.getProperty("user.home")
-        val temporaryHome = Files.createTempDirectory("dynamic-ajf2-test")
+    private fun dynamicConfigPath(): Path {
+        return PathManager.getConfigDir()
+            .resolve("advanced-expression-folding")
+            .resolve("dynamic-ajf2.toml")
+    }
+
+    private fun withTemporaryConfigDir(block: () -> Unit) {
+        val originalConfigPath = System.getProperty(PathManager.PROPERTY_CONFIG_PATH)
+        val originalConfigDir = System.getProperty("idea.config.dir")
+        val temporaryConfigDir = Files.createTempDirectory("dynamic-ajf2-test")
 
         try {
-            System.setProperty("user.home", temporaryHome.toString())
-            block(temporaryHome)
+            System.setProperty(PathManager.PROPERTY_CONFIG_PATH, temporaryConfigDir.toString())
+            System.setProperty("idea.config.path", temporaryConfigDir.toString())
+            System.setProperty("idea.config.dir", temporaryConfigDir.toString())
+            block()
         } finally {
-            Files.deleteIfExists(temporaryHome.resolve("dynamic-ajf2.toml"))
-            Files.deleteIfExists(temporaryHome)
-            if (originalUserHome != null) {
-                System.setProperty("user.home", originalUserHome)
-            } else {
-                System.clearProperty("user.home")
+            Files.walk(temporaryConfigDir).use { stream ->
+                stream.sorted(Comparator.reverseOrder())
+                    .forEach { Files.deleteIfExists(it) }
             }
+            restoreProperty(PathManager.PROPERTY_CONFIG_PATH, originalConfigPath)
+            restoreProperty("idea.config.path", originalConfigPath)
+            restoreProperty("idea.config.dir", originalConfigDir)
+        }
+    }
+
+    private fun restoreProperty(key: String, value: String?) {
+        if (value != null) {
+            System.setProperty(key, value)
+        } else {
+            System.clearProperty(key)
         }
     }
 }


### PR DESCRIPTION
## Summary
- resolve the dynamic configuration file via `PathManager.getConfigDir()` and create an `advanced-expression-folding` folder on demand
- harden TOML read/write helpers to skip non-regular files and write through `Files.newByteChannel` without following links
- update dynamic configuration tests to point at the new location and clean up temporary config directories

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f53a24ae10832e96e6da954590c2d4