### PR TITLE
Add pseudo-annotation @InheritConstructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## [4.0.0] - 2025-07-15
 
 - [[pseudo-annotations] @Main - method-level annotation that generates a main method invoking the annotated method.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
+- [[pseudo-annotations] @InheritConstructors - class-level annotation that copies accessible constructors from the superclass.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 - [[fieldshift] Preconditions.checkNotNull now supported](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/FieldShift#preconditionschecknotnull)
 
 ## [3.8.0] - 2025-07-07

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For more information, read the [blog post](https://medium.com/@andrey_cheptsov/m
 ## 4.0.0 ##
 
 - [[pseudo-annotations] @Main - method-level annotation that generates a main method invoking the annotated method.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
+- [[pseudo-annotations] @InheritConstructors - class-level annotation that copies accessible constructors from the superclass.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 - [[fieldshift] Preconditions.checkNotNull now supported](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/FieldShift#preconditionschecknotnull)
 
 ## 3.8.0 ##

--- a/examples/data/PseudoAnnotationsInheritConstructorsTestData.java
+++ b/examples/data/PseudoAnnotationsInheritConstructorsTestData.java
@@ -1,0 +1,33 @@
+package data;
+
+import java.io.IOException;
+
+public class PseudoAnnotationsInheritConstructorsTestData {
+
+    public static class BaseError extends Exception {
+        public BaseError() {
+        }
+
+        public BaseError(String message) {
+            super(message);
+        }
+
+        public BaseError(String message, Throwable cause) throws IOException {
+            super(message, cause);
+        }
+    }
+
+    public static class DerivedError extends BaseError {
+        public DerivedError() {
+            super();
+        }
+
+        public DerivedError(String message) {
+            super(message);
+        }
+
+        public DerivedError(String message, Throwable cause) throws IOException {
+            super(message, cause);
+        }
+    }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,10 +36,13 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
-        <!-- Suggests the pseudo-annotation @Main used by the plugin -->
+        <!-- Suggests the pseudo-annotations used by the plugin -->
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.InheritConstructorsAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/InheritConstructorsAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/InheritConstructorsAnnotationCompletionContributor.kt
@@ -1,0 +1,165 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IState
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiEllipsisType
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.PsiUtil
+import com.intellij.util.ProcessingContext
+
+class InheritConstructorsAnnotationCompletionContributor(
+    private val state: IState = getInstance().state
+) : CompletionContributor(), IState by state {
+    init {
+        extend(
+            CompletionType.BASIC,
+            com.intellij.patterns.PlatformPatterns.psiElement(PsiIdentifier::class.java)
+                .withParent(com.intellij.psi.PsiJavaCodeReferenceElement::class.java)
+                .withSuperParent(2, com.intellij.psi.PsiAnnotation::class.java)
+                .withSuperParent(3, com.intellij.psi.PsiModifierList::class.java)
+                .withSuperParent(4, PsiClass::class.java),
+            object : CompletionProvider<CompletionParameters>() {
+                override fun addCompletions(
+                    parameters: CompletionParameters,
+                    context: ProcessingContext,
+                    result: CompletionResultSet
+                ) {
+                    if (!pseudoAnnotations) return
+
+                    val lookup = LookupElementBuilder.create("InheritConstructors")
+                        .withLookupString("@InheritConstructors")
+                        .withPresentableText("@InheritConstructors")
+                        .withInsertHandler { insertionContext, _ ->
+                            handleInsert(insertionContext)
+                        }
+                        .withAutoCompletionPolicy(AutoCompletionPolicy.NEVER_AUTOCOMPLETE)
+
+                    result.addElement(lookup)
+                }
+            }
+        )
+    }
+
+    private fun handleInsert(ctx: InsertionContext) {
+        val project = ctx.project
+        val element = ctx.file.findElementAt(ctx.startOffset) ?: return
+        val psiClass = PsiTreeUtil.getParentOfType(element, PsiClass::class.java, false) ?: return
+        val superClass = psiClass.superClass ?: return
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            psiClass.modifierList?.findAnnotation("InheritConstructors")?.delete()
+
+            val accessibleConstructors = superClass.constructors.filter { constructor ->
+                !constructor.hasModifierProperty(PsiModifier.PRIVATE) &&
+                    PsiUtil.isAccessible(constructor, psiClass, psiClass)
+            }
+
+            if (accessibleConstructors.isEmpty()) {
+                return@runWriteCommandAction
+            }
+
+            val existingSignatures = psiClass.constructors.map { signature(it) }.toSet()
+            val factory = JavaPsiFacade.getElementFactory(project)
+            val newConstructors = accessibleConstructors
+                .filter { signature(it) !in existingSignatures }
+                .mapNotNull { constructor ->
+                    createConstructorText(constructor, psiClass.name ?: return@mapNotNull null)?.let {
+                        factory.createMethodFromText(it, psiClass)
+                    }
+                }
+
+            newConstructors.forEach { created ->
+                val inserted = psiClass.add(created) as PsiMethod
+                JavaCodeStyleManager.getInstance(project).shortenClassReferences(inserted)
+                CodeStyleManager.getInstance(project).reformat(inserted)
+            }
+        }
+    }
+
+    private fun signature(method: PsiMethod): String =
+        method.parameterList.parameters.joinToString(prefix = "(", postfix = ")") { parameter ->
+            val type = parameter.type
+            if (type is PsiEllipsisType) {
+                type.componentType.canonicalText + "..."
+            } else {
+                type.canonicalText
+            }
+        }
+
+    private fun createConstructorText(constructor: PsiMethod, className: String): String? {
+        val visibility = when {
+            constructor.hasModifierProperty(PsiModifier.PUBLIC) -> "public "
+            constructor.hasModifierProperty(PsiModifier.PROTECTED) -> "protected "
+            else -> ""
+        }
+
+        val annotations = constructor.modifierList.annotations
+            .map { it.text }
+            .filter { it.isNotBlank() }
+
+        val parameterTexts = constructor.parameterList.parameters.mapIndexed { index, parameter ->
+            createParameterText(parameter, index)
+        }
+        val parameterList = parameterTexts.joinToString(", ", prefix = "(", postfix = ")")
+
+        val parameterNames = constructor.parameterList.parameters.mapIndexed { index, parameter ->
+            parameter.name ?: "param$index"
+        }.joinToString(", ")
+
+        val throwsClause = constructor.throwsList.referencedTypes
+            .takeIf { it.isNotEmpty() }
+            ?.joinToString(", ", prefix = " throws ") { it.presentableText }
+            .orEmpty()
+
+        return buildString {
+            annotations.forEach {
+                appendLine(it)
+            }
+            append(visibility)
+            append(className)
+            append(parameterList)
+            append(throwsClause)
+            appendLine(" {")
+            append("        super(")
+            append(parameterNames)
+            appendLine(");")
+            appendLine("    }")
+        }
+    }
+
+    private fun createParameterText(parameter: PsiParameter, index: Int): String {
+        val annotations = parameter.modifierList?.annotations
+            ?.map { it.text }
+            ?.filter { it.isNotBlank() }
+            ?.joinToString(separator = " ")
+            ?.let { "$it " }
+            .orEmpty()
+
+        val finalModifier = if (parameter.hasModifierProperty(PsiModifier.FINAL)) "final " else ""
+        val type = parameter.type
+        val typeText = if (type is PsiEllipsisType) {
+            type.componentType.presentableText + "..."
+        } else {
+            type.presentableText
+        }
+        val name = parameter.name ?: "param$index"
+        return annotations + finalModifier + typeText + " " + name
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,8 +273,9 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @InheritConstructors") {
             example("PseudoAnnotationsMainTestData.java")
+            example("PseudoAnnotationsInheritConstructorsTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
         // NEW OPTION

--- a/test/com/intellij/advancedExpressionFolding/InheritConstructorsAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/InheritConstructorsAnnotationCompletionContributorTest.kt
@@ -1,0 +1,153 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.application.ApplicationManager
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class InheritConstructorsAnnotationCompletionContributorTest : BaseTest() {
+    private var originalPseudoAnnotationsValue: Boolean = false
+
+    @BeforeEach
+    fun setUp() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        originalPseudoAnnotationsValue = settings.state.pseudoAnnotations
+        settings.state.pseudoAnnotations = true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.state.pseudoAnnotations = originalPseudoAnnotationsValue
+    }
+
+    @Test
+    fun `should offer @InheritConstructors in completion for annotation above class`() {
+        fixture.configureByText("Test.java", @Language("JAVA") """
+            import java.io.IOException;
+            
+            class Base {
+                public Base() {}
+                public Base(String message, Throwable cause) throws IOException {}
+            }
+            
+            @<caret>
+            class Derived extends Base {
+            }
+        """.trimIndent())
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+        assertTrue(completions.any { it.lookupString == "InheritConstructors" })
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    fun `should generate constructors when selecting @InheritConstructors from completion`(testCase: TestCase) {
+        fixture.configureByText("Test.java", testCase.input)
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val inheritConstructors = completions.find { it.lookupString == "InheritConstructors" }
+        assertNotNull(inheritConstructors)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = inheritConstructors
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(testCase.expected)
+    }
+
+    data class TestCase(
+        val name: String,
+        @param:Language("JAVA") val input: String,
+        @param:Language("JAVA") val expected: String
+    ) {
+        override fun toString() = name
+    }
+
+    companion object {
+        @JvmStatic
+        fun testCases(): Stream<TestCase> = Stream.of(
+            TestCase(
+                name = "Generates constructors from parent",
+                input = """
+                    import java.io.IOException;
+                    
+                    class Base {
+                        public Base() {}
+                        public Base(String message, Throwable cause) throws IOException {}
+                        protected Base(int code, String name) {}
+                        private Base(boolean hidden) {}
+                    }
+                    
+                    @<caret>
+                    class Derived extends Base {
+                    }
+                """.trimIndent(),
+                expected = """
+                    import java.io.IOException;
+                    
+                    class Base {
+                        public Base() {}
+                        public Base(String message, Throwable cause) throws IOException {}
+                        protected Base(int code, String name) {}
+                        private Base(boolean hidden) {}
+                    }
+                    
+                    class Derived extends Base {
+                        public Derived() {
+                            super();
+                        }
+                    
+                        public Derived(String message, Throwable cause) throws IOException {
+                            super(message, cause);
+                        }
+                    
+                        protected Derived(int code, String name) {
+                            super(code, name);
+                        }
+                    }
+                """.trimIndent()
+            ),
+            TestCase(
+                name = "Skips existing constructors",
+                input = """
+                    class Base {
+                        public Base() {}
+                        public Base(int value) {}
+                    }
+                    
+                    @<caret>
+                    class Derived extends Base {
+                        public Derived() {}
+                    }
+                """.trimIndent(),
+                expected = """
+                    class Base {
+                        public Base() {}
+                        public Base(int value) {}
+                    }
+                    
+                    class Derived extends Base {
+                        public Derived() {}
+                    
+                        public Derived(int value) {
+                            super(value);
+                        }
+                    }
+                """.trimIndent()
+            )
+        )
+    }
+}

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -280,6 +280,7 @@ Simplifies constructor references and inline field initialization.
 ### Pseudo-annotations for main method generation
 Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
+- [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsInheritConstructorsTestData.java)
 - [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/pseudoAnnotations)
 

--- a/wiki-clone/docs/features/pseudoAnnotations.md
+++ b/wiki-clone/docs/features/pseudoAnnotations.md
@@ -75,3 +75,42 @@ public class Person {
 - The generated main method is fully functional and can be run immediately
 - Only works when `pseudoAnnotations` setting is enabled
 - Designed for rapid prototyping and testing
+
+### @InheritConstructors
+
+Generates constructors in the current class that mirror accessible constructors from the superclass. Ideal for quickly wiring up custom `Exception` types or other subclasses that simply delegate to their parent constructors.
+
+#### How it works:
+1. **Completion trigger**: Type `@InheritConstructors` above a class declaration to see the completion suggestion
+2. **Constructor replication**: Selecting the annotation generates constructors matching each accessible superclass constructor
+3. **Visibility preservation**: Keeps `public` and `protected` visibility modifiers when copying constructors
+4. **Exception propagation**: Copies `throws` clauses so the generated constructors compile immediately
+5. **Duplicate avoidance**: Skips constructors that already exist with the same parameter list in the subclass
+
+#### Example:
+```java
+class BaseError extends Exception {
+    public BaseError() {}
+    public BaseError(String message, Throwable cause) throws java.io.IOException {}
+    protected BaseError(int status) {}
+}
+
+class DerivedError extends BaseError {
+    public DerivedError() {
+        super();
+    }
+
+    public DerivedError(String message, Throwable cause) throws java.io.IOException {
+        super(message, cause);
+    }
+
+    protected DerivedError(int status) {
+        super(status);
+    }
+}
+```
+
+#### Notes:
+- Only generates constructors that are accessible from the subclass (skips `private` and package-private constructors from other packages)
+- Maintains parameter annotations and `final` modifiers when present
+- Available when the `pseudoAnnotations` setting is enabled


### PR DESCRIPTION
## Summary
- add a completion contributor that exposes the @InheritConstructors pseudo-annotation and generates constructors mirroring the superclass
- cover the feature with UI, docs, example data, and integration tests

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68eec400f608832eb87958c6b6391dff