### PR TITLE
Add manual Hercules Insights workflow

### DIFF
--- a/.github/workflows/hercules-insights.yml
+++ b/.github/workflows/hercules-insights.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Hercules Insights
         uses: src-d/hercules@v10.7.2


### PR DESCRIPTION
## Summary
- add a workflow_dispatch job for running Hercules Insights manually

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f6591ad9f8832eacd48a326d04617e