### PR TITLE
Stop extending StateDelegate from CacheExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/cache/CacheExt.kt
@@ -2,12 +2,11 @@ package com.intellij.advancedExpressionFolding.processor.cache
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt.buildExpression
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiElement
 import org.jetbrains.annotations.Contract
 
-object CacheExt : StateDelegate() {
+object CacheExt {
 
     fun PsiElement.invalidateExpired(document: Document, synthetic: Boolean): Boolean {
         val versionKey = Keys.getVersionKey(synthetic)


### PR DESCRIPTION
## Summary
- remove the StateDelegate inheritance from CacheExt so it is a simple object
- verify usages of CacheExt only call its cache helpers and do not depend on IState behaviour

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa45ea93f4832e8af0aad024955669