### PR TITLE
Refactor BinaryExpressionExt to use StateDelegate

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
@@ -15,7 +15,7 @@ import com.intellij.advancedExpressionFolding.processor.util.Consts
 import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.argumentCount
 import com.intellij.advancedExpressionFolding.processor.util.Helper.eraseGenerics
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.StateDelegate
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiBinaryExpression
@@ -26,7 +26,7 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiPrefixExpression
 
-object BinaryExpressionExt {
+object BinaryExpressionExt : StateDelegate() {
 
     fun getBinaryExpression(element: PsiBinaryExpression, document: Document): Expression? {
         tryBuildCompareToBasedExpression(element, document)?.let { return it }
@@ -60,8 +60,7 @@ object BinaryExpressionExt {
     }
 
     private fun tryBuildCompareToBasedExpression(element: PsiBinaryExpression, document: Document): Expression? {
-        val settings = AdvancedExpressionFoldingSettings.getInstance()
-        if (!settings.state.comparingExpressionsCollapse) {
+        if (!comparingExpressionsCollapse) {
             return null
         }
         val methodCall = getMethodCallOperand(element)
@@ -239,8 +238,7 @@ object BinaryExpressionExt {
         b: PsiBinaryExpression,
         document: Document
     ): Expression? {
-        val settings = AdvancedExpressionFoldingSettings.getInstance()
-        if (!settings.state.rangeExpressionsCollapse) {
+        if (!rangeExpressionsCollapse) {
             return null
         }
         if ((a.operationSign.text == "<" || a.operationSign.text == "<=") &&


### PR DESCRIPTION
## Summary
- extend `BinaryExpressionExt` from `StateDelegate` to reuse delegated state accessors
- replace explicit settings lookups with direct property calls for compareTo and range folding helpers

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f88fab0a78832e947fed43b24db401