### PR TITLE
Delegate NullableExt to Kotlin settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt
@@ -4,8 +4,9 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.CheckNotNullExpression
 import com.intellij.advancedExpressionFolding.expression.semantic.lombok.NullAnnotationExpression
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.core.getAnyExpression
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.psi.*
@@ -14,7 +15,7 @@ import com.intellij.psi.*
  * [data.NullableAnnotationTestData]
  * [data.NullableAnnotationCheckNotNullTestData]
  */
-object NullableExt : BaseExtension() {
+object NullableExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()() {
 
     fun findPropertyAnnotation(field: PsiField, typeElement: PsiTypeElement?): Expression? {
         return field.metadata.getter


### PR DESCRIPTION
## Summary
- delegate `NullableExt` to `IKotlinLanguageState` via the global settings state
- update imports to match the new delegation target

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68fa3f01bdbc832e939c0e2af81926de