### PR TITLE
Fix getLast folding detection after merge

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -214,8 +214,8 @@ object Helper {
                 if (identifier != null && (identifier.text == "length" || identifier.text == "size") &&
                     methodExpression.qualifierExpression != null
                 ) {
-                    val qualifierExpression = methodExpression.qualifierExpression ?: return null
-                    val qualifier = BuildExpressionExt.getAnyExpression(qualifierExpression, document)
+                    val qualifierPsiExpression = methodExpression.qualifierExpression ?: return null
+                    val qualifier = BuildExpressionExt.getAnyExpression(qualifierPsiExpression, document)
                     if (qualifier == qualifierExpression) {
                         return NumberLiteral(
                             parent,


### PR DESCRIPTION
## Summary
- avoid shadowing the qualifier expression when computing slice positions so the calculated NumberLiteral is preserved
- ensure collection get/set folding keeps last-element placeholders after rebasing onto main

## Testing
- ./gradlew --no-configuration-cache -Dorg.gradle.daemon=false test -x examples:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f7c9e75430832eb33bf84d209e5f00