### PR TITLE
Refactor collapsed operations

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/operation/CollapsedOperation.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/CollapsedOperation.kt
@@ -1,0 +1,22 @@
+package com.intellij.advancedExpressionFolding.expression.operation
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.expression.Operation
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+
+open class CollapsedOperation(
+    element: PsiElement,
+    text: String,
+    operands: List<Expression> = emptyList(),
+    textRange: TextRange = element.textRange,
+    priority: Int = 300,
+) : Operation(element, textRange, text, priority, operands) {
+
+    override fun buildFolding(character: String): String = character
+
+    override fun isCollapsedByDefault(): Boolean = true
+
+    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
+}

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/FieldShiftMethod.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/FieldShiftMethod.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -11,13 +10,7 @@ class FieldShiftMethod(
     textRange: TextRange,
     operands: List<Expression>,
     private val text: String
-) : Operation(element, textRange, "", 300, operands) {
-
-    override fun buildFolding(character: String): String = character
+) : CollapsedOperation(element, "", operands, textRange) {
 
     override fun suffixText(): String = text
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 }

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapCall.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.optional
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -11,10 +10,4 @@ class OptionalMapCall(
     textRange: TextRange,
     operands: List<Expression>,
     flatMap: Boolean
-) : Operation(element, textRange, if (flatMap) ".*" else ".", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
-}
+) : CollapsedOperation(element, if (flatMap) ".*" else ".", operands, textRange)

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCall.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.optional
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -11,10 +10,4 @@ class OptionalMapSafeCall(
     textRange: TextRange,
     operands: List<Expression>,
     flatMap: Boolean
-) : Operation(element, textRange, if (flatMap) "?.*" else "?.", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
-}
+) : CollapsedOperation(element, if (flatMap) "?.*" else "?.", operands, textRange)

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOfNullable.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOfNullable.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.optional
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -10,14 +9,8 @@ open class OptionalOfNullable(
     element: PsiElement,
     textRange: TextRange,
     operands: List<Expression>
-) : Operation(element, textRange, "", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
+) : CollapsedOperation(element, "", operands, textRange) {
     override fun changeOperandsStartOffset(offset: Int): Int {
         return offset - "Optional".length
     }
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 }

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOrElseElvis.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOrElseElvis.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.optional
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -10,10 +9,4 @@ class OptionalOrElseElvis(
     element: PsiElement,
     textRange: TextRange,
     operands: List<Expression>
-) : Operation(element, textRange, " ?: ", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
-}
+) : CollapsedOperation(element, " ?: ", operands, textRange)

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StreamFilterNotNull.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StreamFilterNotNull.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.stream
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -10,14 +9,8 @@ class StreamFilterNotNull(
     element: PsiElement,
     textRange: TextRange,
     operands: List<Expression>
-) : Operation(element, textRange, ".filterNotNull()", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
+) : CollapsedOperation(element, ".filterNotNull()", operands, textRange) {
     override fun changeOperandsEndOffset(startOffset: Int): Int {
         return startOffset + "Objects::nonNull".length
     }
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 }

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StreamMapCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StreamMapCall.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.expression.operation.stream
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
@@ -11,10 +10,4 @@ class StreamMapCall(
     textRange: TextRange,
     operands: List<Expression>,
     flatMap: Boolean
-) : Operation(element, textRange, if (flatMap) "**." else "*.", 300, operands) {
-    override fun buildFolding(character: String): String = character
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
-}
+) : CollapsedOperation(element, if (flatMap) "**." else "*.", operands, textRange)

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StringOperation.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/stream/StringOperation.kt
@@ -1,28 +1,13 @@
 package com.intellij.advancedExpressionFolding.expression.operation.stream
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.expression.Operation
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.expression.operation.CollapsedOperation
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-
 
 open class StringOperation(
     element: PsiElement,
     text: String,
     operands: List<Expression> = emptyList(),
     textRange: TextRange = element.textRange,
-) : Operation(
-    element,
-    textRange,
-    text,
-    300,
-    operands
-) {
-
-    override fun buildFolding(character: String): String = character
-
-    override fun isCollapsedByDefault(): Boolean = true
-
-    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
-}
+) : CollapsedOperation(element, text, operands, textRange)


### PR DESCRIPTION
## Summary
- add a reusable `CollapsedOperation` base class for always-collapsed operations
- update optional and stream operation wrappers to inherit from the shared base and drop duplicated overrides

## Testing
- ./gradlew test --no-daemon --no-configuration-cache --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ebcb7ac6a4832ea2eefb973af7c138