### PR TITLE
Use settings state delegate for PsiKeywordExt

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt
@@ -9,7 +9,7 @@ import com.intellij.advancedExpressionFolding.processor.nextWhiteSpace
 import com.intellij.advancedExpressionFolding.processor.prevWhiteSpace
 import com.intellij.advancedExpressionFolding.processor.takeIfTrue
 import com.intellij.advancedExpressionFolding.processor.util.Consts.Emoji
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import com.intellij.advancedExpressionFolding.settings.IEmojiVisibilityState
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
@@ -18,7 +18,7 @@ import com.intellij.psi.PsiLocalVariable
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 
-object PsiKeywordExt : IEmojiVisibilityState by AdvancedExpressionFoldingSettings.getInstance().state {
+object PsiKeywordExt : IEmojiVisibilityState by State()() {
 
     fun createExpression(keyword: PsiKeyword): Expression? =
         finalRemoval.takeIfTrue(keyword)?.finalRemoval() ?: finalEmoji.takeIfTrue(keyword)?.finalEmoji()


### PR DESCRIPTION
## Summary
- delegate `PsiKeywordExt`'s emoji visibility to `AdvancedExpressionFoldingSettings.State()()`
- remove the direct `AdvancedExpressionFoldingSettings.getInstance()` usage and import

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa3e37e618832eb67fdcc3934d1f6a