### PR TITLE
Delegate PsiJavaTokenExt emoji settings

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt
@@ -1,13 +1,14 @@
 package com.intellij.advancedExpressionFolding.processor.token
 
 import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.expr
 import com.intellij.advancedExpressionFolding.processor.takeIfTrue
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IEmojiVisibilityState
 import com.intellij.psi.JavaTokenType.*
 import com.intellij.psi.PsiJavaToken
 
-object PsiJavaTokenExt : BaseExtension() {
+object PsiJavaTokenExt : IEmojiVisibilityState by AdvancedExpressionFoldingSettings.State()() {
 
     fun createExpression(element: PsiJavaToken): Expression? {
         emojify.takeIfTrue() ?: return null


### PR DESCRIPTION
## Summary
- delegate `PsiJavaTokenExt` to `AdvancedExpressionFoldingSettings.State` for emoji visibility configuration
- update imports to use emoji visibility interface and remove the base extension dependency

## Testing
- ./gradlew clean build test --no-daemon --console=plain --no-configuration-cache --no-build-cache

------
https://chatgpt.com/codex/tasks/task_e_68fa400e604c832e99511884802867ef