### PR TITLE
Replace folding color control with ActionLink

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -20,10 +20,8 @@ import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
-import java.awt.Color.decode
 import java.awt.FlowLayout
 import java.net.URI
-import javax.swing.JButton
 import javax.swing.JPanel
 import kotlin.reflect.KMutableProperty0
 
@@ -95,13 +93,11 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
 
     override fun createComponent() = panel {
         row {
-            val button =
-                JButton("Apply folded color: ${if (!JBColor.isBright()) "soft blue" else "dark navy"}")
-            button.foreground = if (!JBColor.isBright()) decode("#7ca0bb") else decode("#000091")
-            button.addActionListener {
+            val linkText = "Apply folded color: ${if (!JBColor.isBright()) "soft blue" else "dark navy"}"
+            val actionLink = ActionLink(linkText) {
                 UpdateFoldedTextColorsAction.changeFoldingColors()
             }
-            cell(button)
+            cell(actionLink)
         }
         row {
             cell(createDownloadExamplesLink())


### PR DESCRIPTION
## Summary
- replace the folding color JButton in the settings panel with an IDE-styled ActionLink control

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ea7b435ee0832ead171a01b77471e8