### PR TITLE
Add inline CustomClassAnnotation type for Lombok folding

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/ClassAnnotationExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/ClassAnnotationExpression.kt
@@ -11,7 +11,12 @@ import com.intellij.psi.PsiKeyword
 import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiTypeElement
 
-typealias CustomClassAnnotation = String
+@JvmInline
+value class CustomClassAnnotation(val value: String) {
+    init {
+        require(value.startsWith("@")) { "CustomClassAnnotation must start with '@'" }
+    }
+}
 
 open class ClassAnnotationExpression(
     element: PsiElement,
@@ -53,7 +58,12 @@ open class ClassAnnotationExpression(
         val range = foldOn.textRange
         val newRange = TextRange.create(range.startOffset, range.startOffset + 1)
         val firstChar = newRange.substring(document.text)
-        return fold(foldOn, newRange, "${customClassAnnotations.joinToString(" ")} $firstChar", group)
+        return fold(
+            foldOn,
+            newRange,
+            "${customClassAnnotations.joinToString(" ") { it.value }} $firstChar",
+            group
+        )
     }
 
     private fun findAnnotationFoldOnElement(clazzOrField: PsiElement): PsiElement {

--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding.processor.declaration
 
 import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.expression.semantic.lombok.CustomClassAnnotation
 import com.intellij.advancedExpressionFolding.expression.semantic.lombok.FieldAnnotationExpression
 import com.intellij.advancedExpressionFolding.expression.semantic.lombok.NullAnnotationExpression
 import com.intellij.advancedExpressionFolding.processor.*
@@ -28,7 +29,7 @@ object PsiFieldExt : BaseExtension() {
 
         field.callback?.invoke()?.let { annotations: List<FieldLevelAnnotation> ->
 
-            val annotationsAsString = mutableListOf<String>()
+            val annotationsAsString = mutableListOf<CustomClassAnnotation>()
             val elementsToHide = mutableListOf<PsiElement?>()
             annotations.forEach { fieldLevelAnnotation ->
                 elementsToHide += fieldLevelAnnotation.method

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding.processor.lombok
 
 import com.intellij.advancedExpressionFolding.expression.semantic.lombok.ClassAnnotationExpression
+import com.intellij.advancedExpressionFolding.expression.semantic.lombok.CustomClassAnnotation
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokExt.addLombokSupport
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokExt.lombokPatternOff
@@ -51,7 +52,7 @@ object AnnotationExt {
         val classLevelAnnotations = ClassAnnotationExpression(clazz, changes.map { hidingAnnotation ->
             val notPureSuffix = createNotPureSuffix(hidingAnnotation)
             val args = argsAsString(hidingAnnotation)
-            hidingAnnotation.classAnnotation.annotation + notPureSuffix + args
+            CustomClassAnnotation(hidingAnnotation.classAnnotation.annotation + notPureSuffix + args)
         }, elementsToFold)
         return classLevelAnnotations
     }

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt
@@ -1,5 +1,6 @@
 package com.intellij.advancedExpressionFolding.processor.lombok
 
+import com.intellij.advancedExpressionFolding.expression.semantic.lombok.CustomClassAnnotation
 import com.intellij.advancedExpressionFolding.processor.*
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.lombok.AnnotationExt.ClassLevelAnnotation
@@ -97,13 +98,13 @@ object LombokFieldExt : BaseExtension(), GenericCallback<PsiField, List<FieldLev
         }
     }
 
-    fun FieldLevelAnnotation.createFieldLevelAnnotation(): String {
+    fun FieldLevelAnnotation.createFieldLevelAnnotation(): CustomClassAnnotation {
         val arguments = arguments.takeIf {
             it.isNotEmpty()
         }?.joinToString(separator = ",")?.let {
             "($it)"
         } ?: ""
-        return classAnnotation.annotation + arguments
+        return CustomClassAnnotation(classAnnotation.annotation + arguments)
     }
 
     fun foldProperties(


### PR DESCRIPTION
## Summary
- replace the Lombok `CustomClassAnnotation` string alias with an inline value type that validates the text
- adjust Lombok processors to construct `CustomClassAnnotation` instances and unwrap their values when rendering
- update folding placeholders to join annotation values explicitly

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68f54bb24c28832eb0bdeb208e8455e7