### PR TITLE
Delegate LiteralExpressionExt to log folding state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt
@@ -5,10 +5,11 @@ import com.intellij.advancedExpressionFolding.expression.literal.CharacterLitera
 import com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
 import com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
 import com.intellij.advancedExpressionFolding.processor.util.Consts
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.ILogFoldingState
 import com.intellij.psi.PsiLiteralExpression
 
-object LiteralExpressionExt : StateDelegate() {
+object LiteralExpressionExt : ILogFoldingState by AdvancedExpressionFoldingSettings.State()() {
 
     fun getLiteralExpression(element: PsiLiteralExpression): Expression? {
         val type = element.type ?: return null


### PR DESCRIPTION
## Summary
- delegate `LiteralExpressionExt` to the log folding state provided by `AdvancedExpressionFoldingSettings`
- remove the obsolete `StateDelegate` import

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa45e55114832ea75910254610ebb1