### PR TITLE
Use StateDelegate for literal expressions

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt
@@ -5,10 +5,10 @@ import com.intellij.advancedExpressionFolding.expression.literal.CharacterLitera
 import com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
 import com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
 import com.intellij.advancedExpressionFolding.processor.util.Consts
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.StateDelegate
 import com.intellij.psi.PsiLiteralExpression
 
-object LiteralExpressionExt {
+object LiteralExpressionExt : StateDelegate() {
 
     fun getLiteralExpression(element: PsiLiteralExpression): Expression? {
         val type = element.type ?: return null
@@ -18,7 +18,7 @@ object LiteralExpressionExt {
         val value = element.value
         return when (value) {
             is Number -> NumberLiteral(element, element.textRange, null, value, false)
-            is String -> if (!element.isTextBlock || AdvancedExpressionFoldingSettings.getInstance().state.logFoldingTextBlocks) {
+            is String -> if (!element.isTextBlock || logFoldingTextBlocks) {
                 StringLiteral(element, element.textRange, value)
             } else {
                 null


### PR DESCRIPTION
## Summary
- update `LiteralExpressionExt` to extend `StateDelegate`
- access `logFoldingTextBlocks` through delegated state instead of the settings singleton
- drop the unused `AdvancedExpressionFoldingSettings` import

## Testing
- `./gradlew clean build test --console=plain --no-daemon 2>&1 | stdbuf -o0 tr '\r' '\n'` *(fails: `UpdateFoldedTextColorsActionTest > changeFoldingColorsUsesDarkNavyForegroundForBrightThemes()`)*

------
https://chatgpt.com/codex/tasks/task_e_68f88f9e424c832ead97ae45109048ca