### PR TITLE
Add workflow to convert TODOs into GitHub issues

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -1,0 +1,54 @@
+name: "Run TODO to Issue"
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      INSERT_ISSUE_URLS:
+        description: "Insert issue URLs back to code"
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: "TODO to Issue"
+        id: todo-to-issue
+        uses: "alstr/todo-to-issue-action@v5.1.13"
+        with:
+          AUTO_ASSIGN: "true"
+          CLOSE_ISSUES: "true"
+          AUTO_P: "true"
+          INSERT_ISSUE_URLS: "${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.INSERT_ISSUE_URLS) }}"
+          IDENTIFIERS: '[{"name": "TODO", "labels": ["TODO"]}]'
+          ISSUE_TEMPLATE: |
+            ## Nowe TODO
+            
+            **Commit:** ${{ github.sha }}
+            **Autor:** @{{ github.actor }}
+            
+            {{ body }}
+            
+            [Link do pliku]({{ url }})
+            ```
+            {{ snippet }}
+            ```
+      - name: Set Git user
+        if: steps.todo-to-issue.outputs.changes == 'true'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Commit and Push Changes
+        if: steps.todo-to-issue.outputs.changes == 'true'
+        run: |
+          git add -A
+          if [[ `git status --porcelain` ]]; then
+            git commit -m "Add GitHub issue links to TODOs"
+            git push origin ${{ github.ref_name }}
+          fi


### PR DESCRIPTION
## Summary
- add a workflow that converts TODO comments into GitHub issues using `alstr/todo-to-issue-action`
- allow optional reinsertion of generated issue URLs and auto-commit those updates

## Example
N/A – CI configuration only

## Related Issues
None

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] Tested with latest IDE version

------
https://chatgpt.com/codex/tasks/task_e_68f908726c88832e8f274dabb7171433