### PR TITLE
Use control-flow state delegation without exposing backing field

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/settings/StateDelegate.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/StateDelegate.kt
@@ -1,6 +1,3 @@
 package com.intellij.advancedExpressionFolding.settings
 
-open class StateDelegate(
-    private val state: AdvancedExpressionFoldingSettings.State =
-        AdvancedExpressionFoldingSettings.getInstance().state,
-) : IState by state
+open class StateDelegate(private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.Companion.getInstance().state) : IState by state


### PR DESCRIPTION
## Summary
- revert `StateDelegate` to rely solely on the delegated `IState` implementation
- make `IfExpression.isAssertExpression` accept the control-flow state interface and use the delegated state in `PsiCodeBlockExt`

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68f8952fe23c832e89e5097057c04f13