### PR TITLE
Use settings state delegation in PsiDeclarationStatementExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt
@@ -9,16 +9,14 @@ import com.intellij.advancedExpressionFolding.processor.realNextSibling
 import com.intellij.advancedExpressionFolding.processor.singleArgument
 import com.intellij.advancedExpressionFolding.processor.start
 import com.intellij.advancedExpressionFolding.processor.util.Helper
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
 import com.intellij.psi.*
 
-private val declarationStateDelegate = StateDelegate()
-
 object PsiDeclarationStatementExt :
-    IKotlinLanguageState by declarationStateDelegate,
-    IExpressionCollapseState by declarationStateDelegate {
+    IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()(),
+    IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
 
     fun createExpression(
         element: PsiDeclarationStatement


### PR DESCRIPTION
## Summary
- delegate PsiDeclarationStatementExt directly to the global settings state via AdvancedExpressionFoldingSettings
- clean up the redundant StateDelegate import

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68fa45ec2ef0832eb9aba24fc410c048