### PR TITLE
Wrap error filenames in value class

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt
@@ -33,6 +33,7 @@ import org.kodein.di.DI
 import org.kodein.di.bindSingleton
 import java.io.File
 import java.lang.Thread.sleep
+import kotlin.jvm.JvmInline
 import kotlin.io.path.Path
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -113,7 +114,7 @@ class IntegrationTest {
                 next()
             }
             errorList.forEach { (filename, errors) ->
-                println("File: $filename")
+                println("File: ${filename.value}")
                 errors.forEach { error ->
                     println(error.stackTraceContent)
                 }
@@ -291,7 +292,7 @@ class IntegrationTest {
                     seenErrors.add(error)
                 }.toList()
                 if (errors.isNotEmpty()) {
-                    file.name to errors
+                    ErrorFileName(file.name) to errors
                 } else {
                     null
                 }
@@ -349,7 +350,14 @@ private fun init(testName: String): IDETestContext = Starter.newContext(
     PluginConfigurator(this).installPluginFromPath(Path(latestZipFile))
 }
 
-typealias ErrorFileName = String
+@JvmInline
+value class ErrorFileName(val value: String) {
+    init {
+        require(value.endsWith(".java") && !value.contains("..")) {
+            "Invalid error file name: $value"
+        }
+    }
+}
 
 
 private fun Driver.setupProjectWithGradle() {


### PR DESCRIPTION
## Summary
- replace the IntegrationTest error filename alias with an inline value class that validates `.java` names
- update the openFiles helper and logging to work with the new ErrorFileName wrapper

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68f54bb48368832e8884af2d5e30b29e