### PR TITLE
Delegate LombokExt to settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt
@@ -1,7 +1,6 @@
 package com.intellij.advancedExpressionFolding.processor.lombok
 
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.lombok.AnnotationExt.ClassLevelAnnotation
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokConstructorExt.foldArgsConstructor
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokConstructorExt.foldNoArgsConstructor
@@ -15,12 +14,14 @@ import com.intellij.advancedExpressionFolding.processor.lombok.LombokFoldingAnno
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokMethodExt.interfaceSupport
 import com.intellij.advancedExpressionFolding.processor.lombok.LombokMethodExt.isFinder
 import com.intellij.advancedExpressionFolding.processor.lombok.MethodType.*
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.ILombokState
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.impl.source.PsiClassReferenceType
 
-object LombokExt : BaseExtension() {
+object LombokExt : ILombokState by AdvancedExpressionFoldingSettings.State()() {
 
     fun PsiClass.addLombokSupport(): List<ClassLevelAnnotation> {
         if (isInterface) {


### PR DESCRIPTION
## Summary
- delegate `LombokExt` to `ILombokState` using `AdvancedExpressionFoldingSettings.State` for configuration access
- remove the inherited `BaseExtension` dependency so the object relies only on top-level helper functions

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa3f0a2e9c832ea3d6c2187a8f13af