### PR TITLE
Delegate ExperimentalExt to emoji visibility state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt
@@ -2,12 +2,13 @@ package com.intellij.advancedExpressionFolding.processor.language
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.util.Consts
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IEmojiVisibilityState
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiReferenceExpression
 
-object ExperimentalExt : BaseExtension() {
+object ExperimentalExt : IEmojiVisibilityState by AdvancedExpressionFoldingSettings.State()() {
 
     @JvmStatic
     fun createExpression(element: PsiReferenceExpression): Expression? {


### PR DESCRIPTION
## Summary
- delegate ExperimentalExt to IEmojiVisibilityState using AdvancedExpressionFoldingSettings.State
- adjust imports after removing the BaseExtension inheritance

## Testing
- ./gradlew clean build test --console=plain --no-daemon *(fails: UpdateFoldedTextColorsActionTest > changeFoldingColorsUsesDarkNavyForegroundForBrightThemes with ServiceNotReadyException)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3f05e7f8832ea01d716ed2fcfda1