### PR TITLE
Replace Boolean on/off helpers with takeIf semantics

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/extensions.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/extensions.kt
@@ -11,25 +11,25 @@ inline fun <reified T> Any?.isInstance(): Boolean = this is T
 fun String.equalsIgnoreSpaces(second: String): Boolean =
     filterNot(Char::isWhitespace) == second.filterNot(Char::isWhitespace)
 
-fun Boolean?.on(): Any? = if (this == true) {
-    on(true)
+fun Boolean?.takeIfTrue(): Any? = if (this == true) {
+    takeIfTrue(true)
 } else {
     null
 }
 
-fun <T> Boolean.on(element: T?): T? = if (this) {
+fun <T> Boolean.takeIfTrue(element: T?): T? = if (this) {
     element
 } else {
     null
 }
 
-fun Boolean.off(): Any? = if (this) {
+fun Boolean.takeIfFalse(): Any? = if (this) {
     null
 } else {
     true
 }
 
-fun <T> Boolean.off(element: T?): T? = if (this) {
+fun <T> Boolean.takeIfFalse(element: T?): T? = if (this) {
     null
 } else {
     element

--- a/src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt
@@ -11,7 +11,7 @@ object ExperimentalExt : BaseExtension() {
 
     @JvmStatic
     fun createExpression(element: PsiReferenceExpression): Expression? {
-        return emojify.on(element)?.singletonField()
+        return emojify.takeIfTrue(element)?.singletonField()
     }
 
     private fun PsiReferenceExpression.singletonField(): Expression? {

--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
@@ -2,9 +2,9 @@ package com.intellij.advancedExpressionFolding.processor.logger
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.asInstance
-import com.intellij.advancedExpressionFolding.processor.firstArgument
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
-import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.processor.firstArgument
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
@@ -19,7 +19,7 @@ object LoggerBracketsExt : BaseExtension() {
         methodName: String,
         document: Document
     ): Expression? {
-        logFolding.on() ?: return null
+        logFolding.takeIfTrue() ?: return null
 
         val extensionConstructor: (PsiMethodCallExpression, Document) -> LoggerBracketsExtensionBase = when {
             methodName == "formatted" -> ::StringFormattedLoggerBracketsExtension

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt
@@ -21,7 +21,7 @@ object AnnotationExt {
     )
 
     fun addClassLevelAnnotations(clazz: PsiClass): ClassAnnotationExpression? {
-        (clazz.isIgnored() || clazz.isRecord).off() ?: return null
+        (clazz.isIgnored() || clazz.isRecord).takeIfFalse() ?: return null
 
         lombokPatternOff?.run {
             val regex = patternAsRegex()

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt
@@ -80,7 +80,7 @@ object LombokExt : BaseExtension() {
         }.map { logField ->
             val dirty = logField.name != "log"
             logField.markIgnored()
-            val arguments = dirty.on(logField.name)?.let {
+            val arguments = dirty.takeIfTrue(logField.name)?.let {
                 listOf(it)
             } ?: emptyList()
             ClassLevelAnnotation(LOMBOK_LOG, listOf(logField), arguments = arguments)

--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
@@ -65,7 +65,7 @@ object SummaryParentOverrideExt : BaseExtension() {
         val hasOverride = method.annotations.any {
             it.isOverride()
         }
-        list += hasOverride.on()?.let {
+        list += hasOverride.takeIfTrue()?.let {
             method.body
         }?.let { body ->
             createOverridesComment(method, body)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
@@ -4,7 +4,7 @@ import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.ConfigurationParser
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.DynamicMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.IDynamicDataProvider
-import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.advancedExpressionFolding.processor.util.Consts
 
 typealias MethodName = String
@@ -90,7 +90,7 @@ object MethodCallFactory : BaseExtension(){
 
     private fun getAllMethodCalls(): List<AbstractMethodCall> = MethodCallManager.methodCalls + loadDynamicMethods().orEmpty()
 
-    private fun loadDynamicMethods(): List<DynamicMethodCall>? = dynamic.on()?.let { dynamicProvider?.parse() }
+    private fun loadDynamicMethods(): List<DynamicMethodCall>? = dynamic.takeIfTrue()?.let { dynamicProvider?.parse() }
 
     private fun createSupportedClasses(): Collection<ClassName> =
         methodCallMap.values

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt
@@ -5,7 +5,7 @@ import com.intellij.advancedExpressionFolding.expression.operation.collection.Pu
 import com.intellij.advancedExpressionFolding.processor.methodcall.AbstractMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.advancedExpressionFolding.processor.methodcall.NeedsQualifier
-import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiStatement
@@ -24,7 +24,7 @@ class MapPutMethodCall : AbstractMethodCall(), NeedsQualifier {
         a1Expression: Expression,
         a2Expression: Expression
     ): Expression? {
-        return (element.parent is PsiStatement).on()?.let {
+        return (element.parent is PsiStatement).takeIfTrue()?.let {
             Put(
                 element,
                 element.textRange,

--- a/src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt
@@ -3,14 +3,14 @@ package com.intellij.advancedExpressionFolding.processor.token
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.expr
-import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.psi.JavaTokenType.*
 import com.intellij.psi.PsiJavaToken
 
 object PsiJavaTokenExt : BaseExtension() {
 
     fun createExpression(element: PsiJavaToken): Expression? {
-        emojify.on() ?: return null
+        emojify.takeIfTrue() ?: return null
 
         val emoji = when (element.tokenType) {
             NULL_KEYWORD -> "🕳️"

--- a/src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.*
 object PsiKeywordExt : BaseExtension() {
 
     fun createExpression(keyword: PsiKeyword): Expression? =
-        finalRemoval.on(keyword)?.finalRemoval() ?: finalEmoji.on(keyword)?.finalEmoji()
+        finalRemoval.takeIfTrue(keyword)?.finalRemoval() ?: finalEmoji.takeIfTrue(keyword)?.finalEmoji()
 
     private fun PsiKeyword.finalEmoji(): Expression? = foldFinalsExceptFields { expr(Emoji.FINAL_LOCK.toString()) }
 

--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -2,7 +2,7 @@ package com.intellij.advancedExpressionFolding
 
 import ai.grazie.utils.capitalize
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorExWrapper
-import com.intellij.advancedExpressionFolding.processor.off
+import com.intellij.advancedExpressionFolding.processor.takeIfFalse
 import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.projectRoots.JavaSdk
@@ -60,7 +60,7 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
             val actual = e.actual.stringRepresentation
             Files.writeString(testDataFile.toPath(), actual)
             val wrapper = store.createOrderedFoldingWrapper()
-            saveFoldingsAsJson.off() ?: run {
+            saveFoldingsAsJson.takeIfFalse() ?: run {
                 val folderName = "wrappers"
                 val jsonFileName = fileName.replace("testData/", "$folderName/")
                 File(folderName).mkdirs()

--- a/test/com/intellij/advancedExpressionFolding/CrazyFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/CrazyFoldingTest.kt
@@ -1,6 +1,6 @@
 package com.intellij.advancedExpressionFolding
 
-import com.intellij.advancedExpressionFolding.processor.on
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.allMainProperties
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
@@ -136,7 +136,7 @@ class CrazyFoldingTest : BaseTest() {
 
 
         private fun File.readCounterAndFilename(): Pair<Long, String>? {
-            exists().on() ?: return null
+            exists().takeIfTrue() ?: return null
             val properties = Properties()
             FileInputStream(this).use {
                 properties.load(it)


### PR DESCRIPTION
## Summary
- rename the Boolean extension helpers to takeIfTrue/takeIfFalse for clearer semantics
- update plugin code and tests to use the new helper names

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ee66753150832e8a3f5a6d71b61726