### PR TITLE
Refactor PsiVariableExt to use state delegate for var folding

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt
@@ -3,7 +3,6 @@ package com.intellij.advancedExpressionFolding.processor.declaration
 import com.intellij.advancedExpressionFolding.expression.VariableDeclarationImpl
 import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.util.Helper
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiForeachStatement
 import com.intellij.psi.PsiVariable
@@ -11,8 +10,7 @@ import com.intellij.psi.PsiVariable
 object PsiVariableExt : BaseExtension() {
 
     fun getVariableDeclaration(element: PsiVariable): VariableDeclarationImpl? {
-        val settings = AdvancedExpressionFoldingSettings.getInstance()
-        if (!shouldCollapseVariableDeclaration(element, settings)) {
+        if (!shouldCollapseVariableDeclaration(element)) {
             return null
         }
         val isFinal = Helper.calculateIfFinal(element)
@@ -25,11 +23,10 @@ object PsiVariableExt : BaseExtension() {
     }
 
     private fun shouldCollapseVariableDeclaration(
-        element: PsiVariable,
-        settings: AdvancedExpressionFoldingSettings
+        element: PsiVariable
     ): Boolean {
         val typeElement = element.typeElement ?: return false
-        return settings.state.varExpressionsCollapse &&
+        return varExpressionsCollapse &&
             element.name != null &&
             (element.initializer != null || element.parent is PsiForeachStatement) &&
             element.textRange.startOffset < typeElement.textRange.endOffset


### PR DESCRIPTION
## Summary
- remove the explicit AdvancedExpressionFoldingSettings dependency from PsiVariableExt
- read the varExpressionsCollapse flag directly from the delegated state when deciding to fold variable declarations

## Testing
- ./gradlew --no-daemon --no-configuration-cache test --tests "com.intellij.advancedExpressionFolding.folding.base.FoldingTest.varTestData" -x examples:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f895489178832e837d530cb17c850a