### PR TITLE
@PostConstructor marker annotation for methods called from constructor, methods are not hidden

### DIFF
--- a/examples/data/LombokPostConstructorTestData.java
+++ b/examples/data/LombokPostConstructorTestData.java
@@ -22,4 +22,30 @@ public class LombokPostConstructorTestData {
             computedResult = value1 + value2;
         }
     }
+
+    public static class TaskPipeline {
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
+
+        public TaskPipeline() {
+            this.seed = -1;
+            prepare();
+            execute();
+        }
+
+        public TaskPipeline(int seed) {
+            this.seed = seed;
+            prepare();
+            execute();
+        }
+
+        private void prepare() {
+            prepared = true;
+        }
+
+        private void execute() {
+            executed = prepared;
+        }
+    }
 }

--- a/folded/LombokPostConstructorTestData-folded.java
+++ b/folded/LombokPostConstructorTestData-folded.java
@@ -10,14 +10,42 @@ public class LombokPostConstructorTestData {
         public DataProcessor(int value1, int value2) {
             this.value1 = value1;
             this.value2 = value2;
+            initialize();
         }
 
         public DataProcessor() {
             this(0, 0);
+            initialize();
         }
 
         @PostConstructor private void initialize() {
             computedResult = value1 + value2;
+        }
+    }
+
+    public static class TaskPipeline {
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
+
+        public TaskPipeline() {
+            this.seed = -1;
+            prepare();
+            execute();
+        }
+
+        public TaskPipeline(int seed) {
+            this.seed = seed;
+            prepare();
+            execute();
+        }
+
+        @PostConstructor(1) private void prepare() {
+            prepared = true;
+        }
+
+        @PostConstructor(2) private void execute() {
+            executed = prepared;
         }
     }
 }

--- a/testData/LombokPostConstructorTestData-all.java
+++ b/testData/LombokPostConstructorTestData-all.java
@@ -9,17 +9,43 @@ public class LombokPostConstructorTestData {
 
         public DataProcessor(int value1, int value2) <fold text='{...}' expand='true'>{
             this.value1 = <fold text='<<' expand='false'>value1</fold>;
-            this.value2 = <fold text='<<' expand='false'>value2</fold>;<fold text='' expand='false'>
-            </fold><fold text='' expand='false'>initialize();</fold>
+            this.value2 = <fold text='<<' expand='false'>value2</fold>;
+            initialize();
         }</fold>
 
         public DataProcessor() <fold text='{...}' expand='true'>{
-            this(0, 0);<fold text='' expand='false'>
-            </fold><fold text='' expand='false'>initialize();</fold>
+            this(0, 0);
+            initialize();
         }</fold>
 
         <fold text='@PostConstructor p' expand='false'>p</fold>rivate void initialize()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
             </fold></fold>computedResult = value1 + value2<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+    }</fold>
+
+    public static class TaskPipeline <fold text='{...}' expand='true'>{
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
+
+        public TaskPipeline() <fold text='{...}' expand='true'>{
+            this.seed = -1;
+            prepare();
+            execute();
+        }</fold>
+
+        public TaskPipeline(int seed) <fold text='{...}' expand='true'>{
+            this.seed = <fold text='<<' expand='false'>seed</fold>;
+            prepare();
+            execute();
+        }</fold>
+
+        <fold text='@PostConstructor(1) p' expand='false'>p</fold>rivate void prepare()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold>prepared = true<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+
+        <fold text='@PostConstructor(2) p' expand='false'>p</fold>rivate void execute()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold>executed = prepared<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
         </fold>}</fold>
     }</fold>
 }

--- a/testData/LombokPostConstructorTestData.java
+++ b/testData/LombokPostConstructorTestData.java
@@ -9,17 +9,43 @@ public class LombokPostConstructorTestData {
 
         public DataProcessor(int value1, int value2) <fold text='{...}' expand='true'>{
             this.value1 = value1;
-            this.value2 = value2;<fold text='' expand='false'>
-            </fold><fold text='' expand='false'>initialize();</fold>
+            this.value2 = value2;
+            initialize();
         }</fold>
 
         public DataProcessor() <fold text='{...}' expand='true'>{
-            this(0, 0);<fold text='' expand='false'>
-            </fold><fold text='' expand='false'>initialize();</fold>
+            this(0, 0);
+            initialize();
         }</fold>
 
         <fold text='@PostConstructor p' expand='false'>p</fold>rivate void initialize()<fold text=' { ' expand='false'> {
             </fold>computedResult = value1 + value2;<fold text=' }' expand='false'>
+        }</fold>
+    }</fold>
+
+    public static class TaskPipeline <fold text='{...}' expand='true'>{
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
+
+        public TaskPipeline() <fold text='{...}' expand='true'>{
+            this.seed = -1;
+            prepare();
+            execute();
+        }</fold>
+
+        public TaskPipeline(int seed) <fold text='{...}' expand='true'>{
+            this.seed = seed;
+            prepare();
+            execute();
+        }</fold>
+
+        <fold text='@PostConstructor(1) p' expand='false'>p</fold>rivate void prepare()<fold text=' { ' expand='false'> {
+            </fold>prepared = true;<fold text=' }' expand='false'>
+        }</fold>
+
+        <fold text='@PostConstructor(2) p' expand='false'>p</fold>rivate void execute()<fold text=' { ' expand='false'> {
+            </fold>executed = prepared;<fold text=' }' expand='false'>
         }</fold>
     }</fold>
 }

