### PR TITLE
Delegate control-flow folding state in ForEachStatement

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt
@@ -2,6 +2,7 @@ package com.intellij.advancedExpressionFolding.expression.controlflow
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
@@ -14,8 +15,9 @@ class ForEachStatement(
     textRange: TextRange,
     private val declarationTextRange: TextRange,
     private val variableTextRange: TextRange,
-    private val arrayTextRange: TextRange
-) : Expression(forStatement, textRange) {
+    private val arrayTextRange: TextRange,
+    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state
+) : Expression(forStatement, textRange), IState by state {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 
@@ -26,7 +28,7 @@ class ForEachStatement(
     ): Array<FoldingDescriptor> {
         val descriptors = ArrayList<FoldingDescriptor>()
         val group = FoldingGroup.newGroup(ForEachStatement::class.java.name)
-        if (AdvancedExpressionFoldingSettings.getInstance().state.compactControlFlowSyntaxCollapse &&
+        if (compactControlFlowSyntaxCollapse &&
             this.forStatement.lParenth != null
         ) {
             val startOffset = this.forStatement.lParenth!!.textRange.startOffset
@@ -49,7 +51,7 @@ class ForEachStatement(
             group,
             " : "
         )
-        val placeholder = if (AdvancedExpressionFoldingSettings.getInstance().state.compactControlFlowSyntaxCollapse) {
+        val placeholder = if (compactControlFlowSyntaxCollapse) {
             " {\n"
         } else {
             ") {\n"


### PR DESCRIPTION
## Summary
- inject the settings state into `ForEachStatement` and delegate `IState`
- rely on the delegated `compactControlFlowSyntaxCollapse` flag instead of fetching the settings singleton repeatedly

## Testing
- ./gradlew clean build test *(fails: hangs while calculating the task graph in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f890b482dc832e9211357ee12a1c2d