### PR TITLE
Delegate PsiClassExt to settings interfaces

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt
@@ -2,16 +2,22 @@ package com.intellij.advancedExpressionFolding.processor.declaration
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.addIfEnabled
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.exprList
 import com.intellij.advancedExpressionFolding.processor.exprWrap
 import com.intellij.advancedExpressionFolding.processor.language.kotlin.MethodDefaultParameterExt
 import com.intellij.advancedExpressionFolding.processor.lombok.AnnotationExt
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokPostConstructorExt
 import com.intellij.advancedExpressionFolding.processor.lombok.SummaryParentOverrideExt.addParentSummary
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IHidingSuppressionState
+import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
+import com.intellij.advancedExpressionFolding.settings.ILombokState
 import com.intellij.psi.PsiClass
 
-object PsiClassExt : BaseExtension() {
+object PsiClassExt :
+    IHidingSuppressionState by AdvancedExpressionFoldingSettings.State()(),
+    IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()(),
+    ILombokState by AdvancedExpressionFoldingSettings.State()() {
 
     enum class ClassType {
         BUILDER,


### PR DESCRIPTION
## Summary
- delegate PsiClassExt to IHidingSuppressionState, IKotlinLanguageState, and ILombokState via AdvancedExpressionFoldingSettings
- remove the BaseExtension dependency and rely on static helper utilities

## Testing
- TERM=dumb ./gradlew clean build test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68fa45e8b0d8832ea81df060b6659865