### PR TITLE
Skip logger folding when no arguments remain

### DIFF
--- a/folded/LogBrackets-folded.java
+++ b/folded/LogBrackets-folded.java
@@ -23,6 +23,7 @@ public class LogBrackets {
         log.debug("Debug message with 1 parameter - Name: $name");
 
         log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");
+        log.info(MY_MARKER, "Marker missing parameters {} {}");
 
         log.info("Info message with 2 parameters - Name: $name, Age: $age    ");
         log.info("Info message with 2 parameters - Name: $name, Age: $age");

--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
@@ -31,6 +31,7 @@ open class LoggerBracketsExtensionBase(
         val split = logText.splitTextPattern() ?: return null
 
         val arguments = element.argumentExpressions.toMutableList().prepareArguments()
+        if (arguments.isEmpty()) return null
         var nextStringAddon = ""
         val hasTooManyArguments = split.size <= arguments.size
         var hasLast = false

--- a/testData/LogBrackets.java
+++ b/testData/LogBrackets.java
@@ -23,6 +23,7 @@ public class LogBrackets {
         log.debug("Debug message with 1 parameter - Name: <fold text='$' expand='false'>%s", </fold>name<fold text='")' expand='false'>)</fold>;
 
         log.info(MY_MARKER, "Info message with 2 parameters - Name: <fold text='$' expand='false'>%s, Age: %d", </fold>name<fold text=', Age: $' expand='false'>, </fold>age<fold text='")' expand='false'>)</fold>;
+        log.info(MY_MARKER, "Marker missing parameters {} {}");
 
         log.info("Info message with 2 parameters - Name: <fold text='$' expand='false'>%s, Age: %d    ", </fold>name<fold text=', Age: $' expand='false'>, </fold>age<fold text='    ")' expand='false'>)</fold>;
         log.info("Info message with 2 parameters - Name: <fold text='$' expand='false'>%s, Age: %d", </fold>name<fold text=', Age: $' expand='false'>, </fold>age<fold text='")' expand='false'>)</fold>;


### PR DESCRIPTION
## Summary
- stop logger bracket folding when prepareArguments removes every argument, avoiding marker-only calls from hitting the trailing segment logic

## Testing
- ./gradlew --no-daemon test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68ee6e60819c832e83ddcba4b54fc35b