### PR TITLE
Delegate LoggerBracketsExt to settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt
@@ -2,16 +2,17 @@ package com.intellij.advancedExpressionFolding.processor.logger
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.processor.asInstance
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.firstArgument
 import com.intellij.advancedExpressionFolding.processor.takeIfTrue
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.ILogFoldingState
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.impl.source.PsiClassReferenceType
 
-object LoggerBracketsExt : BaseExtension() {
+object LoggerBracketsExt : ILogFoldingState by AdvancedExpressionFoldingSettings.State()() {
 
     @JvmStatic
     fun createExpression(


### PR DESCRIPTION
## Summary
- delegate `LoggerBracketsExt` to `AdvancedExpressionFoldingSettings.State()()` so it implements `ILogFoldingState`
- drop the obsolete `BaseExtension` dependency and update the imports accordingly

## Testing
- ./gradlew clean build test --console=plain --no-daemon -Dkotlin.incremental=false *(hangs during `:test`; terminated after extended wait)*

------
https://chatgpt.com/codex/tasks/task_e_68fa40131ff8832e9fc1d7d18470fb6a