### PR TITLE
Address review feedback on cache key tests

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt
@@ -8,6 +8,8 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.util.MethodSignature
+import org.jetbrains.annotations.TestOnly
+import java.lang.reflect.Modifier
 
 object Keys {
     private const val PREFIX = "AEF-"
@@ -32,21 +34,21 @@ object Keys {
 
     val METHOD_TO_PARENT_CLASS_KEY = Key<MutableMap<MethodSignature, String>>("${PREFIX}methodToParentClass")
 
-    //TODO: convert Keys to enum
     private val values: Set<Key<*>> by lazy {
-        setOf(
-            BUILDER,
-            CLASS_TYPE_KEY,
-            FIELD_META_DATA_KEY,
-            IGNORED,
-            SYNTHETIC_KEY,
-            NOT_SYNTHETIC_KEY,
-            VERSION_SYNTHETIC_KEY,
-            VERSION_NOT_SYNTHETIC_KEY,
-            FIELD_KEY,
-            FULL_CACHE,
-        )
+        Keys::class.java.declaredFields
+            .asSequence()
+            .filter { Modifier.isStatic(it.modifiers) }
+            .filter { Key::class.java.isAssignableFrom(it.type) }
+            .mapNotNull { field ->
+                field.isAccessible = true
+                field.get(null) as? Key<*>
+            }
+            .toSet()
     }
+
+    @TestOnly
+    internal val allKeys: Set<Key<*>> = values
+
     fun clearAllOnExpire(psiElement: PsiElement) {
         values.forEach {
             psiElement.putUserData(it, null)

--- a/test/com/intellij/advancedExpressionFolding/processor/cache/KeysTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/cache/KeysTest.kt
@@ -1,0 +1,32 @@
+package com.intellij.advancedExpressionFolding.processor.cache
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.openapi.application.runReadAction
+import org.jetbrains.annotations.TestOnly
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@TestOnly
+class KeysTest : BaseTest() {
+
+    @Test
+    fun validateAllKeysAreReflected() {
+        val expected = setOf(
+            Keys.BUILDER,
+            Keys.CLASS_TYPE_KEY,
+            Keys.FIELD_META_DATA_KEY,
+            Keys.IGNORED,
+            Keys.FIELD_KEY,
+            Keys.FULL_CACHE,
+            Keys.METHOD_TO_PARENT_CLASS_KEY,
+            Keys.getKey(true),
+            Keys.getKey(false),
+            Keys.getVersionKey(true),
+            Keys.getVersionKey(false),
+        )
+
+        val allKeys = runReadAction { Keys.allKeys }
+
+        assertEquals(expected, allKeys)
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/processor/cache/MethodToParentClassCacheTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/cache/MethodToParentClassCacheTest.kt
@@ -1,0 +1,66 @@
+package com.intellij.advancedExpressionFolding.processor.cache
+
+import com.intellij.advancedExpressionFolding.BaseTest
+import com.intellij.advancedExpressionFolding.processor.lombok.SummaryParentOverrideExt.addParentSummary
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
+import com.intellij.openapi.application.runReadAction
+import org.jetbrains.annotations.TestOnly
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@TestOnly
+class MethodToParentClassCacheTest : BaseTest() {
+
+    @Test
+    fun validateAllKeysAreReflected() {
+        val keys = runReadAction { Keys.allKeys }
+        assertTrue(Keys.METHOD_TO_PARENT_CLASS_KEY in keys)
+    }
+
+    @Test
+    fun clearsMethodToParentClassCache() {
+        val psiFile = fixture.configureByText(
+            "Child.java",
+            """
+            interface Parent {
+                void method();
+            }
+
+            class Child implements Parent {
+                @Override
+                public void method() {}
+            }
+            """.trimIndent()
+        ) as PsiJavaFile
+
+        runReadAction {
+            psiFile.requiredChildClass("Child").addParentSummary()
+        }
+
+        val cached = runReadAction {
+            psiFile.requiredChildClass("Child")
+                .getUserData(Keys.METHOD_TO_PARENT_CLASS_KEY)
+        }
+        assertNotNull(cached)
+        assertTrue(cached!!.isNotEmpty())
+
+        runReadAction {
+            Keys.clearAll(psiFile.requiredChildClass("Child"))
+        }
+
+        val cleared = runReadAction {
+            psiFile.requiredChildClass("Child")
+                .getUserData(Keys.METHOD_TO_PARENT_CLASS_KEY)
+        }
+        assertNull(cleared)
+    }
+
+    private fun PsiJavaFile.childClass(name: String): PsiClass? =
+        classes.firstOrNull { it.name == name }
+
+    private fun PsiJavaFile.requiredChildClass(name: String): PsiClass =
+        childClass(name) ?: error("Child class '$name' not found")
+}


### PR DESCRIPTION
## Summary
- drop the unused `readAction` helper from `BaseTest`
- call `runReadAction` inline in the cache key tests that need read access

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68f521b77bf0832e83c4872e2a590c1b