### PR TITLE
Add @PropertyChangeListener pseudo-annotation completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 - Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+- [[pseudo-annotations] @PropertyChangeListener - generate PropertyChangeSupport boilerplate for setters.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 
 ## [4.2.0] - 2025-09-20
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For more information, read the [blog post](https://medium.com/@andrey_cheptsov/m
 
 ## 4.0.0 ##
 
-- [[pseudo-annotations] @Main - method-level annotation that generates a main method invoking the annotated method.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
+- [[pseudo-annotations] @Main, @PropertyChangeListener - helpers for generating boilerplate code.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 - [[fieldshift] Preconditions.checkNotNull now supported](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/FieldShift#preconditionschecknotnull)
 
 ## 3.8.0 ##

--- a/examples/data/PseudoAnnotationsPropertyChangeListenerTestData.java
+++ b/examples/data/PseudoAnnotationsPropertyChangeListenerTestData.java
@@ -1,0 +1,29 @@
+package data;
+
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
+public class PseudoAnnotationsPropertyChangeListenerTestData {
+
+    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+    private String name;
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.addPropertyChangeListener(listener);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        propertyChangeSupport.removePropertyChangeListener(listener);
+    }
+
+    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+    }
+
+    public void setName(String name) {
+        String oldName = this.name;
+        this.name = name;
+        firePropertyChange("name", oldName, name);
+    }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,6 +40,10 @@
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+        <!-- Suggests the pseudo-annotation @PropertyChangeListener -->
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.PropertyChangeListenerAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/PropertyChangeListenerAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/PropertyChangeListenerAnnotationCompletionContributor.kt
@@ -1,0 +1,216 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IState
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiModifierList
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.util.ProcessingContext
+
+private const val PROPERTY_CHANGE_SUPPORT_FIELD = "propertyChangeSupport"
+
+class PropertyChangeListenerAnnotationCompletionContributor(
+    private val state: IState = getInstance().state
+) : CompletionContributor(), IState by state {
+
+    init {
+        val provider = object : CompletionProvider<CompletionParameters>() {
+            override fun addCompletions(
+                parameters: CompletionParameters,
+                context: ProcessingContext,
+                result: CompletionResultSet
+            ) {
+                if (!pseudoAnnotations) return
+
+                result.addElement(createLookupElement())
+            }
+        }
+
+        val basePattern = PlatformPatterns.psiElement(PsiIdentifier::class.java)
+            .withParent(PsiJavaCodeReferenceElement::class.java)
+            .withSuperParent(2, PsiAnnotation::class.java)
+            .withSuperParent(3, PsiModifierList::class.java)
+
+        extend(CompletionType.BASIC, basePattern.withSuperParent(4, PsiClass::class.java), provider)
+        extend(CompletionType.BASIC, basePattern.withSuperParent(4, PsiField::class.java), provider)
+    }
+
+    private fun createLookupElement(): LookupElement {
+        return LookupElementBuilder.create("PropertyChangeListener")
+            .withLookupString("@PropertyChangeListener")
+            .withPresentableText("@PropertyChangeListener")
+            .withInsertHandler { ctx, _ ->
+                handleInsert(ctx)
+            }
+            .withAutoCompletionPolicy(AutoCompletionPolicy.NEVER_AUTOCOMPLETE)
+    }
+
+    private fun handleInsert(ctx: InsertionContext) {
+        val element = ctx.file.findElementAt(ctx.startOffset) ?: return
+        val annotation = PsiTreeUtil.getParentOfType(element, PsiAnnotation::class.java, false) ?: return
+        val owner = PsiTreeUtil.getParentOfType(annotation, PsiModifierListOwner::class.java, false) ?: return
+
+        when (owner) {
+            is PsiClass -> handleClassInsert(owner, annotation, ctx)
+            is PsiField -> handleFieldInsert(owner, annotation, ctx)
+        }
+    }
+
+    private fun handleClassInsert(psiClass: PsiClass, annotation: PsiAnnotation, ctx: InsertionContext) {
+        val project = psiClass.project
+        val documentManager = PsiDocumentManager.getInstance(project)
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            annotation.delete()
+
+            val insertedElements = ensurePropertyChangeInfrastructure(psiClass)
+
+            documentManager.doPostponedOperationsAndUnblockDocument(ctx.document)
+            documentManager.commitDocument(ctx.document)
+
+            val javaStyle = JavaCodeStyleManager.getInstance(project)
+            val codeStyle = CodeStyleManager.getInstance(project)
+
+            insertedElements.forEach { element ->
+                javaStyle.shortenClassReferences(element)
+                codeStyle.reformat(element)
+            }
+
+            insertedElements.lastOrNull()?.let {
+                ctx.editor.caretModel.moveToOffset(it.textRange.startOffset)
+            }
+        }
+    }
+
+    private fun handleFieldInsert(field: PsiField, annotation: PsiAnnotation, ctx: InsertionContext) {
+        val psiClass = field.containingClass ?: return
+        val project = psiClass.project
+        val documentManager = PsiDocumentManager.getInstance(project)
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            annotation.delete()
+
+            val insertedElements = ensurePropertyChangeInfrastructure(psiClass).toMutableList()
+            val setter = upsertSetter(field, psiClass)
+            setter?.let(insertedElements::add)
+
+            documentManager.doPostponedOperationsAndUnblockDocument(ctx.document)
+            documentManager.commitDocument(ctx.document)
+
+            val javaStyle = JavaCodeStyleManager.getInstance(project)
+            val codeStyle = CodeStyleManager.getInstance(project)
+
+            insertedElements.forEach { element ->
+                javaStyle.shortenClassReferences(element)
+                codeStyle.reformat(element)
+            }
+
+            moveCaretToPropertyLiteral(setter, ctx)
+        }
+    }
+
+    private fun ensurePropertyChangeInfrastructure(psiClass: PsiClass): List<PsiElement> {
+        val project = psiClass.project
+        val factory = JavaPsiFacade.getElementFactory(project)
+        val inserted = mutableListOf<PsiElement>()
+
+        if (psiClass.fields.none { it.name == PROPERTY_CHANGE_SUPPORT_FIELD }) {
+            val fieldText = "private final java.beans.PropertyChangeSupport $PROPERTY_CHANGE_SUPPORT_FIELD = new java.beans.PropertyChangeSupport(this);"
+            val field = factory.createFieldFromText(fieldText, psiClass)
+            inserted.add(psiClass.add(field))
+        }
+
+        fun ensureMethod(name: String, parameterCount: Int, text: String) {
+            val exists = psiClass.methods.any { it.name == name && it.parameterList.parametersCount == parameterCount }
+            if (!exists) {
+                val method = factory.createMethodFromText(text, psiClass)
+                inserted.add(psiClass.add(method))
+            }
+        }
+
+        ensureMethod(
+            name = "addPropertyChangeListener",
+            parameterCount = 1,
+            text = "public void addPropertyChangeListener(java.beans.PropertyChangeListener listener) { $PROPERTY_CHANGE_SUPPORT_FIELD.addPropertyChangeListener(listener); }"
+        )
+        ensureMethod(
+            name = "removePropertyChangeListener",
+            parameterCount = 1,
+            text = "public void removePropertyChangeListener(java.beans.PropertyChangeListener listener) { $PROPERTY_CHANGE_SUPPORT_FIELD.removePropertyChangeListener(listener); }"
+        )
+        ensureMethod(
+            name = "firePropertyChange",
+            parameterCount = 3,
+            text = "protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) { $PROPERTY_CHANGE_SUPPORT_FIELD.firePropertyChange(propertyName, oldValue, newValue); }"
+        )
+
+        return inserted
+    }
+
+    private fun upsertSetter(field: PsiField, psiClass: PsiClass): PsiMethod? {
+        if (field.hasModifierProperty(PsiModifier.STATIC)) return null
+        if (field.hasModifierProperty(PsiModifier.FINAL)) return null
+
+        val project = psiClass.project
+        val factory = JavaPsiFacade.getElementFactory(project)
+
+        val fieldName = field.name ?: return null
+        val capitalized = StringUtil.capitalize(fieldName)
+        val setterName = "set$capitalized"
+        val typeText = field.type.presentableText
+        val parameterName = fieldName
+        val oldValueName = "old$capitalized"
+
+        val methodText = """
+            public void $setterName($typeText $parameterName) {
+                $typeText $oldValueName = this.$fieldName;
+                this.$fieldName = $parameterName;
+                firePropertyChange("$fieldName", $oldValueName, $parameterName);
+            }
+        """.trimIndent()
+
+        val newMethod = factory.createMethodFromText(methodText, psiClass)
+
+        val existing = psiClass.findMethodsByName(setterName, false)
+            .firstOrNull { it.parameterList.parametersCount == 1 }
+
+        return if (existing != null) {
+            existing.replace(newMethod) as? PsiMethod
+        } else {
+            psiClass.add(newMethod) as? PsiMethod
+        }
+    }
+
+    private fun moveCaretToPropertyLiteral(method: PsiMethod?, ctx: InsertionContext) {
+        val literal = PsiTreeUtil.findChildOfType(method ?: return, PsiLiteralExpression::class.java) ?: return
+        val offset = literal.textRange.startOffset + 1
+        if (offset <= ctx.document.textLength) {
+            ctx.editor.caretModel.moveToOffset(offset)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,8 +273,9 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @PropertyChangeListener") {
             example("PseudoAnnotationsMainTestData.java")
+            example("PseudoAnnotationsPropertyChangeListenerTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
         // NEW OPTION

--- a/test/com/intellij/advancedExpressionFolding/PropertyChangeListenerAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/PropertyChangeListenerAnnotationCompletionContributorTest.kt
@@ -1,0 +1,214 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.ExtensionTestUtil
+import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.codeInsight.completion.CompletionContributorEP
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertNotNull
+
+class PropertyChangeListenerAnnotationCompletionContributorTest : BaseTest() {
+
+    companion object {
+        private var originalPseudoAnnotationsValue: Boolean = false
+        private val completionContributorEp = ExtensionPointName.create<CompletionContributorEP>(
+            "com.intellij.completion.contributor"
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        originalPseudoAnnotationsValue = settings.state.pseudoAnnotations
+        settings.state.pseudoAnnotations = true
+
+        val completionContributors = completionContributorEp.point.extensionList
+        val filteredContributors = completionContributors.filter {
+            it.implementationClass?.startsWith("com.intellij.advancedExpressionFolding") == true
+        }
+        ExtensionTestUtil.maskExtensions(completionContributorEp, filteredContributors, fixture.testRootDisposable, false)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.state.pseudoAnnotations = originalPseudoAnnotationsValue
+    }
+
+    @Test
+    fun `should offer @PropertyChangeListener for class`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                @<caret>
+                public class Test {
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+        assertTrue(completions.any { it.lookupString == "PropertyChangeListener" })
+    }
+
+    @Test
+    fun `should generate infrastructure when selecting @PropertyChangeListener on class`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                @<caret>
+                public class Test {
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        val propertyChange = completions?.find { it.lookupString == "PropertyChangeListener" }
+        assertNotNull(propertyChange)
+        val completion = propertyChange!!
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = completion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                import java.beans.PropertyChangeListener;
+                import java.beans.PropertyChangeSupport;
+
+                public class Test {
+                    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+
+                    public void addPropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.addPropertyChangeListener(listener);
+                    }
+
+                    public void removePropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.removePropertyChangeListener(listener);
+                    }
+
+                    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+                        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should generate setter when selecting @PropertyChangeListener on field`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                public class Test {
+                    @<caret>
+                    private String name;
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        val propertyChange = completions?.find { it.lookupString == "PropertyChangeListener" }
+        assertNotNull(propertyChange)
+        val completion = propertyChange!!
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = completion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                import java.beans.PropertyChangeListener;
+                import java.beans.PropertyChangeSupport;
+
+                public class Test {
+                    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+                    private String name;
+
+                    public void addPropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.addPropertyChangeListener(listener);
+                    }
+
+                    public void removePropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.removePropertyChangeListener(listener);
+                    }
+
+                    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+                        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+                    }
+
+                    public void setName(String name) {
+                        String oldName = this.name;
+                        this.name = name;
+                        firePropertyChange("name", oldName, name);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should update existing setter to fire property change`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                public class Test {
+                    @<caret>
+                    private String name;
+
+                    public void setName(String name) {
+                        this.name = name;
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        val propertyChange = completions?.find { it.lookupString == "PropertyChangeListener" }
+        assertNotNull(propertyChange)
+        val completion = propertyChange!!
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = completion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                import java.beans.PropertyChangeListener;
+                import java.beans.PropertyChangeSupport;
+
+                public class Test {
+                    private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
+                    private String name;
+
+                    public void setName(String name) {
+                        String oldName = this.name;
+                        this.name = name;
+                        firePropertyChange("name", oldName, name);
+                    }
+
+                    public void addPropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.addPropertyChangeListener(listener);
+                    }
+
+                    public void removePropertyChangeListener(PropertyChangeListener listener) {
+                        propertyChangeSupport.removePropertyChangeListener(listener);
+                    }
+
+                    protected void firePropertyChange(String propertyName, Object oldValue, Object newValue) {
+                        propertyChangeSupport.firePropertyChange(propertyName, oldValue, newValue);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a completion contributor that inserts @PropertyChangeListener pseudo-annotations on classes and fields
- document and expose the new pseudo-annotation in plugin metadata, settings UI, and example data
- cover the contributor with completion tests for class, field, and existing-setter scenarios

This was inspired by several long-standing Lombok issues requesting PropertyChangeListener support:

- [#394 PropertyChangeListener](https://github.com/rzwitserloot/lombok/issues/394) - marked as wontfix
- [#100 Add PropertyChangeSupport to @Data for two-way databinding](https://github.com/rzwitserloot/lombok/issues/100) - accepted but never implemented
- [#2128 [FEATURE] Property Change Listener Support Annotation](https://github.com/rzwitserloot/lombok/issues/2128) - request for annotation support
- [lombok-pg #94 @VetoableChangeListenerSupport](https://github.com/peichhorn/lombok-pg/issues/94) - extension project attempt


## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68eec5138a88832e85bfe7032e6e3e74