### PR TITLE
Add label rule for type cast collapses

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,6 +29,11 @@ collapse-operators:
     - '**/PolyadicExpressionExt.kt'
     - '**/PrefixExpressionExt.kt'
 
+collapse-type-casts:
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/PsiTypeCastExpressionExt.kt'
+
 collapse-slicing:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
- add a collapse-type-casts label entry mapped to PsiTypeCastExpressionExt files

## Testing
- not run (not required for label updates)

------
https://chatgpt.com/codex/tasks/task_e_68f922c802c0832e9f6b530da8953943