### PR TITLE
Add pull request labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,74 @@
+collapse-control-flow:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/IfExpressionExt.kt'
+    - '**/TernaryExpressionExt.kt'
+
+collapse-declaration:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/AssignmentExpressionExt.kt'
+    - '**/VariableDeclarationExpressionExt.kt'
+
+collapse-literals:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/ConcatenationExpressionExt.kt'
+    - '**/NumberLiteralExpressionExt.kt'
+    - '**/StringLiteralExpressionExt.kt'
+
+collapse-methods:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/MethodCallExpressionExt.kt'
+
+collapse-operators:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/BinaryExpressionExt.kt'
+    - '**/PolyadicExpressionExt.kt'
+    - '**/PrefixExpressionExt.kt'
+
+collapse-slicing:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/ArrayAccessExpressionExt.kt'
+
+field-shift:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/FieldShiftBuilder.kt'
+
+kotlin:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/kotlin.xml'
+    - '**/KotlinPluginUtils.kt'
+
+lombok:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/LombokState.kt'
+    - '**/PsiMethodExt.kt'
+    - 'processor/lombok/**'
+
+pseudoAnnotations:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'pseudo/**'
+
+settings-ui:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/CheckboxesProvider.kt'
+
+state:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/AdvancedExpressionFoldingSettings.kt'
+    - '**/State.kt'
+
+tests:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*Test*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'PR number to label'
+        required: false
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v6.0.1
+      with:
+        sync-labels: false
+        pr-number: ${{ github.event.inputs.pr-number }}


### PR DESCRIPTION
## Summary
- add a workflow that applies labels to pull requests on demand or when opened
- define label patterns to tag changes based on modified Kotlin plugin files

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68f90b490590832ea33df2932dc0d904