### PR TITLE
Default nameless accessors to !! placeholder

### DIFF
--- a/examples/data/ExperimentalTestData.java
+++ b/examples/data/ExperimentalTestData.java
@@ -103,4 +103,27 @@ public class ExperimentalTestData {
         }
     }
 
+
+    static class NamelessAccessorExample {
+
+        private String state;
+
+        void set(String value) {
+            this.state = value;
+        }
+
+        String get() {
+            return state;
+        }
+
+        void demo() {
+            NamelessAccessorExample example = new NamelessAccessorExample();
+            example.set("ok");
+            String current = example.get();
+            System.out.println(example.get().isEmpty());
+            example.set(example.get());
+            String duplicate = example.get() + example.get();
+        }
+    }
+
 }

--- a/folded/ExperimentalTestData-folded.java
+++ b/folded/ExperimentalTestData-folded.java
@@ -15,7 +15,7 @@ public class ExperimentalTestData {
 
         public String utf8ToStringMultiline(byte[] bytes) {
             @SneakyThrows {
-                byte[] bytez = System["sort-desc"].getBytes();
+                byte[] bytez = System["sort-desc"].bytes;
                 return new String(bytez, "UTF-8");
             }
         }
@@ -44,7 +44,7 @@ public class ExperimentalTestData {
 
         public String utf8ToString(byte[] bytes) {
             @SneakyThrows
-            return new String(System["sort-desc"].getBytes(), "UTF-8");
+            return new String(System["sort-desc"].bytes, "UTF-8");
         }
         public void run() {
             @SneakyThrows
@@ -85,6 +85,29 @@ public class ExperimentalTestData {
                     throw new RuntimeException("", t);
                 }
             }
+        }
+    }
+
+
+    static class NamelessAccessorExample {
+
+        private String state;
+
+        void set(String value) {
+            this.state = value;
+        }
+
+        String get() {
+            return state;
+        }
+
+        void demo() {
+            NamelessAccessorExample example = new NamelessAccessorExample();
+            example!! = "ok";
+            String current = example!!;
+            System.out.println(example!!.empty);
+            example!! = example!!;
+            String duplicate = example!! + example!!;
         }
     }
 

--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -19,6 +19,7 @@ import com.intellij.psi.PsiExpressionStatement
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiLoopStatement
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiMethodReferenceExpression
 import com.intellij.psi.PsiModifier
@@ -26,6 +27,7 @@ import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiPostfixExpression
 import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiTypes
 import com.intellij.psi.PsiStatement
 import com.intellij.psi.PsiVariable
 import com.intellij.psi.SyntaxTraverser
@@ -258,6 +260,38 @@ object Helper {
     fun isGetterAux(name: String?, prefix: String): Boolean {
         return startsWith(name, prefix) && name!!.length > prefix.length && name[prefix.length].isUpperCase()
     }
+
+    fun isNamelessGetter(name: String, expression: PsiMethodCallExpression, method: PsiMethod?): Boolean {
+        if (name != "get") {
+            return false
+        }
+        if (expression.argumentExpressions.isNotEmpty()) {
+            return false
+        }
+        return hasNonVoidReturn(expression, method)
+    }
+
+    fun isNamelessSetter(name: String, expression: PsiMethodCallExpression, method: PsiMethod?): Boolean {
+        if (name != "set") {
+            return false
+        }
+        if (expression.argumentExpressions.size != 1) {
+            return false
+        }
+        return hasVoidReturn(expression, method)
+    }
+
+    fun hasVoidReturn(expression: PsiMethodCallExpression, method: PsiMethod?): Boolean {
+        val returnType = method?.returnType ?: expression.type ?: return false
+        return returnType == PsiTypes.voidType()
+    }
+
+    fun hasNonVoidReturn(expression: PsiMethodCallExpression, method: PsiMethod?): Boolean {
+        val returnType = method?.returnType ?: expression.type ?: return false
+        return returnType != PsiTypes.voidType()
+    }
+
+    fun guessNamelessPropertyName(method: PsiMethod?): String = "!!"
 
     fun findAncestorsUntilClass(element: PsiElement, ancestorClass: Class<out PsiElement>): Sequence<PsiElement> {
         return findAncestorsUntil(element) { parent -> !ancestorClass.isInstance(parent) }

--- a/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
@@ -542,7 +542,14 @@ staticMethod.newName = 'changedStaticMethod'
      */
     @Test
     open fun experimentalTestData() {
-        doFoldingTest(state::experimental, state::nullable, state::const, state::lombok, state::getExpressionsCollapse)
+        doFoldingTest(
+            state::experimental,
+            state::nullable,
+            state::const,
+            state::lombok,
+            state::getExpressionsCollapse,
+            state::getSetExpressionsCollapse
+        )
     }
 
 }

--- a/testData/ExperimentalTestData-all.java
+++ b/testData/ExperimentalTestData-all.java
@@ -103,4 +103,27 @@ public class ExperimentalTestData {
         }</fold>
     }</fold>
 
