### PR TITLE
Replace PrefixExpressionExt state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt
@@ -8,7 +8,9 @@ import com.intellij.advancedExpressionFolding.expression.operation.basic.Equal
 import com.intellij.advancedExpressionFolding.expression.operation.basic.GreaterEqual
 import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.util.Helper
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IDateOperationsState
+import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiExpression
@@ -17,7 +19,9 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiPrefixExpression
 
-object PrefixExpressionExt : StateDelegate() {
+object PrefixExpressionExt :
+    IDateOperationsState by AdvancedExpressionFoldingSettings.State()(),
+    IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
 
     fun getPrefixExpression(element: PsiPrefixExpression, document: Document): Expression? {
         val operand = element.operand ?: return null


### PR DESCRIPTION
## Summary
- replace the use of StateDelegate in PrefixExpressionExt with explicit delegation to the date and expression collapse settings interfaces
- add the required settings imports for the new delegation approach

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68fa45e46ce4832e984bacdfaef004a9