### PR TITLE
Remove redundant dynamic override in MethodCallFactory

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt
@@ -1,11 +1,12 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall
 
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.ConfigurationParser
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.DynamicMethodCall
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.IDynamicDataProvider
 import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.advancedExpressionFolding.processor.util.Consts
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IGlobalSettingsState
 
 typealias MethodName = String
 typealias ClassName = String
@@ -34,7 +35,7 @@ typealias ClassName = String
  * - Reads: O(1) HashMap lookup, no synchronization overhead
  * - Writes: O(n) reconstruction of all mappings, synchronized but infrequent
  */
-object MethodCallFactory : BaseExtension(){
+object MethodCallFactory : IGlobalSettingsState by AdvancedExpressionFoldingSettings.getInstance().state {
 
     @Volatile
     private var dynamicProvider: IDynamicDataProvider? = ConfigurationParser


### PR DESCRIPTION
## Summary
- remove the redundant `dynamic` override from `MethodCallFactory` now that the object delegates to `IGlobalSettingsState`

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f806ffd658832ea0c63b951f8ce91a