### PR TITLE
Add inline description wrapper for settings DSL

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/Description.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/Description.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.settings.view
+
+import org.jetbrains.annotations.Nls
+
+@JvmInline
+value class Description(@Nls val text: String) {
+    init {
+        require(text.isNotBlank()) { "Description must not be blank." }
+    }
+
+    override fun toString(): String = text
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -53,7 +53,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
         val panel = JPanel(FlowLayout(FlowLayout.LEFT))
 
         examples?.forEach { (file, desc) ->
-            val suffix = desc?.let { " $it" } ?: ""
+            val suffix = desc?.let { " ${it.text}" } ?: ""
             val description = "example$suffix"
 
             val actionLink = ActionLink(description) {

--- a/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/checkboxDsl.kt
@@ -4,8 +4,6 @@ import kotlin.reflect.KMutableProperty0
 
 @DslMarker
 annotation class CheckboxDsl
-
-typealias Description = String
 typealias UrlSuffix = String
 typealias ExampleFile = String
 
@@ -21,8 +19,8 @@ class CheckboxBuilder {
     private val examples = mutableMapOf<ExampleFile, Description?>()
     private var docLink: UrlSuffix? = null
 
-    fun example(file: ExampleFile, description: Description? = null) {
-        examples[file] = description
+    fun example(file: ExampleFile, description: String? = null) {
+        examples[file] = description?.let(::Description)
     }
 
     fun link(documentationLink: UrlSuffix) {

--- a/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
@@ -31,7 +31,10 @@ class SettingsConfigurableTest {
     }
 
     private fun createExamplePanel(configurable: SettingsConfigurable): JPanel {
-        return configurable.createExamplePanel(mapOf<ExampleFile, Description?>("Example.java" to null), null)
+        return configurable.createExamplePanel(
+            mapOf<ExampleFile, Description?>("Example.java" to Description("Example description")),
+            null
+        )
     }
 
     private fun triggerAction(actionLink: ActionLink) {


### PR DESCRIPTION
## Summary
- add an inline `Description` value class that enforces non-blank text for settings example descriptions
- wrap DSL example descriptions in the new type and unwrap them explicitly when rendering the UI
- update settings tests to build example panels with non-blank descriptions

## Testing
- ./gradlew test --console=plain --no-daemon --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68f54b9bc990832e8066ed3c0fc5f1b0