### PR TITLE
Add debugger coverage for default parameter folding

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterDebuggerTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterDebuggerTest.kt
@@ -1,0 +1,47 @@
+package com.intellij.advancedExpressionFolding.processor.language.kotlin
+
+import com.intellij.advancedExpressionFolding.processor.language.kotlin.MethodDefaultParameterExt.enhanceMethodsWithDefaultParams
+import com.intellij.debugger.DebuggerTestCase
+import com.intellij.openapi.application.ex.PathManagerEx
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.search.GlobalSearchScope
+import java.nio.file.Paths
+import kotlin.test.assertNull
+
+class MethodDefaultParameterDebuggerTest : DebuggerTestCase() {
+
+    fun testMethodDefaultParametersAreNotFoldedWhileDebugging() {
+        ensureDebugSessionStarted()
+        val psiClass = resolveClass("DefaultParameterVarargs")
+        val expression = enhanceMethodsWithDefaultParams(psiClass)
+        assertNull(expression)
+    }
+
+    override fun getTestAppPath(): String = TEST_APP_PATH
+
+    private fun ensureDebugSessionStarted() {
+        if (debuggerSession == null) {
+            createLocalProcess(MAIN_CLASS_NAME)
+        }
+        requireNotNull(debuggerSession?.xDebugSession) { "No active XDebugSession" }
+    }
+
+    private fun resolveClass(targetClassFqn: String): PsiClass {
+        val psiClass = JavaPsiFacade.getInstance(project)
+            .findClass(targetClassFqn, GlobalSearchScope.allScope(project))
+        return psiClass ?: error("Class $targetClassFqn not found")
+    }
+
+    companion object {
+        private const val MAIN_CLASS_NAME = "MethodDefaultParameterApp"
+        private val TEST_APP_PATH: String = Paths.get(
+            PathManagerEx.getCommunityHomePath(),
+            "testData",
+            "debug",
+            "advancedExpressionFolding",
+            "methodDefaultParameter",
+            "app"
+        ).toString()
+    }
+}

--- a/testData/debug/advancedExpressionFolding/methodDefaultParameter/app/src/DefaultParameterVarargs.java
+++ b/testData/debug/advancedExpressionFolding/methodDefaultParameter/app/src/DefaultParameterVarargs.java
@@ -1,0 +1,4 @@
+public class DefaultParameterVarargs {
+    void target(int a, String... values) {}
+    void target(int a) { target(a, "default"); }
+}

--- a/testData/debug/advancedExpressionFolding/methodDefaultParameter/app/src/MethodDefaultParameterApp.java
+++ b/testData/debug/advancedExpressionFolding/methodDefaultParameter/app/src/MethodDefaultParameterApp.java
@@ -1,0 +1,18 @@
+public class MethodDefaultParameterApp {
+    public static void main(String[] args) {
+        invokeWithDefault();
+    }
+
+    private static void invokeWithDefault() {
+        target(21);
+    }
+
+    private static void target(int value, String... values) {
+        // Intentionally empty; real debugger session will attach here.
+    }
+
+    private static void target(int value) {
+        // Breakpoint! LogExpression("target invoked")
+        target(value, "default");
+    }
+}


### PR DESCRIPTION
similar: #512 

## Summary
- add a debugger regression test that ensures Kotlin default parameter folding is disabled during debugging sessions
- provide the accompanying debug app sources under testData/debug/advancedExpressionFolding/methodDefaultParameter

## Testing
- ./gradlew test (fails: command stalled while resolving IDE dependencies in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f29794ae10832ea9c3bc1be3d455c3