### PR TITLE
Handle quote character boundaries in interpolated string folding

### DIFF
--- a/examples/data/InterpolatedStringTestData.java
+++ b/examples/data/InterpolatedStringTestData.java
@@ -11,6 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, " + name + "!");
         System.out.println(name + ", hello!");
         System.out.println(name + ", " + name);
+        System.out.println('"' + name + " says hi");
+        System.out.println("Hi " + name + '"');
         System.out.println("Unicode: " + '\u0041');
         System.out.println("Next: " + (char)('A' + 1));
         System.out.println("Length: " + args.length);

--- a/folded/InterpolatedStringTestData-folded.java
+++ b/folded/InterpolatedStringTestData-folded.java
@@ -11,6 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, $name!");
         System.out.println("$name, hello!");
         System.out.println("$name, $name");
+        System.out.println("\"$name says hi");
+        System.out.println("Hi $name\"");
         System.out.println("Unicode: ${'\u0041'}");
         System.out.println("Next: ${(char)('A' + 1)}");
         System.out.println("Length: ${args.length}");

--- a/testData/InterpolatedStringTestData-all.java
+++ b/testData/InterpolatedStringTestData-all.java
@@ -11,6 +11,8 @@ public class InterpolatedStringTestData {
         <fold text='' expand='false'>System.out.</fold>println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
+        <fold text='' expand='false'>System.out.</fold>println(<fold text='"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi");
+        <fold text='' expand='false'>System.out.</fold>println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='"' expand='false'>'"'</fold>');
         <fold text='' expand='false'>System.out.</fold>println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println("Next: <fold text='${' expand='false'>" + </fold><fold text='' expand='false'>(char)(</fold>'A' + 1<fold text='' expand='false'>)</fold><fold text='}")' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;

--- a/testData/InterpolatedStringTestData.java
+++ b/testData/InterpolatedStringTestData.java
@@ -11,6 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
+        System.out.println(<fold text='"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi");
+        System.out.println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='"' expand='false'>'"'</fold>');
         System.out.println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
         System.out.println("Next: <fold text='${' expand='false'>" + </fold>(char)('A' + 1)<fold text='}")' expand='false'>)</fold>;
         System.out.println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;


### PR DESCRIPTION
## Summary
- detect character literals representing double quotes on either edge of interpolated strings and fold them before general literal handling
- suppress extra interpolation markers around neighboring quote characters so folding output renders expected placeholders
- add regression inputs and folded expectations for interpolated strings that begin or end with a character literal quote
- update examples/data/InterpolatedStringTestData.java to cover quote character operands in interpolated strings

## Testing
- ./gradlew test --tests com.intellij.advancedExpressionFolding.FoldingTest.interpolatedStringTestData --exclude-task examples:test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f4fbc636d0832ea3bf9022664bee09