### PR TITLE
Remove unnecessary BaseExtension inheritance from ConstExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/ConstExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/ConstExt.kt
@@ -3,13 +3,12 @@ package com.intellij.advancedExpressionFolding.processor.language.kotlin
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.FieldConstExpression
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.PsiTypeElement
 
-object ConstExt : BaseExtension() {
+object ConstExt {
 
     fun fieldConstExpression(
         field: PsiField,


### PR DESCRIPTION
## Summary
- stop inheriting from BaseExtension in the Kotlin constant extension and remove the unused import while keeping helper access unchanged

## Testing
- ./gradlew clean build test --no-build-cache --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f9e257c474832eab857049930eb58b