### PR TITLE
Introduce ActionId wrapper for integration actions

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/ActionId.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/ActionId.kt
@@ -1,0 +1,11 @@
+package com.intellij.advancedExpressionFolding.integration
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+
+@JvmInline
+value class ActionId(val value: String) {
+    override fun toString(): String = value
+}
+
+fun ActionManager.getAction(actionId: ActionId): AnAction? = getAction(actionId.value)

--- a/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
@@ -14,14 +14,15 @@ import java.util.concurrent.atomic.AtomicReference
 
 @TestOnly
 object IntegrationTestApi {
-    private const val GLOBAL_TOGGLE_ACTION_ID =
-        "com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"
+    private val GLOBAL_TOGGLE_ACTION_ID =
+        ActionId("com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction")
 
     @JvmStatic
-    fun toggleGlobalFolding(state: Boolean) {
+    fun toggleGlobalFolding(actionId: ActionId, state: Boolean) {
         runOnEdt {
-            val action = ActionManager.getInstance().getAction(GLOBAL_TOGGLE_ACTION_ID) as? ToggleAction
-                ?: error("Action $GLOBAL_TOGGLE_ACTION_ID not found")
+            val resolvedActionId = if (actionId == GLOBAL_TOGGLE_ACTION_ID) GLOBAL_TOGGLE_ACTION_ID else actionId
+            val action = ActionManager.getInstance().getAction(resolvedActionId) as? ToggleAction
+                ?: error("Action $resolvedActionId not found")
             val event = AnActionEvent.createEvent(
                 DataContext.EMPTY_CONTEXT,
                 null,

--- a/test/com/intellij/advancedExpressionFolding/FoldingActionsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingActionsTest.kt
@@ -1,5 +1,7 @@
 package com.intellij.advancedExpressionFolding
 
+import com.intellij.advancedExpressionFolding.integration.ActionId
+import com.intellij.advancedExpressionFolding.integration.getAction
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.impl.SimpleDataContext
@@ -34,7 +36,11 @@ class FoldingActionsTest : BaseTest() {
 
     @Test
     fun globalToggleActionFlipsStateThroughActionManager() {
-        val action = ActionManager.getInstance().getAction("com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction")
+        val action = requireNotNull(
+            ActionManager.getInstance().getAction(
+                ActionId("com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction")
+            )
+        ) { "Expected GlobalToggleFoldingAction to be registered" }
         val toggle = assertInstanceOf<ToggleAction>(action)
 
         val initialEvent = createEvent(toggle)
@@ -65,7 +71,11 @@ class FoldingActionsTest : BaseTest() {
         val (editor, region) = setUpEditorWithRegion(initiallyExpanded = true)
         settings.state.globalOn = false
 
-        val action = ActionManager.getInstance().getAction("com.intellij.advancedExpressionFolding.action.FoldingOnAction")
+        val action = requireNotNull(
+            ActionManager.getInstance().getAction(
+                ActionId("com.intellij.advancedExpressionFolding.action.FoldingOnAction")
+            )
+        ) { "Expected FoldingOnAction to be registered" }
         val event = createEvent(action, editor)
 
         ApplicationManager.getApplication().invokeAndWait {
@@ -89,7 +99,11 @@ class FoldingActionsTest : BaseTest() {
         val (editor, region) = setUpEditorWithRegion(initiallyExpanded = false)
         settings.state.globalOn = true
 
-        val action = ActionManager.getInstance().getAction("com.intellij.advancedExpressionFolding.action.FoldingOffAction")
+        val action = requireNotNull(
+            ActionManager.getInstance().getAction(
+                ActionId("com.intellij.advancedExpressionFolding.action.FoldingOffAction")
+            )
+        ) { "Expected FoldingOffAction to be registered" }
         val event = createEvent(action, editor)
 
         ApplicationManager.getApplication().invokeAndWait {

--- a/test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt
@@ -1,5 +1,4 @@
 package com.intellij.advancedExpressionFolding.integration
-
 import com.intellij.driver.client.Driver
 import com.intellij.driver.client.service
 import com.intellij.driver.client.utility
@@ -170,7 +169,10 @@ class IntegrationTest {
                 "Optional folding should stay enabled when testing the global toggle"
             }
 
-            utility<FoldingIntegrationStub>().toggleGlobalFolding(false)
+            utility<FoldingIntegrationStub>().toggleGlobalFolding(
+                ActionId("com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"),
+                false
+            )
             check(!service<SettingsStub>().getState().globalOn) {
                 "Global folding should be disabled after toggling off"
             }
@@ -182,7 +184,10 @@ class IntegrationTest {
                 "Expected no advanced folds when global toggle is disabled, but found $foldsWhenDisabled"
             }
 
-            utility<FoldingIntegrationStub>().toggleGlobalFolding(true)
+            utility<FoldingIntegrationStub>().toggleGlobalFolding(
+                ActionId("com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"),
+                true
+            )
             check(service<SettingsStub>().getState().globalOn) {
                 "Global folding should be enabled after toggling on"
             }

--- a/test/com/intellij/advancedExpressionFolding/integration/integrationStubs.kt
+++ b/test/com/intellij/advancedExpressionFolding/integration/integrationStubs.kt
@@ -1,5 +1,6 @@
 package com.intellij.advancedExpressionFolding.integration
 
+import com.intellij.advancedExpressionFolding.integration.ActionId
 import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.driver.client.Remote
@@ -20,7 +21,7 @@ interface ColorActionStub {
 
 @Remote("com.intellij.advancedExpressionFolding.integration.IntegrationTestApi", plugin = "com.github.advanced-java-folding2")
 interface FoldingIntegrationStub {
-    fun toggleGlobalFolding(state: Boolean)
+    fun toggleGlobalFolding(actionId: ActionId, state: Boolean)
     fun countAdvancedFoldRegions(): Int
 }
 


### PR DESCRIPTION
## Summary
- add an `ActionId` value class with an `ActionManager` helper to avoid raw string IDs
- switch the integration API and remote stubs to accept `ActionId` instead of string action IDs
- update tests to create `ActionId` instances and assert retrieved actions are present

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f54b75457c832e871839a9e1b96926