### PR TITLE
Use settings state delegate for PsiFieldExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt
@@ -23,7 +23,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiRecordComponent
 
-object PsiFieldExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.getInstance().state {
+object PsiFieldExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()() {
 
     fun createExpression(field: PsiField, document: Document): Expression? {
         val typeElement = field.typeElement.takeIf {


### PR DESCRIPTION
## Summary
- delegate the PsiFieldExt language settings to AdvancedExpressionFoldingSettings.State() for static helper usage

## Testing
- ./gradlew clean build test --console=plain --no-daemon --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68fa45eddb5c832eb0b061aa6aafd45a