### PR TITLE
Adjust binary expression state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt
@@ -11,11 +11,12 @@ import com.intellij.advancedExpressionFolding.expression.operation.basic.Equal
 import com.intellij.advancedExpressionFolding.expression.operation.basic.Greater
 import com.intellij.advancedExpressionFolding.expression.operation.basic.GreaterEqual
 import com.intellij.advancedExpressionFolding.expression.operation.collection.Range
-import com.intellij.advancedExpressionFolding.processor.util.Consts
 import com.intellij.advancedExpressionFolding.processor.argumentExpressions
 import com.intellij.advancedExpressionFolding.processor.argumentCount
+import com.intellij.advancedExpressionFolding.processor.util.Consts
 import com.intellij.advancedExpressionFolding.processor.util.Helper.eraseGenerics
-import com.intellij.advancedExpressionFolding.settings.StateDelegate
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiBinaryExpression
@@ -26,7 +27,7 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiPrefixExpression
 
-object BinaryExpressionExt : StateDelegate() {
+object BinaryExpressionExt : IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
 
     fun getBinaryExpression(element: PsiBinaryExpression, document: Document): Expression? {
         tryBuildCompareToBasedExpression(element, document)?.let { return it }


### PR DESCRIPTION
## Summary
- delegate `BinaryExpressionExt` to `IExpressionCollapseState` via `AdvancedExpressionFoldingSettings.State`
- update the imports to drop `StateDelegate`

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa40221b24832e9eb963854a9439b7