### PR TITLE
Use settings delegation in NewExpressionExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt
@@ -13,7 +13,8 @@ import com.intellij.advancedExpressionFolding.processor.expression.LiteralExpres
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallExpressionExt
 import com.intellij.advancedExpressionFolding.processor.util.Consts
 import com.intellij.advancedExpressionFolding.processor.util.Helper
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiAnonymousClass
@@ -32,7 +33,7 @@ import java.util.ArrayList
 import java.math.BigDecimal
 import java.math.BigInteger
 
-object NewExpressionExt : StateDelegate() {
+object NewExpressionExt : IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
 
     fun getNewExpression(element: PsiNewExpression, document: Document): Expression? {
         val type = element.type


### PR DESCRIPTION
## Summary
- replace the StateDelegate base class in `NewExpressionExt` with delegation to `AdvancedExpressionFoldingSettings.State`
- update the imports to include `IExpressionCollapseState` and drop `StateDelegate`

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68fa45ea49b8832e85759cc64f6dbdf7