### PR TITLE
Add label for LoggerBrackets folding files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,11 @@ collapse-slicing:
   - any-glob-to-any-file:
     - '**/ArrayAccessExpressionExt.kt'
 
+collapse-logger-brackets:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/LoggerBracketsExt.kt'
+
 field-shift:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
- add a collapse-logger-brackets label to the labeler configuration
- associate LoggerBracketsExt Kotlin files with the new label

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68f922caa094832eb3011028c5bb2a31