### PR TITLE
Introduce DSL for method call folding processors

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallDsl.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallDsl.kt
@@ -1,0 +1,158 @@
+package com.intellij.advancedExpressionFolding.processor.methodcall
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethodCallExpression
+import java.util.LinkedHashSet
+
+class MethodCallBuilder {
+    private var canExecute: () -> Boolean = { true }
+    private val methodNames = LinkedHashSet<MethodName>()
+    private val classNames = LinkedHashSet<ClassName>()
+
+    private var onNoArguments: ((PsiMethodCallExpression, Context) -> Expression?)? = null
+    private var onSingleArgument: ((PsiMethodCallExpression, Context, PsiExpression, Expression) -> Expression?)? = null
+    private var onTwoArguments: ((PsiMethodCallExpression, Context, PsiExpression, PsiExpression, Expression, Expression) -> Expression?)? = null
+    private var onManyArguments: ((PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?)? = null
+    private var onAnyArguments: ((PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?)? = null
+
+    fun enableWhen(predicate: () -> Boolean) {
+        canExecute = predicate
+    }
+
+    fun methods(vararg names: MethodName) {
+        methodNames.addAll(names)
+    }
+
+    fun methods(names: Iterable<MethodName>) {
+        methodNames.addAll(names)
+    }
+
+    fun classes(vararg names: ClassName) {
+        classNames.addAll(names)
+    }
+
+    fun classes(names: Iterable<ClassName>) {
+        classNames.addAll(names)
+    }
+
+    fun onNoArguments(handler: (PsiMethodCallExpression, Context) -> Expression?) {
+        onNoArguments = handler
+    }
+
+    fun onSingleArgument(
+        handler: (PsiMethodCallExpression, Context, PsiExpression, Expression) -> Expression?
+    ) {
+        onSingleArgument = handler
+    }
+
+    fun onTwoArguments(
+        handler: (PsiMethodCallExpression, Context, PsiExpression, PsiExpression, Expression, Expression) -> Expression?
+    ) {
+        onTwoArguments = handler
+    }
+
+    fun onManyArguments(
+        handler: (PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?
+    ) {
+        onManyArguments = handler
+    }
+
+    fun onAnyArguments(
+        handler: (PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?
+    ) {
+        onAnyArguments = handler
+    }
+
+    fun build(): MethodCallConfiguration = MethodCallConfiguration(
+        canExecute = canExecute,
+        methodNames = methodNames.toList(),
+        classNames = classNames.toList(),
+        onNoArguments = onNoArguments,
+        onSingleArgument = onSingleArgument,
+        onTwoArguments = onTwoArguments,
+        onManyArguments = onManyArguments,
+        onAnyArguments = onAnyArguments
+    )
+}
+
+data class MethodCallConfiguration(
+    val canExecute: () -> Boolean,
+    val methodNames: List<MethodName>,
+    val classNames: List<ClassName>,
+    val onNoArguments: ((PsiMethodCallExpression, Context) -> Expression?)?,
+    val onSingleArgument: ((PsiMethodCallExpression, Context, PsiExpression, Expression) -> Expression?)?,
+    val onTwoArguments: ((PsiMethodCallExpression, Context, PsiExpression, PsiExpression, Expression, Expression) -> Expression?)?,
+    val onManyArguments: ((PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?)?,
+    val onAnyArguments: ((PsiMethodCallExpression, Context, Array<PsiExpression>) -> Expression?)?
+)
+
+abstract class DslMethodCall : AbstractMethodCall() {
+    private val configuration: MethodCallConfiguration by lazy(LazyThreadSafetyMode.NONE) {
+        MethodCallBuilder().also { builder ->
+            configure(builder)
+        }.build()
+    }
+
+    protected open fun configure(builder: MethodCallBuilder) {
+        // subclasses will populate the builder
+    }
+
+    override fun canExecute(): Boolean = configuration.canExecute()
+
+    override val methodNames: List<MethodName> by lazy(LazyThreadSafetyMode.NONE) {
+        configuration.methodNames
+    }
+
+    override val classNames: List<ClassName> by lazy(LazyThreadSafetyMode.NONE) {
+        configuration.classNames
+    }
+
+    override fun onAnyArguments(
+        element: PsiMethodCallExpression,
+        context: Context,
+        expressions: Array<PsiExpression>
+    ): Expression? {
+        return configuration.onAnyArguments?.invoke(element, context, expressions)
+            ?: super.onAnyArguments(element, context, expressions)
+    }
+
+    override fun onNoArguments(
+        element: PsiMethodCallExpression,
+        context: Context
+    ): Expression? {
+        return configuration.onNoArguments?.invoke(element, context)
+            ?: super.onNoArguments(element, context)
+    }
+
+    override fun onSingleArgument(
+        element: PsiMethodCallExpression,
+        context: Context,
+        argument: PsiExpression,
+        argumentExpression: Expression
+    ): Expression? {
+        return configuration.onSingleArgument?.invoke(element, context, argument, argumentExpression)
+            ?: super.onSingleArgument(element, context, argument, argumentExpression)
+    }
+
+    override fun onTwoArguments(
+        element: PsiMethodCallExpression,
+        context: Context,
+        a1: PsiExpression,
+        a2: PsiExpression,
+        a1Expression: Expression,
+        a2Expression: Expression
+    ): Expression? {
+        return configuration.onTwoArguments?.invoke(element, context, a1, a2, a1Expression, a2Expression)
+            ?: super.onTwoArguments(element, context, a1, a2, a1Expression, a2Expression)
+    }
+
+    override fun onManyArguments(
+        element: PsiMethodCallExpression,
+        context: Context,
+        expressions: Array<PsiExpression>
+    ): Expression? {
+        return configuration.onManyArguments?.invoke(element, context, expressions)
+            ?: super.onManyArguments(element, context, expressions)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/AbstractArithmeticMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/AbstractArithmeticMethodCall.kt
@@ -1,13 +1,15 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.processor.methodcall.AbstractMethodCall
+import com.intellij.advancedExpressionFolding.processor.methodcall.DslMethodCall
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 import com.intellij.advancedExpressionFolding.processor.methodcall.NeedsQualifier
 
-abstract class AbstractArithmeticMethodCall : AbstractMethodCall(), NeedsQualifier {
-    override val classNames by lazy { 
-        listOf(
+abstract class AbstractArithmeticMethodCall : DslMethodCall(), NeedsQualifier {
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.classes(
             "java.math.BigDecimal",
             "java.math.BigInteger"
-        ) 
+        )
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
@@ -1,19 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Abs
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticAbsMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("abs") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Abs(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("abs")
+        builder.onNoArguments { element, context ->
+            Abs(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.basic.Add
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticAddMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("add") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Add(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("add")
+        builder.onSingleArgument { element, context, _, _ ->
+            Add(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.And
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticAndMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("and") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = And(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("and")
+        builder.onSingleArgument { element, context, _, _ ->
+            And(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndNotMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndNotMethodCall.kt
@@ -1,32 +1,26 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Not
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.And
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
-import java.util.*
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticAndNotMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("andNot") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? {
-        val qualifier = context.qualifierExpr
-        val notExpr = Not(
-            element,
-            argumentExpression.textRange,
-            Collections.singletonList(argumentExpression)
-        )
-        return And(
-            element,
-            element.textRange,
-            listOf(qualifier, notExpr)
-        )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("andNot")
+        builder.onSingleArgument { element, context, _, argumentExpression ->
+            val qualifier = context.qualifierExpr
+            val notExpr = Not(
+                element,
+                argumentExpression.textRange,
+                listOf(argumentExpression)
+            )
+            And(
+                element,
+                element.textRange,
+                listOf(qualifier, notExpr)
+            )
+        }
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
@@ -1,24 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.trig.Atan2
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticAtan2MethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("atan2") }
-
-    override fun onTwoArguments(
-        element: PsiMethodCallExpression,
-        context: Context,
-        a1: PsiExpression,
-        a2: PsiExpression,
-        a1Expression: Expression,
-        a2Expression: Expression
-    ): Expression? = Atan2(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("atan2")
+        builder.onTwoArguments { element, context, _, _, _, _ ->
+            Atan2(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.basic.Divide
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticDivideMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("divide") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Divide(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("divide")
+        builder.onSingleArgument { element, context, _, _ ->
+            Divide(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.advanced.Gcd
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticGcdMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("gcd") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Gcd(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("gcd")
+        builder.onSingleArgument { element, context, _, _ ->
+            Gcd(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
@@ -1,24 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Max
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticMaxMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("max") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? {
-        return Max(
-            element,
-            element.textRange,
-            context.getOperands()
-        )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("max")
+        builder.onSingleArgument { element, context, _, _ ->
+            Max(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMinMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMinMethodCall.kt
@@ -1,27 +1,23 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Min
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticMinMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("min") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? {
-        if (context.className == "java.util.stream.Stream") {
-            return null
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("min")
+        builder.onSingleArgument { element, context, _, _ ->
+            if (context.className == "java.util.stream.Stream") {
+                null
+            } else {
+                Min(
+                    element,
+                    element.textRange,
+                    context.getOperands()
+                )
+            }
         }
-        return Min(
-            element,
-            element.textRange,
-            context.getOperands()
-        )
     }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Multiply
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticMultiplyMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("multiply") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Multiply(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("multiply")
+        builder.onSingleArgument { element, context, _, _ ->
+            Multiply(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
@@ -1,19 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Negate
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticNegateMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("negate") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Negate(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("negate")
+        builder.onNoArguments { element, context ->
+            Negate(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
@@ -1,19 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Not
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticNotMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("not") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Not(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("not")
+        builder.onNoArguments { element, context ->
+            Not(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Or
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticOrMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("or") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Or(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("or")
+        builder.onSingleArgument { element, context, _, _ ->
+            Or(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
@@ -1,15 +1,14 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticPlusMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("plus") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = context.qualifierExprNullable
-
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("plus")
+        builder.onNoArguments { _, context ->
+            context.qualifierExprNullable
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.advanced.Pow
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticPowMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("pow") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Pow(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("pow")
+        builder.onSingleArgument { element, context, _, _ ->
+            Pow(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Remainder
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticRemainderMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("remainder", "mod") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Remainder(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("remainder", "mod")
+        builder.onSingleArgument { element, context, _, _ ->
+            Remainder(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.ShiftLeft
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticShiftLeftMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftLeft") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = ShiftLeft(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("shiftLeft")
+        builder.onSingleArgument { element, context, _, _ ->
+            ShiftLeft(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.ShiftRight
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticShiftRightMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftRight") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = ShiftRight(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("shiftRight")
+        builder.onSingleArgument { element, context, _, _ ->
+            ShiftRight(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
@@ -1,19 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Signum
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticSignumMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("signum") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Signum(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("signum")
+        builder.onNoArguments { element, context ->
+            Signum(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Subtract
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticSubtractMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("subtract") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Subtract(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("subtract")
+        builder.onSingleArgument { element, context, _, _ ->
+            Subtract(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
@@ -1,22 +1,19 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Xor
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 
 class ArithmeticXorMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("xor") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Xor(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.methods("xor")
+        builder.onSingleArgument { element, context, _, _ ->
+            Xor(
+                element,
+                element.textRange,
+                context.getOperands()
+            )
+        }
+    }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt
@@ -1,57 +1,51 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.basic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
 import com.intellij.advancedExpressionFolding.expression.operation.basic.Append
-import com.intellij.advancedExpressionFolding.processor.methodcall.AbstractMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.advancedExpressionFolding.processor.methodcall.NeedsQualifier
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.DslMethodCall
+import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallBuilder
 import com.intellij.psi.PsiStatement
-import java.util.*
 
-class AppendMethodCall : AbstractMethodCall(), NeedsQualifier {
-    override fun canExecute() = concatenationExpressionsCollapse
-
-    override val methodNames by lazy { listOf("append") }
-    
-    override val classNames by lazy { listOf(
-        "java.lang.StringBuilder", 
-        "java.lang.AbstractStringBuilder"
-    ) }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? {
-        val qualifier = context.qualifierExpr
-        return when {
-            qualifier is Append -> {
-                val operands = ArrayList(qualifier.operands)
-                operands.add(argumentExpression)
-                Append(
-                    element,
-                    element.textRange,
-                    operands,
-                    element.parent is PsiStatement
-                )
-            }
-            qualifier is StringLiteral && qualifier.string.isEmpty() -> {
-                Append(
-                    element, element.textRange,
-                    Collections.singletonList(argumentExpression), element.parent is PsiStatement
-                )
-            }
-            else -> {
-                Append(
-                    element,
-                    element.textRange,
-                    context.getOperands(),
-                    element.parent is PsiStatement
-                )
+class AppendMethodCall : DslMethodCall(), NeedsQualifier {
+    override fun configure(builder: MethodCallBuilder) {
+        super.configure(builder)
+        builder.enableWhen { concatenationExpressionsCollapse }
+        builder.methods("append")
+        builder.classes(
+            "java.lang.StringBuilder",
+            "java.lang.AbstractStringBuilder"
+        )
+        builder.onSingleArgument { element, context, _, argumentExpression ->
+            val qualifier = context.qualifierExpr
+            when {
+                qualifier is Append -> {
+                    val operands = qualifier.operands.toMutableList()
+                    operands.add(argumentExpression)
+                    Append(
+                        element,
+                        element.textRange,
+                        operands,
+                        element.parent is PsiStatement
+                    )
+                }
+                qualifier is StringLiteral && qualifier.string.isEmpty() -> {
+                    Append(
+                        element,
+                        element.textRange,
+                        listOf(argumentExpression),
+                        element.parent is PsiStatement
+                    )
+                }
+                else -> {
+                    Append(
+                        element,
+                        element.textRange,
+                        context.getOperands(),
+                        element.parent is PsiStatement
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a `DslMethodCall` helper with a fluent `MethodCallBuilder` so folding processors can declare settings, method/class filters, and argument handlers in one place
- refactor arithmetic and append method-call processors to consume the DSL, removing duplicated boilerplate and centralizing qualifier/class configuration

## Testing
- ./gradlew test --console=plain 2>&1 | tee /tmp/gradle-test.log

------
https://chatgpt.com/codex/tasks/task_e_68ec153ea020832ea2846d297d514624