### PR TITLE
Update PrintlnExt state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt
@@ -6,12 +6,12 @@ import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.equalsIgnoreSpaces
 import com.intellij.advancedExpressionFolding.processor.isWhitespace
 import com.intellij.advancedExpressionFolding.processor.start
+import com.intellij.advancedExpressionFolding.processor.toTextRange
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiMethodCallExpression
 
-object PrintlnExt : IKotlinLanguageState by StateDelegate() {
+object PrintlnExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()() {
 
     fun createExpression(
         element: PsiMethodCallExpression,
@@ -30,7 +30,7 @@ object PrintlnExt : IKotlinLanguageState by StateDelegate() {
         } ?: dotElement
         val start = element.start()
         val end = endSibling.end()
-        return PrintlnExpression(element, TextRange(start, end), argumentExpression)
+        return PrintlnExpression(element, (start to end).toTextRange(), argumentExpression)
     }
 
 }


### PR DESCRIPTION
## Summary
- delegate `PrintlnExt` to `AdvancedExpressionFoldingSettings.State()()` instead of the old `StateDelegate`
- use the existing `toTextRange` helper when creating the `PrintlnExpression`

## Testing
- `./gradlew clean build test --console=plain --no-daemon --stacktrace --info` *(fails: IDE-based tests raise `StorageAlreadyInUseException`/`EOFException` in the sandboxed indexing step)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3f03bf58832eac9c1efb332a14e9