### PR TITLE
Add broader labeler coverage for docs, workflows, and key classes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -72,3 +72,35 @@ tests:
 - changed-files:
   - any-glob-to-any-file:
     - '**/*Test*'
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.md'
+
+github-actions:
+- changed-files:
+  - any-glob-to-any-file:
+    - '.github/workflows/**'
+
+build-system:
+- changed-files:
+  - any-glob-to-any-file:
+    - 'build.gradle.kts'
+    - 'settings.gradle.kts'
+    - 'gradle/**'
+
+advanced-expression-folding-builder:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/AdvancedExpressionFoldingBuilder.kt'
+
+global-toggle-action:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/GlobalToggleFoldingAction.kt'
+
+settings-configurable:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/SettingsConfigurable.kt'


### PR DESCRIPTION
## Summary
- add documentation label to cover Markdown files across the repo
- label GitHub workflow, Gradle build, and key Kotlin classes for targeted triage

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f90f1d9120832e8fe748e3960f2be2