### PR TITLE
Delegate FieldShiftExt to settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt
@@ -8,13 +8,14 @@ import com.intellij.advancedExpressionFolding.expression.property.INameable
 import com.intellij.advancedExpressionFolding.expression.semantic.BuilderShiftExpression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.CheckNotNullExpression
 import com.intellij.advancedExpressionFolding.processor.*
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
 import com.intellij.advancedExpressionFolding.processor.core.getAnyExpression
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.*
 
-object FieldShiftExt : BaseExtension() {
+object FieldShiftExt : IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()() {
     private const val FIELD_SHIFT = "<<"
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- delegate FieldShiftExt to AdvancedExpressionFoldingSettings.State so the extension exposes the collapse flag directly
- replace the BaseExtension superclass with IExpressionCollapseState delegation and add the required imports

## Testing
- ./gradlew clean build test --console=plain --no-configuration-cache *(fails: UpdateFoldedTextColorsActionTest -> ServiceNotReadyException)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3f0696f8832e94620af35c4e6b6d