--- a/wiki-clone/docs/features/lombok.md
+++ b/wiki-clone/docs/features/lombok.md
@@ -148,51 +148,111 @@ Removes boilerplate while preserving behavior.
 ### @PostConstructor
 LombokPostConstructorTestData.java:
 ```java
-public class DataProcessor {
-    private final int value1;
-    private final int value2;
-    private int computedResult;
+public class LombokPostConstructorTestData {
 
-    public DataProcessor(int value1, int value2) {
-        this.value1 = value1;
-        this.value2 = value2;
-        initialize();
+    public static class DataProcessor {
+        private final int value1;
+        private final int value2;
+        private int computedResult;
+
+        public DataProcessor(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+            initialize();
+        }
+
+        public DataProcessor() {
+            this(0, 0);
+            initialize();
+        }
+
+        private void initialize() {
+            computedResult = value1 + value2;
+        }
     }
 
-    public DataProcessor() {
-        this(0, 0);
-        initialize();
-    }
+    public static class TaskPipeline {
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
 
-    private void initialize() {
-        computedResult = value1 + value2;
+        public TaskPipeline() {
+            this.seed = -1;
+            prepare();
+            execute();
+        }
+
+        public TaskPipeline(int seed) {
+            this.seed = seed;
+            prepare();
+            execute();
+        }
+
+        private void prepare() {
+            prepared = true;
+        }
+
+        private void execute() {
+            executed = prepared;
+        }
     }
 }
 ```
 
 LombokPostConstructorTestData-folded.java:
 ```java
-public class DataProcessor {
-    private final int value1;
-    private final int value2;
-    private int computedResult;
+public class LombokPostConstructorTestData {
 
-    public DataProcessor(int value1, int value2) {
-        this.value1 = value1;
-        this.value2 = value2;
+    public static class DataProcessor {
+        private final int value1;
+        private final int value2;
+        private int computedResult;
+
+        public DataProcessor(int value1, int value2) {
+            this.value1 = value1;
+            this.value2 = value2;
+            initialize();
+        }
+
+        public DataProcessor() {
+            this(0, 0);
+            initialize();
+        }
+
+        @PostConstructor private void initialize() {
+            computedResult = value1 + value2;
+        }
     }
 
-    public DataProcessor() {
-        this(0, 0);
-    }
+    public static class TaskPipeline {
+        private final int seed;
+        private boolean prepared;
+        private boolean executed;
 
-    @PostConstructor private void initialize() {
-        computedResult = value1 + value2;
+        public TaskPipeline() {
+            this.seed = -1;
+            prepare();
+            execute();
+        }
+
+        public TaskPipeline(int seed) {
+            this.seed = seed;
+            prepare();
+            execute();
+        }
+
+        @PostConstructor(1) private void prepare() {
+            prepared = true;
+        }
+
+        @PostConstructor(2) private void execute() {
+            executed = prepared;
+        }
     }
 }
 ```
 
-Methods invoked at the end of every constructor are replaced with the `@PostConstructor` marker while their explicit calls are hidden.
+Methods invoked at the end of every constructor now receive an informational `@PostConstructor` annotation while their explicit calls remain visible. When more than one method participates, numbering communicates the execution order.
 
 ### @LightValue
 This seems to be a custom annotation not present in standard Lombok. It appears to create an immutable class without equals and hashCode methods.


### PR DESCRIPTION
## Summary
- simplify Lombok post constructor preparation by capturing the first trailing call sequence and reusing it for annotation numbering
- fall back to the plain @PostConstructor tag whenever only one method qualifies or no stable ordering is available

## Testing
- ./gradlew clean build test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68f7b96c0534832eb5bde16b758a7397