### PR TITLE
Update Hercules Insights workflow

### DIFF
--- a/.github/workflows/hercules-insights.yml
+++ b/.github/workflows/hercules-insights.yml
@@ -15,7 +15,14 @@ jobs:
           fetch-depth: 0
 
       - name: Hercules Insights
-        uses: src-d/hercules@v10.6.3
+        run: |
+          docker run --rm -v $(pwd):/repo srcd/hercules:latest \
+            /bin/bash -c "pip install matplotlib==3.2.0 && \
+            hercules --devs --burndown --burndown-people --couples --pb /repo | \
+            labours -m all -f pb --disable-projector -o /repo/hercules_charts && \
+            cd /repo/hercules_charts && \
+            tar -cf ../hercules_charts.tar * ../hercules_charts_* && \
+            cd .. && rm -r hercules_charts"
 
       - name: Upload insights artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- replace the Hercules Insights workflow action with a Docker-based invocation that reproduces the previous Hercules and labours pipeline
- keep the artifact upload step so the generated tarball is preserved

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f7c7040c04832e8763a006d1074286