### PR TITLE
Trim whitespace in PsiTypeCastExpressionExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/PsiTypeCastExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/PsiTypeCastExpressionExt.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiTypeCastExpression
 
 object PsiTypeCastExpressionExt {
-
     fun getTypeCastExpression(expression: PsiTypeCastExpression, document: Document): TypeCast? {
         val operand = expression.operand ?: return null
         return TypeCast(expression, expression.textRange, BuildExpressionExt.getAnyExpression(operand, document))


### PR DESCRIPTION
## Summary
- remove the redundant blank line after the `PsiTypeCastExpressionExt` object declaration

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa45e38518832e8cc871883e26e91e