### PR TITLE
Remove SummaryParentOverrideExt BaseExtension inheritance

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt
@@ -2,9 +2,15 @@ package com.intellij.advancedExpressionFolding.processor.lombok
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.SimpleExpression
-import com.intellij.advancedExpressionFolding.processor.*
+import com.intellij.advancedExpressionFolding.processor.asInstance
+import com.intellij.advancedExpressionFolding.processor.expr
+import com.intellij.advancedExpressionFolding.processor.exprOnLastChar
+import com.intellij.advancedExpressionFolding.processor.exprWrap
+import com.intellij.advancedExpressionFolding.processor.isOverride
+import com.intellij.advancedExpressionFolding.processor.one
+import com.intellij.advancedExpressionFolding.processor.signature
+import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.advancedExpressionFolding.processor.cache.Keys.METHOD_TO_PARENT_CLASS_KEY
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.openapi.util.removeUserData
 import com.intellij.psi.*
 import com.intellij.psi.util.MethodSignature
@@ -14,7 +20,7 @@ private data class ReferenceWithMethods(
     val methods: List<String>
 )
 
-object SummaryParentOverrideExt : BaseExtension() {
+object SummaryParentOverrideExt {
 
     fun PsiClass.addParentSummary(): Expression? {
         val parentToMethods = mutableMapOf<String, List<String>>()


### PR DESCRIPTION
## Summary
- remove the BaseExtension inheritance from SummaryParentOverrideExt and eliminate the unused import
- rely on processor utility extension functions for helper calls such as exprWrap and exprOnLastChar

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f9e26fa494832e9097c269cc76b592