### PR TITLE
Adjust MethodReferenceExt settings delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt
@@ -6,14 +6,14 @@ import com.intellij.advancedExpressionFolding.expression.operation.stream.Stream
 import com.intellij.advancedExpressionFolding.processor.filter
 import com.intellij.advancedExpressionFolding.processor.findParents
 import com.intellij.advancedExpressionFolding.processor.guessPropertyName
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import com.intellij.advancedExpressionFolding.settings.ICollectionsStreamsState
 import com.intellij.psi.PsiExpressionList
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiMethodReferenceExpression
 
-object MethodReferenceExt : ICollectionsStreamsState by AdvancedExpressionFoldingSettings.getInstance().state {
+object MethodReferenceExt : ICollectionsStreamsState by State()() {
     @JvmStatic
     fun createExpression(element: PsiMethodReferenceExpression): Expression? {
         if (!(optional || streamSpread)) {


### PR DESCRIPTION
## Summary
- update `MethodReferenceExt` to use a freshly constructed `State` delegate instead of the singleton `getInstance()` state
- drop the direct singleton settings import in favor of the nested `State`

## Testing
- ./gradlew build test --no-configuration-cache --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68fa3e545ac4832eb5a2e4f25c5f276f