### PR TITLE
Secure dynamic configuration storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@
 - [lombok] - @RequiredArgsConstructor, @RequiredArgsConstructor(protected), etc.
 - [lombok] - @Log and @Log(logger) - present for every Logger field
 - [expressionFunc] - Kotlin's Single-expression functions for with single statement body with size < 145 characters. {} used instead of =, because of default method folding.
-- [dynamic] - dynamic names for methods based on file $HOME/dynamic-ajf2.toml works only for methods with qualifier
+- [dynamic] - dynamic names for methods based on file PathManager.getConfigDir()/advanced-expression-folding/dynamic-ajf2.toml works only for methods with qualifier
 - [const] - show modifiers for fields and hide types for enums(not statically imported) and factory methods
 - [lombok] - @Constructor(nr) on field level for additional constructors
 

--- a/docs/docusaurus/features/dynamic-renaming.md
+++ b/docs/docusaurus/features/dynamic-renaming.md
@@ -5,7 +5,7 @@ sidebar_label: Dynamic Renaming
 description: Pull friendly display names for methods from an external configuration file.
 ---
 
-Enable **dynamic** to map fully-qualified method names to human-friendly labels stored in `~/dynamic-ajf2.toml`. The plugin reads the file on the fly and displays the alias wherever the method appears, making domain-specific APIs easier to reason about.
+Enable **dynamic** to map fully-qualified method names to human-friendly labels stored in `PathManager.getConfigDir()/advanced-expression-folding/dynamic-ajf2.toml`. The plugin reads the file on the fly and displays the alias wherever the method appears, making domain-specific APIs easier to reason about.
 
 ![Dynamic renaming applied to method calls](https://github.com/user-attachments/assets/250e6884-6254-4707-85ac-7c861d3773f2)
 

--- a/docs/docusaurus/options/index.md
+++ b/docs/docusaurus/options/index.md
@@ -234,8 +234,8 @@ Simplifies single-expression functions.
 - [Folded](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/folded/ExpressionFuncTestData-folded.java)
 
 ## dynamic
-### Dynamic names for methods based on $user.home/dynamic-ajf2.toml
-Applies dynamic naming to methods based on a configuration file.
+### Dynamic names for methods based on IntelliJ config directory (PathManager.getConfigDir())/advanced-expression-folding/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file stored under the IntelliJ config directory.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/DynamicTestData.java)
 - [Folded](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/folded/DynamicTestData-folded.java)
 - [Documentation](../features/dynamic-renaming.md)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicFileSecurity.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicFileSecurity.kt
@@ -1,0 +1,125 @@
+package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
+
+import com.intellij.openapi.diagnostic.Logger
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.AclEntry
+import java.nio.file.attribute.AclEntryFlag
+import java.nio.file.attribute.AclEntryPermission
+import java.nio.file.attribute.AclEntryType
+import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.attribute.PosixFilePermission
+import java.util.EnumSet
+import kotlin.io.path.exists
+
+internal object DynamicFileSecurity {
+    private val logger: Logger = Logger.getInstance(DynamicFileSecurity::class.java)
+
+    private val insecurePosixPermissions = setOf(
+        PosixFilePermission.GROUP_READ,
+        PosixFilePermission.GROUP_WRITE,
+        PosixFilePermission.GROUP_EXECUTE,
+        PosixFilePermission.OTHERS_READ,
+        PosixFilePermission.OTHERS_WRITE,
+        PosixFilePermission.OTHERS_EXECUTE
+    )
+
+    private val secureDirectoryPermissions = PosixFilePermissions.fromString("rwx------")
+    private val secureFilePermissions = PosixFilePermissions.fromString("rw-------")
+
+    fun ensureDirectorySecure(directory: Path) {
+        runCatching { Files.createDirectories(directory) }
+            .onFailure { logger.warn("Failed to create configuration directory $directory", it) }
+
+        if (!directory.exists()) {
+            return
+        }
+
+        setPosixPermissions(directory, isDirectory = true)
+        setWindowsPermissions(directory, isDirectory = true)
+    }
+
+    fun ensureFileSecure(file: Path) {
+        if (!Files.exists(file)) {
+            return
+        }
+
+        setPosixPermissions(file, isDirectory = false)
+        setWindowsPermissions(file, isDirectory = false)
+    }
+
+    fun isOwnedByCurrentUser(path: Path): Boolean {
+        val owner = runCatching { Files.getOwner(path) }
+            .getOrElse {
+                logger.warn("Failed to resolve file owner for $path", it)
+                return false
+            }
+
+        val currentUser = System.getProperty("user.name") ?: return false
+
+        if (owner.name == currentUser || owner.name.endsWith("\\$currentUser", ignoreCase = true)) {
+            return true
+        }
+
+        val lookupService = runCatching { path.fileSystem.userPrincipalLookupService }
+            .getOrElse {
+                logger.warn("Failed to obtain user principal lookup service for $path", it)
+                return false
+            }
+
+        val currentPrincipal = runCatching { lookupService.lookupPrincipalByName(currentUser) }.getOrNull()
+        return currentPrincipal != null && (owner == currentPrincipal || owner.name == currentPrincipal.name)
+    }
+
+    fun hasWorldAccessiblePermissions(path: Path): Boolean {
+        if (!supportsPosix()) {
+            return false
+        }
+
+        return runCatching { Files.getPosixFilePermissions(path) }
+            .onFailure { logger.warn("Failed to read POSIX permissions for $path", it) }
+            .getOrNull()
+            ?.any { it in insecurePosixPermissions }
+            ?: false
+    }
+
+    private fun setPosixPermissions(path: Path, isDirectory: Boolean) {
+        if (!supportsPosix()) {
+            return
+        }
+
+        val permissions = if (isDirectory) secureDirectoryPermissions else secureFilePermissions
+        runCatching { Files.setPosixFilePermissions(path, permissions) }
+            .onFailure { logger.warn("Failed to set POSIX permissions for $path", it) }
+    }
+
+    private fun setWindowsPermissions(path: Path, isDirectory: Boolean) {
+        if (supportsPosix() || !supportsAcl()) {
+            return
+        }
+
+        val owner = runCatching { Files.getOwner(path) }.getOrElse {
+            logger.warn("Failed to resolve owner while updating ACL for $path", it)
+            return
+        }
+
+        val entryBuilder = AclEntry.newBuilder()
+            .setType(AclEntryType.ALLOW)
+            .setPrincipal(owner)
+            .setPermissions(EnumSet.allOf(AclEntryPermission::class.java))
+
+        if (isDirectory) {
+            entryBuilder.setFlags(AclEntryFlag.FILE_INHERIT, AclEntryFlag.DIRECTORY_INHERIT)
+        }
+
+        runCatching { Files.setAttribute(path, "acl:acl", listOf(entryBuilder.build())) }
+            .onFailure { logger.warn("Failed to update ACL permissions for $path", it) }
+    }
+
+    private fun supportsPosix(): Boolean =
+        FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+
+    private fun supportsAcl(): Boolean =
+        FileSystems.getDefault().supportedFileAttributeViews().contains("acl")
+}

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt
@@ -66,6 +66,7 @@ interface IDynamicDataProvider {
      * Extension method to write a Map to a TOML file or delete file if empty.
      */
     fun ObjectMapper.writeTomlFile(path: Path, data: Map<String, Any>) {
+        path.parent?.let { DynamicFileSecurity.ensureDirectorySecure(it) }
         val file = path.toFile()
         if (data.isEmpty()) {
             if (Files.exists(path)) {
@@ -73,6 +74,7 @@ interface IDynamicDataProvider {
             }
         } else {
             this.writeValue(file, data)
+            DynamicFileSecurity.ensureFileSecure(path)
         }
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -217,7 +217,10 @@ abstract class CheckboxesProvider {
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#expressionfunc")
         }
 
-        registerCheckbox(state::dynamic, "Dynamic names for methods based on \$user.home/dynamic-ajf2.toml") {
+        registerCheckbox(
+            state::dynamic,
+            "Dynamic names for methods based on IntelliJ config directory (PathManager.getConfigDir())/advanced-expression-folding/dynamic-ajf2.toml"
+        ) {
             example("DynamicTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#dynamic")
         }

--- a/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
@@ -1,11 +1,17 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.openapi.application.ApplicationManager
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.Comparator
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
@@ -13,8 +19,8 @@ class ConfigurationParserTest {
 
     @Test
     fun parseSkipsEntriesMissingRequiredKeys() {
-        withTemporaryHome { temporaryHome ->
-            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+        withTemporaryConfigDir { configRoot ->
+            val configPath = configRoot.resolve("advanced-expression-folding/dynamic-ajf2.toml")
             configPath.parent?.createDirectories()
             configPath.writeText(
                 """
@@ -26,28 +32,32 @@ class ConfigurationParserTest {
             val parsed = ConfigurationParser.parse()
             assertTrue(parsed.isEmpty(), "Expected entries without required keys to be skipped")
 
-            assertDoesNotThrow {
-                MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+            if (ApplicationManager.getApplication() != null) {
+                assertDoesNotThrow {
+                    MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+                }
             }
         }
     }
 
     @Test
     fun parseReturnsEmptyListWhenConfigFileMissing() {
-        withTemporaryHome {
+        withTemporaryConfigDir {
             val parsed = ConfigurationParser.parse()
             assertTrue(parsed.isEmpty(), "Expected empty list when dynamic configuration file is absent")
 
-            assertDoesNotThrow {
-                MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+            if (ApplicationManager.getApplication() != null) {
+                assertDoesNotThrow {
+                    MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+                }
             }
         }
     }
 
     @Test
     fun parseSkipsEntriesWithBlankValues() {
-        withTemporaryHome { temporaryHome ->
-            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+        withTemporaryConfigDir { configRoot ->
+            val configPath = configRoot.resolve("advanced-expression-folding/dynamic-ajf2.toml")
             configPath.parent?.createDirectories()
             configPath.writeText(
                 """
@@ -60,26 +70,78 @@ class ConfigurationParserTest {
             val parsed = ConfigurationParser.parse()
             assertTrue(parsed.isEmpty(), "Expected entries with blank values to be skipped")
 
-            assertDoesNotThrow {
-                MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+            if (ApplicationManager.getApplication() != null) {
+                assertDoesNotThrow {
+                    MethodCallFactory.refreshMethodCallMappings(ConfigurationParser)
+                }
             }
         }
     }
 
-    private fun withTemporaryHome(block: (Path) -> Unit) {
-        val originalUserHome = System.getProperty("user.home")
-        val temporaryHome = Files.createTempDirectory("dynamic-ajf2-test")
+    @Test
+    fun parseIgnoresWorldReadableFileOnPosix() {
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return
+        }
 
-        try {
-            System.setProperty("user.home", temporaryHome.toString())
-            block(temporaryHome)
-        } finally {
-            Files.deleteIfExists(temporaryHome.resolve("dynamic-ajf2.toml"))
-            Files.deleteIfExists(temporaryHome)
-            if (originalUserHome != null) {
-                System.setProperty("user.home", originalUserHome)
+        withTemporaryConfigDir { configRoot ->
+            val configPath = configRoot.resolve("advanced-expression-folding/dynamic-ajf2.toml")
+            configPath.parent?.createDirectories()
+            configPath.writeText(
+                """
+                [valid]
+                method = "com.example.Source.method"
+                newName = "Method"
+                """.trimIndent()
+            )
+
+            Files.setPosixFilePermissions(configPath, PosixFilePermissions.fromString("rw-r--r--"))
+
+            val parsed = ConfigurationParser.parse()
+            assertTrue(parsed.isEmpty(), "Expected insecure configuration file to be ignored")
+        }
+    }
+
+    private fun withTemporaryConfigDir(block: (Path) -> Unit) {
+        cleanupConfigDir(testConfigRoot)
+        Files.createDirectories(testConfigRoot)
+        block(testConfigRoot)
+        cleanupConfigDir(testConfigRoot)
+    }
+
+    companion object {
+        private val testConfigRoot: Path = Files.createTempDirectory("dynamic-ajf2-test")
+        private val originalConfigPath: String? = System.getProperty("idea.config.path")
+
+        @JvmStatic
+        @BeforeAll
+        fun prepareConfigPath() {
+            System.setProperty("idea.config.path", testConfigRoot.toString())
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun cleanup() {
+            cleanupConfigDir(testConfigRoot)
+            Files.deleteIfExists(testConfigRoot)
+            if (originalConfigPath != null) {
+                System.setProperty("idea.config.path", originalConfigPath)
             } else {
-                System.clearProperty("user.home")
+                System.clearProperty("idea.config.path")
+            }
+        }
+
+        private fun cleanupConfigDir(root: Path) {
+            if (!Files.exists(root)) {
+                return
+            }
+
+            Files.walk(root).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { path ->
+                    if (path != root) {
+                        Files.deleteIfExists(path)
+                    }
+                }
             }
         }
     }

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -226,8 +226,8 @@ Simplifies single-expression functions.
 - [Folded](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/folded/ExpressionFuncTestData-folded.java)
 
 ## dynamic
-### Dynamic names for methods based on $user.home/dynamic-ajf2.toml
-Applies dynamic naming to methods based on a configuration file.
+### Dynamic names for methods based on IntelliJ config directory (PathManager.getConfigDir())/advanced-expression-folding/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file stored under the IntelliJ config directory.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/DynamicTestData.java)
 - [Folded](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/folded/DynamicTestData-folded.java)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/dynamic)

--- a/wiki-clone/docs/features/dynamic.md
+++ b/wiki-clone/docs/features/dynamic.md
@@ -1,7 +1,7 @@
 ## dynamic
 
-### Dynamic names for methods based on $user.home/dynamic-ajf2.toml
-Applies dynamic naming to methods based on a configuration file.
+### Dynamic names for methods based on IntelliJ config directory (PathManager.getConfigDir())/advanced-expression-folding/dynamic-ajf2.toml
+Applies dynamic naming to methods based on a configuration file stored under the IntelliJ config directory.
 
 #### Example: DynamicTestData
 
@@ -21,7 +21,7 @@ folded/DynamicTestData-folded.java:
                         changedStaticMethod(
 ```
 
-Highlights DynamicTestData with dynamic names for methods based on $user.home/dynamic-ajf2.toml.
+Highlights DynamicTestData with dynamic names for methods based on the file located at PathManager.getConfigDir()/advanced-expression-folding/dynamic-ajf2.toml.
 Removes boilerplate while preserving behavior.
 
 Default: On


### PR DESCRIPTION
## Summary
- store the dynamic method mapping under PathManager.getConfigDir()/advanced-expression-folding/dynamic-ajf2.toml and reject insecure ownership or permissions
- ensure dynamic configuration directories/files receive restrictive POSIX or ACL permissions when created or rewritten
- update tests, UI copy, and docs to target the new IntelliJ configuration path and cover permission validation

## Testing
- ./gradlew test --console=plain --no-daemon


------
https://chatgpt.com/codex/tasks/task_e_68f53a1afb98832e8acd88e8fa2be976