### PR TITLE
Lombok @Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 - Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+- [lombok] extend @Builder emulation to support field- and class-level annotations
 
 ## [4.2.0] - 2025-09-20
 

--- a/examples/data/LombokBuilderFields.java
+++ b/examples/data/LombokBuilderFields.java
@@ -1,0 +1,22 @@
+public class LombokBuilderFields {
+
+    private String first;
+    private String second;
+
+    class LombokBuilderFieldsBuilder {
+        private String first;
+        private String second;
+
+        public LombokBuilderFieldsBuilder first(String first) {
+            this.first = first;
+            return this;
+        }
+
+        public LombokBuilderFields build() {
+            LombokBuilderFields result = new LombokBuilderFields();
+            result.first = this.first;
+            result.second = this.second;
+            return result;
+        }
+    }
+}

--- a/folded/LombokBuilderFields-folded.java
+++ b/folded/LombokBuilderFields-folded.java
@@ -1,0 +1,17 @@
+@Builder public class LombokBuilderFields {
+
+    @Builder private String first;
+    private String second;
+
+    class LombokBuilderFieldsBuilder {
+        private String first;
+        private String second;
+
+        public LombokBuilderFields build() {
+            LombokBuilderFields result = new LombokBuilderFields();
+            result.first = this.first;
+            result.second = this.second;
+            return result;
+        }
+    }
+}

--- a/folded/LombokPatternOffNegativeTestData-folded.java
+++ b/folded/LombokPatternOffNegativeTestData-folded.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokPatternOffTestData()}
  */
 @SuppressWarnings("ALL")
-@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
+@Getter @Setter @Serial public class LombokPatternOffNegativeTestData {
 
     LombokPatternOffNegativeTestData data;
     boolean ok;

--- a/folded/LombokTestData-folded.java
+++ b/folded/LombokTestData-folded.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokTestData()}
  */
 @SuppressWarnings("ALL")
