### PR TITLE
Delegate PsiVariableExt to settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt
@@ -1,13 +1,14 @@
 package com.intellij.advancedExpressionFolding.processor.declaration
 
 import com.intellij.advancedExpressionFolding.expression.VariableDeclarationImpl
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.util.Helper
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiForeachStatement
 import com.intellij.psi.PsiVariable
 
-object PsiVariableExt : BaseExtension() {
+object PsiVariableExt : IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
 
     fun getVariableDeclaration(element: PsiVariable): VariableDeclarationImpl? {
         if (!shouldCollapseVariableDeclaration(element)) {


### PR DESCRIPTION
## Summary
- replace the BaseExtension inheritance with delegation to the settings state in `PsiVariableExt`
- update imports to use the settings-based collapse state interface

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa45edce64832ebf3bb1591794d0f3