### PR TITLE
Fix option generator for unclassified state

### DIFF
--- a/docs/option-generator.md
+++ b/docs/option-generator.md
@@ -31,6 +31,7 @@ The following JVM properties must be provided for meaningful output:
 The script uses comment markers such as `// NEW OPTION` to inject code in several existing files. Expect edits in the following locations:
 
 - `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt`
 - `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
 - `examples/data/<VarName>TestData.java`
 - `test/com/intellij/advancedExpressionFolding/FoldingTest.kt`

--- a/scripts/option-code-generator.main.kts
+++ b/scripts/option-code-generator.main.kts
@@ -11,9 +11,28 @@ settingsFile.doInFile {
     it.insertBeforeMarker("// NEW OPTION VAR", "        override var $varName: Boolean = true,")
 }
 
-val stateInterfaceFile = "$basePath/src/com/intellij/advancedExpressionFolding/settings/IState.kt"
-stateInterfaceFile.doInFile {
-    it.insertBeforeMarker("// NEW OPTION VAL", "    val $varName: Boolean")
+val unclassifiedStateFile =
+    "$basePath/src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt"
+unclassifiedStateFile.doInFile { lines ->
+    val result = mutableListOf<String>()
+    var markerCount = 0
+
+    lines.forEach { line ->
+        if (line.trim().startsWith("// NEW OPTION VAR")) {
+            markerCount += 1
+            when (markerCount) {
+                1 -> result.add("    val $varName: Boolean")
+                2 -> result.add("    override val $varName: Boolean = true,")
+            }
+        }
+        result.add(line)
+    }
+
+    if (markerCount < 2) {
+        error("Expected two '// NEW OPTION VAR' markers in UnclassifiedFeatureState.kt")
+    }
+
+    result
 }
 
 val exampleFileName = "${varName.replaceFirstChar(Char::titlecase)}TestData"


### PR DESCRIPTION
## Summary
- update the option generator to append new toggles into `UnclassifiedFeatureState`
- document that the generator now edits the unclassified feature state file

## Testing
- ./gradlew clean build test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f8783113d8832eaf19f762451eb1d9