### PR TITLE
Introduce AnnotationName value class for pseudo annotation completions

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
@@ -31,7 +31,7 @@ abstract class AbstractLoggingAnnotationCompletionContributor(
     private val state: IState = getInstance().state
 ) : CompletionContributor(), IState by state {
 
-    protected abstract val annotationName: String
+    protected abstract val annotationName: AnnotationName
 
     init {
         extend(
@@ -111,11 +111,11 @@ abstract class AbstractLoggingAnnotationCompletionContributor(
     }
 
     private fun removeAnnotation(method: PsiMethod) {
-        method.modifierList.findAnnotation(annotationName)?.delete()
+        method.modifierList.findAnnotation(annotationName.value)?.delete()
     }
 
     private fun removeAnnotation(psiClass: PsiClass) {
-        psiClass.modifierList?.findAnnotation(annotationName)?.delete()
+        psiClass.modifierList?.findAnnotation(annotationName.value)?.delete()
     }
 
     protected abstract fun isAlreadyLogged(
@@ -140,9 +140,9 @@ abstract class AbstractLoggingAnnotationCompletionContributor(
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
             if (!pseudoAnnotations) return
 
-            val lookup = LookupElementBuilder.create(annotationName)
-                .withLookupString("@$annotationName")
-                .withPresentableText("@$annotationName")
+            val lookup = LookupElementBuilder.create(annotationName.value)
+                .withLookupString("@${annotationName.value}")
+                .withPresentableText("@${annotationName.value}")
                 .withInsertHandler { ctx, _ ->
                     handleMethodInsert(ctx)
                 }
@@ -156,9 +156,9 @@ abstract class AbstractLoggingAnnotationCompletionContributor(
         override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
             if (!pseudoAnnotations) return
 
-            val lookup = LookupElementBuilder.create(annotationName)
-                .withLookupString("@$annotationName")
-                .withPresentableText("@$annotationName")
+            val lookup = LookupElementBuilder.create(annotationName.value)
+                .withLookupString("@${annotationName.value}")
+                .withPresentableText("@${annotationName.value}")
                 .withInsertHandler { ctx, _ ->
                     handleClassInsert(ctx)
                 }

--- a/src/com/intellij/advancedExpressionFolding/pseudo/AnnotationName.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/AnnotationName.kt
@@ -1,0 +1,24 @@
+package com.intellij.advancedExpressionFolding.pseudo
+
+@JvmInline
+value class AnnotationName(val value: String) {
+    init {
+        require(value.isNotBlank()) { "Annotation name must not be blank." }
+        val segments = value.split('.')
+        require(segments.all(::isValidSegment)) { "Invalid annotation name: $value" }
+    }
+
+    override fun toString(): String = value
+
+    companion object {
+        private fun isValidSegment(segment: String): Boolean {
+            if (segment.isEmpty()) return false
+            val first = segment.first()
+            if (!Character.isJavaIdentifierStart(first)) return false
+            for (ch in segment.drop(1)) {
+                if (!Character.isJavaIdentifierPart(ch)) return false
+            }
+            return true
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt
@@ -10,7 +10,7 @@ import java.util.LinkedHashSet
 
 class LoggableAnnotationCompletionContributor : AbstractLoggingAnnotationCompletionContributor() {
 
-    override val annotationName: String = "Loggable"
+    override val annotationName: AnnotationName = AnnotationName("Loggable")
 
     override fun isAlreadyLogged(
         @Suppress("UNUSED_PARAMETER") method: PsiMethod,

--- a/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
@@ -14,7 +14,11 @@ import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 
-class MainAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(), IState by state {
+class MainAnnotationCompletionContributor(
+    private val state: IState = getInstance().state,
+) : CompletionContributor(), IState by state {
+
+    private val annotationName = AnnotationName("Main")
     init {
         extend(
             CompletionType.BASIC,
@@ -31,9 +35,9 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
                 ) {
                     if (!pseudoAnnotations) return
 
-                    val lookup = LookupElementBuilder.create("Main")
-                        .withLookupString("@Main")
-                        .withPresentableText("@Main")
+                    val lookup = LookupElementBuilder.create(annotationName.value)
+                        .withLookupString("@${annotationName.value}")
+                        .withPresentableText("@${annotationName.value}")
                         .withInsertHandler { ctx, _ ->
                             handleMainInsert(ctx)
                         }
@@ -53,7 +57,7 @@ class MainAnnotationCompletionContributor(private val state: IState = getInstanc
         val topClass = findTopLevelClass(immediateClass)
 
         WriteCommandAction.runWriteCommandAction(project) {
-            method.modifierList.findAnnotation("Main")?.delete()
+            method.modifierList.findAnnotation(annotationName.value)?.delete()
             removeExistingMain(topClass)
             val mainCode = generateMainCode(method, immediateClass).trimEnd()
             insertFormatted(mainCode, topClass, ctx)

--- a/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt
@@ -9,7 +9,7 @@ import com.intellij.xdebugger.breakpoints.XLineBreakpoint
 
 class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotationCompletionContributor() {
 
-    override val annotationName: String = "TracingLoggable"
+    override val annotationName: AnnotationName = AnnotationName("TracingLoggable")
 
     override fun shouldRemoveClassLogging(psiClass: PsiClass): Boolean {
         val className = psiClass.name ?: return false
@@ -89,7 +89,13 @@ class TracingLoggableAnnotationCompletionContributor : AbstractLoggingAnnotation
         exitLine: Int,
         buildExitExpression: String
     ) {
-        BreakpointUtil.toggleBreakpoint(project, file, exitLine, buildExitExpression, groupName = "$annotationName-${file.name}")
+        BreakpointUtil.toggleBreakpoint(
+            project,
+            file,
+            exitLine,
+            buildExitExpression,
+            groupName = "${annotationName.value}-${file.name}",
+        )
     }
 
     private fun resolveTarget(method: PsiMethod, body: PsiCodeBlock): LoggingTarget? {

--- a/test/com/intellij/advancedExpressionFolding/pseudo/AnnotationNameTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/AnnotationNameTest.kt
@@ -1,0 +1,25 @@
+package com.intellij.advancedExpressionFolding.pseudo
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class AnnotationNameTest {
+
+    @Test
+    fun `should accept valid annotation names`() {
+        assertDoesNotThrow { AnnotationName("Loggable") }
+        assertDoesNotThrow { AnnotationName("com.example.Valid") }
+        assertDoesNotThrow { AnnotationName("_Underscore") }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", " ", "1Invalid", "Invalid-Name", "com..example", ".Leading", "Trailing.", "inv@lid"])
+    fun `should reject invalid annotation names`(candidate: String) {
+        assertThrows(IllegalArgumentException::class.java) {
+            AnnotationName(candidate)
+        }
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt
@@ -17,6 +17,8 @@ import java.util.stream.Stream
 
 class LoggableAnnotationCompletionContributorTest : BaseTest() {
 
+    private val annotationName = AnnotationName("Loggable")
+
     companion object {
         private var originalPseudoAnnotationsValue: Boolean = false
 
@@ -310,7 +312,7 @@ class LoggableAnnotationCompletionContributorTest : BaseTest() {
 
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
-        assertTrue(completions.any { it.lookupString == "Loggable" })
+        assertTrue(completions.any { it.lookupString == annotationName.value })
     }
 
     @ParameterizedTest
@@ -321,7 +323,7 @@ class LoggableAnnotationCompletionContributorTest : BaseTest() {
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
 
-        val logCompletion = completions.find { it.lookupString == "Loggable" }
+        val logCompletion = completions.find { it.lookupString == annotationName.value }
         assertNotNull(logCompletion)
 
         ApplicationManager.getApplication().invokeAndWait {
@@ -340,7 +342,7 @@ class LoggableAnnotationCompletionContributorTest : BaseTest() {
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
 
-        val logCompletion = completions.find { it.lookupString == "Loggable" }
+        val logCompletion = completions.find { it.lookupString == annotationName.value }
         assertNotNull(logCompletion)
 
         ApplicationManager.getApplication().invokeAndWait {

--- a/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt
@@ -17,6 +17,8 @@ import java.util.stream.Stream
 
 class MainAnnotationCompletionContributorTest : BaseTest() {
 
+    private val annotationName = AnnotationName("Main")
+
     companion object {
         private var originalPseudoAnnotationsValue: Boolean = false
         
@@ -365,7 +367,7 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
 
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
-        assertTrue(completions.any { it.lookupString == "Main" })
+        assertTrue(completions.any { it.lookupString == annotationName.value })
     }
 
     @ParameterizedTest
@@ -376,7 +378,7 @@ class MainAnnotationCompletionContributorTest : BaseTest() {
         val completions = fixture.complete(CompletionType.BASIC)
         assertNotNull(completions)
         
-        val mainCompletion = completions.find { it.lookupString == "Main" }
+        val mainCompletion = completions.find { it.lookupString == annotationName.value }
         assertNotNull(mainCompletion)
 
         ApplicationManager.getApplication().invokeAndWait {

--- a/test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test
 
 class TracingLoggableAnnotationCompletionContributorTest : BaseTest() {
 
+    private val annotationName = AnnotationName("TracingLoggable")
+
     private lateinit var settings: AdvancedExpressionFoldingSettings
     private var originalPseudoAnnotationsValue: Boolean = false
 
@@ -53,7 +55,7 @@ class TracingLoggableAnnotationCompletionContributorTest : BaseTest() {
         )
 
         val completions = fixture.complete(CompletionType.BASIC) ?: error("Expected completion results")
-        assertTrue(completions.any { it.lookupString == "TracingLoggable" })
+        assertTrue(completions.any { it.lookupString == annotationName.value })
     }
 
     @Test
@@ -159,7 +161,7 @@ class TracingLoggableAnnotationCompletionContributorTest : BaseTest() {
     private fun selectTracingLoggableCompletion() {
         val completions = fixture.complete(CompletionType.BASIC) ?: error("Expected completion results")
 
-        val tracingCompletion = completions.find { it.lookupString == "TracingLoggable" }
+        val tracingCompletion = completions.find { it.lookupString == annotationName.value }
             ?: error("TracingLoggable completion not found")
 
         ApplicationManager.getApplication().invokeAndWait {


### PR DESCRIPTION
## Summary
- add a dedicated AnnotationName inline value class with validation for pseudo annotations
- migrate pseudo completion contributors and tests to work with AnnotationName values
- cover invalid annotation names via unit tests and refresh completion assertions

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f54ba206e0832eb8e378f9019e9538