### PR TITLE
Refactor LetReturnExt to use Kotlin state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/LetReturnExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/LetReturnExt.kt
@@ -4,11 +4,12 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.ElvisReturnNull
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.LetReturnIt
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
 import com.intellij.psi.*
 
 
-object LetReturnExt : BaseExtension() {
+object LetReturnExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State() {
 
     @JvmStatic
     fun getIfExpression(element: PsiIfStatement): Expression? {


### PR DESCRIPTION
## Summary
- delegate `LetReturnExt` to `IKotlinLanguageState` using a fresh `AdvancedExpressionFoldingSettings.State`
- drop the `BaseExtension` superclass and clean up the imports

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68f9e2564404832ea68b65f2a5998ddb