### PR TITLE
Delegate IfNullSafeExt to settings state

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
@@ -6,17 +6,18 @@ import com.intellij.advancedExpressionFolding.expression.property.INameable
 import com.intellij.advancedExpressionFolding.expression.semantic.WrapperExpression
 import com.intellij.advancedExpressionFolding.expression.semantic.kotlin.IfNullSafeExpression
 import com.intellij.advancedExpressionFolding.processor.asInstance
-import com.intellij.advancedExpressionFolding.processor.core.BaseExtension
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
 import com.intellij.advancedExpressionFolding.processor.end
 import com.intellij.advancedExpressionFolding.processor.start
 import com.intellij.advancedExpressionFolding.processor.toTextRange
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.*
 import com.intellij.psi.util.elementType
 
 
-object IfNullSafeExt : BaseExtension() {
+object IfNullSafeExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()() {
 
     @JvmStatic
     fun createExpression(element: PsiPolyadicExpression, document: Document): Expression? {


### PR DESCRIPTION
## Summary
- delegate the Kotlin if-null safe processor to IKotlinLanguageState via AdvancedExpressionFoldingSettings.State()
- update imports to reflect the new delegation

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fa3e9bc3e0832e8588ea8bbde4bec5