### PR TITLE
Handle missing application instance in regex editor validator

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -299,34 +299,48 @@ private fun createEditor(property: KMutableProperty0<String?>): EditorEx {
     val document = factory.createDocument(property.get() ?: "")
 
     val editor = factory.createEditor(document, null) as EditorEx
-    val validator = ComponentValidator(ApplicationManager.getApplication())
-        .withValidator(Supplier {
-            val text = document.text.trim()
-            if (text.isEmpty()) {
-                property.set(null)
-                return@Supplier null
-            }
+    val application = ApplicationManager.getApplication()
 
-            try {
-                text.toPattern()
-                property.set(text)
-                null
-            } catch (exception: PatternSyntaxException) {
-                property.set(null)
-                ValidationInfo(
-                    exception.description ?: exception.message ?: "Invalid regular expression",
-                    editor.component
-                )
-            }
-        })
-        .installOn(editor.component)
+    fun validateDocument(): ValidationInfo? {
+        val text = document.text.trim()
+        if (text.isEmpty()) {
+            property.set(null)
+            return null
+        }
+
+        return try {
+            text.toPattern()
+            property.set(text)
+            null
+        } catch (exception: PatternSyntaxException) {
+            property.set(null)
+            ValidationInfo(
+                exception.description ?: exception.message ?: "Invalid regular expression",
+                editor.component
+            )
+        }
+    }
+
+    val validator = application?.let {
+        ComponentValidator(it)
+            .withValidator(Supplier { validateDocument() })
+            .installOn(editor.component)
+    }
 
     document.addDocumentListener(object : DocumentListener {
         override fun documentChanged(event: DocumentEvent) {
-            validator.revalidate()
+            if (validator != null) {
+                validator.revalidate()
+            } else {
+                validateDocument()
+            }
         }
     })
-    validator.revalidate()
+    if (validator != null) {
+        validator.revalidate()
+    } else {
+        validateDocument()
+    }
     return editor.apply {
         settings.apply {
             isUseSoftWraps = true


### PR DESCRIPTION
## Summary
- avoid creating a `ComponentValidator` when the IDE application instance is unavailable
- keep the regex setting in sync by validating directly when the validator cannot be created

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68f67031d574832e80b6ef9243343cf3