### PR TITLE
Refactor logger brackets state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt
@@ -6,8 +6,9 @@ import com.intellij.advancedExpressionFolding.expression.semantic.logging.Logger
 import com.intellij.advancedExpressionFolding.expression.semantic.logging.LoggerBracketParentExpression
 import com.intellij.advancedExpressionFolding.processor.asInstance
 import com.intellij.advancedExpressionFolding.processor.argumentExpressions
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
-import com.intellij.advancedExpressionFolding.processor.core.getAnyExpression
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.ILogFoldingState
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.start
 import com.intellij.advancedExpressionFolding.processor.toTextRange
@@ -21,7 +22,7 @@ import com.intellij.psi.PsiMethodCallExpression
 open class LoggerBracketsExtensionBase(
     protected val element: PsiMethodCallExpression,
     protected val document: Document
-) : BaseExtension(){
+) : ILogFoldingState by AdvancedExpressionFoldingSettings.State()(){
 
     fun processExpression(): Expression? {
         val logLiteral = element.argumentExpressions.takeIf {
@@ -62,7 +63,7 @@ open class LoggerBracketsExtensionBase(
                     null
                 }
             } else {
-                val expression = getAnyExpression(argument, document)
+                val expression = BuildExpressionExt.getAnyExpression(argument, document)
                 val text = if (expression is Variable) {
                     "\$"
                 } else {
@@ -91,7 +92,7 @@ open class LoggerBracketsExtensionBase(
     ): LoggerBracketParentExpression {
         val finalExpressions = if (hasTooManyArguments) {
             this + arguments.subList(split.size - 1, arguments.size).map { expr ->
-                getAnyExpression(expr, document)
+                BuildExpressionExt.getAnyExpression(expr, document)
             }
         } else {
             this


### PR DESCRIPTION
## Summary
- delegate `LoggerBracketsExtensionBase` to `AdvancedExpressionFoldingSettings.State` for log folding configuration
- replace direct `getAnyExpression` calls with `BuildExpressionExt.getAnyExpression` and update imports

## Testing
- ./gradlew clean build test --console=plain --info

------
https://chatgpt.com/codex/tasks/task_e_68fa3f20123c832e9522d9a58de366dd