### PR TITLE
Add contextual help topic for settings configurable

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -38,7 +38,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
 
     override fun getDisplayName() = "Advanced Expression Folding 2"
 
-    override fun getHelpTopic() = null
+    override fun getHelpTopic() = HELP_PAGE_URL
 
     private fun createExamplePanel(examples: Map<ExampleFile, Description?>? = null, docLink: UrlSuffix? = null): JPanel {
         val panel = JPanel(FlowLayout(FlowLayout.LEFT))
@@ -166,6 +166,7 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
 
     companion object {
         private const val EXAMPLE_DIR = "data"
+        private const val HELP_PAGE_URL = "https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki"
     }
     
     @CheckboxDsl


### PR DESCRIPTION
## Summary
- connect the settings configurable help topic to the plugin wiki so the IDE help button opens documentation

## Testing
- `CI=true ./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68ea4254276c832eb34330dc1e97e4b6