### PR TITLE
Guard dynamic configuration parsing against oversized inputs

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt
@@ -1,6 +1,8 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodName
+import com.intellij.openapi.diagnostic.Logger
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -8,13 +10,33 @@ import kotlin.io.path.readText
 
 object ConfigurationParser : IDynamicDataProvider {
 
+    internal const val MAX_SUPPORTED_FILE_SIZE_BYTES: Long = IDynamicDataProvider.MAX_SUPPORTED_FILE_SIZE_BYTES
+
+    private val logger: Logger
+        get() = Logger.getInstance(ConfigurationParser::class.java)
+
     private val filePath: Path
-        get() = Paths.get(System.getProperty("user.home"), "dynamic-ajf2.toml")
+        get() = Paths.get(System.getProperty("user.home"), IDynamicDataProvider.CONFIGURATION_FILE_NAME)
 
     override fun parse(): List<DynamicMethodCall> {
         if (!Files.exists(filePath)) {
             return emptyList()
         }
+
+        val size = try {
+            Files.size(filePath)
+        } catch (ioException: IOException) {
+            logger.warn("Failed to determine size of dynamic configuration file at $filePath", ioException)
+            return emptyList()
+        }
+
+        if (size > MAX_SUPPORTED_FILE_SIZE_BYTES) {
+            logger.warn(
+                "Dynamic configuration file $filePath exceeds supported size of $MAX_SUPPORTED_FILE_SIZE_BYTES bytes (actual: $size bytes); skipping."
+            )
+            return emptyList()
+        }
+
         val text = filePath.readText()
         return parseToml(text)
     }

--- a/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
@@ -1,11 +1,13 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
+import com.intellij.openapi.diagnostic.Logger
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
@@ -66,6 +68,36 @@ class ConfigurationParserTest {
         }
     }
 
+    @Test
+    fun parseReturnsEmptyListAndLogsWarningWhenFileTooLarge() {
+        withTemporaryHome { temporaryHome ->
+            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+            configPath.parent?.createDirectories()
+            val oversizedBytes = ByteArray((ConfigurationParser.MAX_SUPPORTED_FILE_SIZE_BYTES + 1).toInt()) { 'a'.code.toByte() }
+            Files.write(configPath, oversizedBytes)
+
+            val previousFactory = Logger.getFactory()
+            val capturingFactory = CapturingLoggerFactory()
+            Logger.setFactory(capturingFactory)
+
+            try {
+                val parsed = ConfigurationParser.parse()
+                assertTrue(parsed.isEmpty(), "Expected empty list when configuration file exceeds supported size")
+
+                val configurationWarnings = capturingFactory.getLoggerForCategory("#" + ConfigurationParser::class.java.name)?.warnings.orEmpty()
+                val providerWarnings = capturingFactory.getLoggerForCategory("#" + IDynamicDataProvider::class.java.name)?.warnings.orEmpty()
+                val recordedWarnings = configurationWarnings + providerWarnings
+
+                assertTrue(
+                    recordedWarnings.any { it.contains("exceeds supported size") },
+                    "Expected warning about oversized configuration file to be logged"
+                )
+            } finally {
+                Logger.setFactory(previousFactory)
+            }
+        }
+    }
+
     private fun withTemporaryHome(block: (Path) -> Unit) {
         val originalUserHome = System.getProperty("user.home")
         val temporaryHome = Files.createTempDirectory("dynamic-ajf2-test")
@@ -82,5 +114,40 @@ class ConfigurationParserTest {
                 System.clearProperty("user.home")
             }
         }
+    }
+}
+
+private class CapturingLoggerFactory : Logger.Factory {
+    private val loggers = ConcurrentHashMap<String, CapturingLogger>()
+
+    override fun getLoggerInstance(category: String): Logger =
+        loggers.computeIfAbsent(category) { CapturingLogger(it) }
+
+    fun getLoggerForCategory(category: String): CapturingLogger? = loggers[category]
+}
+
+private class CapturingLogger(private val category: String) : Logger() {
+    private val collectedWarnings = mutableListOf<String>()
+
+    val warnings: List<String>
+        get() = collectedWarnings
+
+    override fun isDebugEnabled(): Boolean = false
+
+    override fun debug(message: String, t: Throwable?) {
+        // no-op for tests
+    }
+
+    override fun info(message: String, t: Throwable?) {
+        // no-op for tests
+    }
+
+    override fun warn(message: String, t: Throwable?) {
+        collectedWarnings.add(message)
+    }
+
+    override fun error(message: String, t: Throwable?, vararg details: String) {
+        val detailText = if (details.isNotEmpty()) details.joinToString(prefix = "[", postfix = "]") else ""
+        throw AssertionError("Unexpected error log from $category: $message $detailText", t)
     }
 }


### PR DESCRIPTION
## Summary
- add a size check in `ConfigurationParser` to skip loading dynamic config files that exceed the supported limit and log a warning
- ensure `parseToml` and `parseTomlValues` exit early for oversized inputs using the shared limit constants
- add a regression test capturing the logger to verify oversized files yield no data and emit a warning

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68f53a193288832eaccc7e5226d3a804