-@Builder(ClassWithBuilder) @Getter @Setter @Serial public class LombokTestData {
+@Getter @Setter @Serial public class LombokTestData {
 
     LombokTestData data;
     boolean ok;
@@ -488,7 +488,7 @@ import java.util.logging.Logger;
 
     }
 
-    @Builder(FirstBuilder) @Builder(SecondBuilder) @Builder class Builders {
+    class Builders {
 
         class FirstBuilder {
 

--- a/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingTest.kt
@@ -250,6 +250,14 @@ open class FoldingTest : BaseTest() {
     }
 
     /**
+     * [data.LombokBuilderFields]
+     */
+    @Test
+    open fun lombokBuilderFields() {
+        doFoldingTest(state::lombok)
+    }
+
+    /**
      * [data.FieldShiftBuilder]
      */
     @Test

--- a/testData/LombokBuilderFields-all.java
+++ b/testData/LombokBuilderFields-all.java
@@ -1,0 +1,22 @@
+<fold text='@Builder p' expand='false'>p</fold>ublic class LombokBuilderFields {
+
+    <fold text='@Builder p' expand='false'>p</fold>rivate String first;
+    private String second;
+
+    class LombokBuilderFieldsBuilder <fold text='{...}' expand='true'>{
+        private String first;
+        private String second;<fold text='' expand='false'>
+
+        </fold><fold text='' expand='false'>public LombokBuilderFieldsBuilder first(String first) <fold text='{...}' expand='true'>{
+            this.first = <fold text='<<' expand='false'>first</fold>;
+            return this;
+        }</fold></fold>
+
+        public LombokBuilderFields build() <fold text='{...}' expand='true'>{
+            <fold text='val' expand='false'>LombokBuilderFields</fold> result = new LombokBuilderFields();
+            result.first = this.<fold text='<<' expand='true'>first</fold>;
+            result.second = this.<fold text='<<' expand='true'>second</fold>;
+            return result;
+        }</fold>
+    }</fold>
+}

--- a/testData/LombokBuilderFields.java
+++ b/testData/LombokBuilderFields.java
@@ -1,0 +1,22 @@
+<fold text='@Builder p' expand='false'>p</fold>ublic class LombokBuilderFields {
+
+    <fold text='@Builder p' expand='false'>p</fold>rivate String first;
+    private String second;
+
+    class LombokBuilderFieldsBuilder <fold text='{...}' expand='true'>{
+        private String first;
+        private String second;<fold text='' expand='false'>
+
+        </fold><fold text='' expand='false'>public LombokBuilderFieldsBuilder first(String first) <fold text='{...}' expand='true'>{
+            this.first = first;
+            return this;
+        }</fold></fold>
+
+        public LombokBuilderFields build() <fold text='{...}' expand='true'>{
+            LombokBuilderFields result = new LombokBuilderFields();
+            result.first = this.first;
+            result.second = this.second;
+            return result;
+        }</fold>
+    }</fold>
+}

--- a/testData/LombokPatternOffNegativeTestData-all.java
+++ b/testData/LombokPatternOffNegativeTestData-all.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;</fold>
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokPatternOffTestData()}
  */</fold>
 @SuppressWarnings("ALL")
-<fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokPatternOffNegativeTestData {<fold text='' expand='false'>
+<fold text='@Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokPatternOffNegativeTestData {<fold text='' expand='false'>
 
     </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
 

--- a/testData/LombokPatternOffNegativeTestData.java
+++ b/testData/LombokPatternOffNegativeTestData.java
@@ -16,7 +16,7 @@ import java.util.logging.Logger;</fold>
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokPatternOffTestData()}
  */</fold>
 @SuppressWarnings("ALL")
-<fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokPatternOffNegativeTestData {<fold text='' expand='false'>
+<fold text='@Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokPatternOffNegativeTestData {<fold text='' expand='false'>
 
     </fold><fold text='' expand='false'>private static final long serialVersionUID = 1234567L;</fold>
 

--- a/testData/LombokTestData-all.java
+++ b/testData/LombokTestData-all.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;</fold>
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokTestData()}
  */</fold>
 @SuppressWarnings("ALL")
-<fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokTestData {<fold text='' expand='false'>
+<fold text='@Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokTestData {<fold text='' expand='false'>
 
     </fold><fold text='' expand='false'>private <fold text='const' expand='false'>static final </fold><fold text='' expand='false'>long</fold> serialVersionUID = 1234567L;</fold>
 
@@ -1259,7 +1259,7 @@ import java.util.logging.Logger;</fold>
 
     }</fold>
 
-    <fold text='@Builder(FirstBuilder) @Builder(SecondBuilder) @Builder c' expand='false'>c</fold>lass Builders <fold text='{...}' expand='true'>{
+    class Builders <fold text='{...}' expand='true'>{
 
         class FirstBuilder <fold text='{...}' expand='true'>{
 

--- a/testData/LombokTestData.java
+++ b/testData/LombokTestData.java
@@ -15,7 +15,7 @@ import java.util.logging.Logger;</fold>
  * {@link com.intellij.advancedExpressionFolding.FoldingTest#testLombokTestData()}
  */</fold>
 @SuppressWarnings("ALL")
-<fold text='@Builder(ClassWithBuilder) @Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokTestData {<fold text='' expand='false'>
+<fold text='@Getter @Setter @Serial p' expand='false'>p</fold>ublic class LombokTestData {<fold text='' expand='false'>
 
     </fold><fold text='' expand='false'>private static final long serialVersionUID = 1234567L;</fold>
 
@@ -1259,7 +1259,7 @@ import java.util.logging.Logger;</fold>
 
     }</fold>
 
-    <fold text='@Builder(FirstBuilder) @Builder(SecondBuilder) @Builder c' expand='false'>c</fold>lass Builders <fold text='{...}' expand='true'>{
+    class Builders <fold text='{...}' expand='true'>{
 
         class FirstBuilder <fold text='{...}' expand='true'>{
 


### PR DESCRIPTION
## Summary
- ignore inner builder classes that do not touch any of the owning type's fields before emitting a class-level @Builder annotation
- collect builder setter coverage using property names so fluent setters like setField(...) still contribute field-level folding when needed

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68eea92cfc88832ea5e1a36d9e60fea7