### PR TITLE
Suppress deprecated arithmetic warnings

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/literal/InterpolatedString.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/InterpolatedString.kt
@@ -76,13 +76,6 @@ class InterpolatedString(
                     )
                 }
             }
-        } else if (first is CharacterLiteral) {
-            descriptors += FoldingDescriptor(
-                element.node,
-                TextRange.create(first.textRange.startOffset, first.textRange.startOffset + 1),
-                group,
-                "\""
-            )
         }
         for (i in 0 until operands.size - 1) {
             val start = if (operands[i] is CharSequenceLiteral) {
@@ -159,13 +152,6 @@ class InterpolatedString(
                     last.element.text + suffix + "\""
                 )
             }
-        } else if (last is CharacterLiteral) {
-            descriptors += FoldingDescriptor(
-                element.node,
-                TextRange.create(last.textRange.endOffset - 1, last.textRange.endOffset),
-                group,
-                "\""
-            )
         }
         for (operand in operands) {
             if (operand.supportsFoldRegions(document, this)) {

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/NumberLiteral.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/NumberLiteral.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.literal
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/ArithmeticExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/ArithmeticExpression.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math
 
 @Deprecated("Replaced by Kotlin expressions")

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Cbrt.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Cbrt.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Ceil.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Ceil.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Exp.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Exp.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Floor.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Floor.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Gcd.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Gcd.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Log.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Log.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Log10.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Log10.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Pow.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Pow.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Random.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Random.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Rint.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Rint.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Round.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Round.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Sqrt.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Sqrt.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Ulp.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Ulp.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.advanced
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Abs.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Abs.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Add.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Add.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/AddAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/AddAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Divide.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Divide.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/DivideAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/DivideAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Max.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Max.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Min.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Min.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Multiply.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Multiply.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/MultiplyAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/MultiplyAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Negate.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Negate.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Not.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Not.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Signum.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Signum.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/Subtract.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/Subtract.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/basic/SubtractAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/basic/SubtractAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/And.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/And.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/AndAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/AndAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Or.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Or.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Remainder.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Remainder.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/RemainderAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/RemainderAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftLeft.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftLeft.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftLeftAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftLeftAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftRight.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftRight.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftRightAssign.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/ShiftRightAssign.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Xor.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/bitwise/Xor.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.bitwise
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Acos.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Acos.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Asin.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Asin.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Atan.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Atan.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Atan2.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Atan2.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Cos.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Cos.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Cosh.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Cosh.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Sin.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Sin.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Sinh.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Sinh.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Tan.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Tan.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/Tanh.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/Tanh.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/ToDegrees.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/ToDegrees.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/math/trig/ToRadians.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/trig/ToRadians.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.math.trig
 
 import com.intellij.advancedExpressionFolding.expression.Expression

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Variable.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/basic/Variable.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.intellij.advancedExpressionFolding.expression.operation.basic
 
 import com.intellij.advancedExpressionFolding.expression.Expression


### PR DESCRIPTION
## Summary
- add file-level `@file:Suppress("DEPRECATION")` annotations to the arithmetic folding classes so implementing the deprecated `ArithmeticExpression` interface no longer generates compiler noise
- drop the unused `CharacterLiteral` branches in `InterpolatedString` to eliminate the constant-condition warning without altering folding behaviour

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f2aab89918832ebf491f71b68c148f