### PR TITLE
Introduce FoldedCode inline class

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/diff/FoldingTemporaryEditor.kt
+++ b/src/com/intellij/advancedExpressionFolding/diff/FoldingTemporaryEditor.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.util.TextRange
 
 object FoldingTemporaryEditor {
 
-    fun foldInEditor(text: String, list: List<FoldingDescriptorEx>) : FoldedCode {
+    fun foldInEditor(text: String, list: List<FoldingDescriptorEx>): FoldedCode {
         val editorFactory = EditorFactory.getInstance()
         val document = editorFactory.createDocument(removeFoldingMarkers(text))
 
@@ -31,7 +31,7 @@ object FoldingTemporaryEditor {
     private fun getVisibleCode(editor: EditorEx): FoldedCode {
         val document = editor.document
         var offset = 0
-        return buildString(document.textLength) {
+        val visibleCode = buildString(document.textLength) {
             for (region in editor.foldingModel.allFoldRegions) {
                 if (region.isValid && region.isExpanded) {
                     val foldStart = region.startOffset
@@ -46,6 +46,7 @@ object FoldingTemporaryEditor {
             }
             append(document.getText(TextRange(offset, document.textLength)))
         }
+        return FoldedCode(visibleCode)
     }
 
     private const val FOLD = "fold"
@@ -56,4 +57,5 @@ object FoldingTemporaryEditor {
 
 }
 
-typealias FoldedCode = String
+@JvmInline
+value class FoldedCode(val value: String)

--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -77,7 +77,10 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
 
     private fun createFoldedFile(fileName: String, actual: String, wrapper: FoldingDescriptorExWrapper) {
         val foldingFile = fileName.replace("testData/", "folded/")
-        Files.writeString(createOutputFile(foldingFile, "-folded.java").toPath(), FoldingTemporaryTestEditor.getFoldedText(actual, wrapper))
+        Files.writeString(
+            createOutputFile(foldingFile, "-folded.java").toPath(),
+            FoldingTemporaryTestEditor.getFoldedText(actual, wrapper).value
+        )
     }
 
     protected open fun getTestFileName(testName: String) = "testData/${testName.capitalize()}.java"


### PR DESCRIPTION
## Summary
- replace the `FoldedCode` typealias with a dedicated `@JvmInline` value class and return it from folding helpers
- ensure the test harness unwraps `FoldedCode` when writing comparison files

## Testing
- ./gradlew test --no-daemon --console=plain --stacktrace --info

------
https://chatgpt.com/codex/tasks/task_e_68f54bbd052c832ea7c32f31d91fa996