### PR TITLE
Wrap captured default parameter literals in value class

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/MethodDefaultParameterExt.kt
@@ -54,7 +54,7 @@ object MethodDefaultParameterExt : BaseExtension(){
             params.map.forEach { (paramNr, value) ->
                 val paramWithValue = method.parameterList.parameters.getOrNull(paramNr)
                 val paramNextElement = paramWithValue?.nextSibling
-                list += paramNextElement?.expr(" = $value${paramNextElement.text}", group = group)
+                list += paramNextElement?.expr(" = ${value.value}${paramNextElement.text}", group = group)
             }
             if (params.map.isNotEmpty()) {
                 list += duplicatedMethod.exprHide(group = group)
@@ -69,7 +69,8 @@ object MethodDefaultParameterExt : BaseExtension(){
             val expressions = methodCall?.argumentList?.expressions
             val params = expressions?.mapIndexedNotNull { index, psiExpression ->
                 if (asPsiParameter(psiExpression) == null) {
-                    index to psiExpression.text
+                    val literal = psiExpression.text.trim()
+                    literal.takeIf { it.isNotEmpty() }?.let { index to DefaultParameterLiteral(it) }
                 } else {
                     null
                 }
@@ -118,7 +119,7 @@ object MethodDefaultParameterExt : BaseExtension(){
     )
 
     @JvmInline
-    private value class DefaultParameterMap(val map: Map<ParameterIndex, ParameterDefaultValueAsString>)
+    private value class DefaultParameterMap(val map: Map<ParameterIndex, DefaultParameterLiteral>)
 
     private fun Project.isDebugSessionRunning(): Boolean {
         if (isDisposed || isDefault) {
@@ -129,5 +130,11 @@ object MethodDefaultParameterExt : BaseExtension(){
 }
 
 typealias ParameterIndex = Int
-typealias ParameterDefaultValueAsString = String
+
+@JvmInline
+value class DefaultParameterLiteral(val value: String) {
+    init {
+        require(value.isNotBlank())
+    }
+}
 


### PR DESCRIPTION
## Summary
- replace the default-parameter string alias with a DefaultParameterLiteral inline value class that enforces non-blank content
- build DefaultParameterMap entries with trimmed argument text and unwrap the literal when rendering expressions

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f54bbc02e4832eac8cc4c15e96e5a1