### PR TITLE
Refine Kotlin println extension state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt
@@ -2,15 +2,16 @@ package com.intellij.advancedExpressionFolding.processor.language.kotlin
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.PrintlnExpression
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.equalsIgnoreSpaces
 import com.intellij.advancedExpressionFolding.processor.isWhitespace
 import com.intellij.advancedExpressionFolding.processor.start
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiMethodCallExpression
 
-object PrintlnExt : BaseExtension() {
+object PrintlnExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State() {
 
     fun createExpression(
         element: PsiMethodCallExpression,


### PR DESCRIPTION
## Summary
- delegate `PrintlnExt` to `IKotlinLanguageState` via a new settings state instance
- adjust imports to remove the base extension dependency

## Testing
- ./gradlew clean build test --console=plain --no-daemon *(fails: FoldingTest regressions)*

------
https://chatgpt.com/codex/tasks/task_e_68f9e25ad574832e89270df15ad04a1c