### PR TITLE
Adjust Hercules Insights workflow to v10.7.1

### DIFF
--- a/.github/workflows/hercules-insights.yml
+++ b/.github/workflows/hercules-insights.yml
@@ -15,4 +15,10 @@ jobs:
           fetch-depth: 0
 
       - name: Hercules Insights
-        uses: src-d/hercules@v10.7.2
+        uses: src-d/hercules@v10.7.1
+
+      - name: Upload insights artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hercules-insights
+          path: hercules_charts.tar


### PR DESCRIPTION
## Summary
- switch the Hercules Insights workflow to use src-d/hercules@v10.7.1 as requested
- upload the generated hercules_charts.tar artifact so the workflow exposes its results

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68f7ad05b68c832e85feab57de24eaeb