+
+    static class NamelessAccessorExample <fold text='{...}' expand='true'>{
+
+        private String state;
+
+        void set(String value)<fold text=' { ' expand='false'> {
+            </fold>this.state = value;<fold text=' }' expand='false'>
+        }</fold>
+
+        String get()<fold text=' { ' expand='false'> {
+            </fold>return state;<fold text=' }' expand='false'>
+        }</fold>
+
+        void demo() <fold text='{...}' expand='true'>{
+            NamelessAccessorExample example = new NamelessAccessorExample();
+            example<fold text='!! = ' expand='false'>.set(</fold>"ok"<fold text='' expand='false'>)</fold>;
+            String current = example<fold text='!!' expand='false'>.get()</fold>;
+            System.out.println(example<fold text='!!' expand='false'>.get()</fold>.<fold text='empty' expand='false'>isEmpty()</fold>);
+            example<fold text='!! = ' expand='false'>.set(</fold>example<fold text='!!' expand='false'>.get()</fold><fold text='' expand='false'>)</fold>;
+            String duplicate = example<fold text='!!' expand='false'>.get()</fold> + example<fold text='!!' expand='false'>.get()</fold>;
+        }</fold>
+    }</fold>
+
 }

--- a/testData/ExperimentalTestData.java
+++ b/testData/ExperimentalTestData.java
@@ -15,7 +15,7 @@ public class ExperimentalTestData {
 
         public String utf8ToStringMultiline(byte[] bytes) <fold text='{...}' expand='true'>{
             <fold text='@SneakyThrows' expand='true'>try</fold> <fold text='{...}' expand='true'>{
-                byte[] bytez = System<fold text='[' expand='false'>.getProperty(</fold>"sort-desc"<fold text=']' expand='false'>)</fold>.getBytes();
+                byte[] bytez = System<fold text='[' expand='false'>.getProperty(</fold>"sort-desc"<fold text=']' expand='false'>)</fold>.<fold text='bytes' expand='false'>getBytes()</fold>;
                 return new String(bytez, "UTF-8");
             }</fold><fold text='' expand='true'> </fold><fold text='' expand='true'>catch (UnsupportedEncodingException e) <fold text='{...}' expand='true'>{
                 throw new RuntimeException(e);
@@ -53,7 +53,7 @@ public class ExperimentalTestData {
 
         public String utf8ToString(byte[] bytes) <fold text='{...}' expand='true'>{
             <fold text='@SneakyThrows' expand='true'>try</fold><fold text='' expand='true'> </fold><fold text='' expand='true'><fold text='{...}' expand='true'>{</fold>
-            <fold text='' expand='true'>    </fold>return new String(System<fold text='[' expand='false'>.getProperty(</fold>"sort-desc"<fold text=']' expand='false'>)</fold>.getBytes(), "UTF-8");<fold text='' expand='true'>
+            <fold text='' expand='true'>    </fold>return new String(System<fold text='[' expand='false'>.getProperty(</fold>"sort-desc"<fold text=']' expand='false'>)</fold>.<fold text='bytes' expand='false'>getBytes()</fold>, "UTF-8");<fold text='' expand='true'>
             </fold><fold text='' expand='true'>}</fold></fold><fold text='' expand='true'> <fold text='' expand='true'></fold>catch (UnsupportedEncodingException e) <fold text='{...}' expand='true'>{
                 throw new RuntimeException(e);
             }</fold></fold>
@@ -100,6 +100,29 @@ public class ExperimentalTestData {
                     throw new RuntimeException("", t);
                 }</fold>
             }</fold>
+        }</fold>
+    }</fold>
+
+
+    static class NamelessAccessorExample <fold text='{...}' expand='true'>{
+
+        private String state;
+
+        void set(String value)<fold text=' { ' expand='false'> {
+            </fold>this.state = value;<fold text=' }' expand='false'>
+        }</fold>
+
+        String get()<fold text=' { ' expand='false'> {
+            </fold>return state;<fold text=' }' expand='false'>
+        }</fold>
+
+        void demo() <fold text='{...}' expand='true'>{
+            NamelessAccessorExample example = new NamelessAccessorExample();
+            example<fold text='!! = ' expand='false'>.set(</fold>"ok"<fold text='' expand='false'>)</fold>;
+            String current = example<fold text='!!' expand='false'>.get()</fold>;
+            System.out.println(example<fold text='!!' expand='false'>.get()</fold>.<fold text='empty' expand='false'>isEmpty()</fold>);
+            example<fold text='!! = ' expand='false'>.set(</fold>example<fold text='!!' expand='false'>.get()</fold><fold text='' expand='false'>)</fold>;
+            String duplicate = example<fold text='!!' expand='false'>.get()</fold> + example<fold text='!!' expand='false'>.get()</fold>;
         }</fold>
     }</fold>
 


### PR DESCRIPTION
## Summary
- return the Kotlin-style `!!` placeholder for nameless getter/setter folds instead of guessing a field name
- update the experimental nameless accessor sample and expectations to exercise chained calls and same-line set/get usage

## Testing
- `./gradlew --console=plain --no-daemon test --tests "com.intellij.advancedExpressionFolding.FoldingTest.experimentalTestData" -x examples:test`
- `./gradlew --console=plain clean build test` *(fails: 290 tests completed, 86 failed, 123 skipped; numerous FoldingTest expectation mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68f687b9f7c4832eaea913ade697575a