### PR TITLE
Add @Adapter pseudo-annotation generator

### DIFF
--- a/examples/data/PseudoAnnotationsAdapterTestData.java
+++ b/examples/data/PseudoAnnotationsAdapterTestData.java
@@ -1,0 +1,12 @@
+package data;
+
+interface PseudoAnnotationsAdapterListener {
+    void onEvent();
+    int onCompute();
+    Boolean isReady();
+}
+
+abstract class PseudoAnnotationsAdapterProcessor {
+    public abstract void execute();
+    protected abstract long scheduledAt();
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,10 +36,13 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
-        <!-- Suggests the pseudo-annotation @Main used by the plugin -->
+        <!-- Suggests pseudo-annotations used by the plugin -->
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.AdapterAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/AdapterAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdapterAnnotationCompletionContributor.kt
@@ -1,0 +1,318 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IState
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.*
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+
+class AdapterAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(), IState by state {
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement(PsiIdentifier::class.java)
+                .withParent(PsiJavaCodeReferenceElement::class.java)
+                .withSuperParent(2, PsiAnnotation::class.java)
+                .withSuperParent(3, PsiModifierList::class.java)
+                .withSuperParent(4, PsiClass::class.java),
+            object : CompletionProvider<CompletionParameters>() {
+                override fun addCompletions(
+                    parameters: CompletionParameters,
+                    context: ProcessingContext,
+                    result: CompletionResultSet
+                ) {
+                    if (!pseudoAnnotations) return
+
+                    val lookup = LookupElementBuilder.create("Adapter")
+                        .withLookupString("@Adapter")
+                        .withPresentableText("@Adapter")
+                        .withInsertHandler { ctx, _ ->
+                            handleAdapterInsert(ctx)
+                        }
+                        .withAutoCompletionPolicy(AutoCompletionPolicy.NEVER_AUTOCOMPLETE)
+
+                    result.addElement(lookup)
+                }
+            }
+        )
+    }
+
+    private fun handleAdapterInsert(ctx: InsertionContext) {
+        val project = ctx.project
+        val element = ctx.file.findElementAt(ctx.startOffset) ?: return
+        val targetClass = PsiTreeUtil.getParentOfType(element, PsiClass::class.java, false) ?: return
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            val config = extractConfigAndRemoveAnnotations(targetClass, ctx) ?: return@runWriteCommandAction
+            generateAdapter(targetClass, ctx, config)
+        }
+    }
+
+    private fun extractConfigAndRemoveAnnotations(targetClass: PsiClass, ctx: InsertionContext): AdapterConfig? {
+        val document = ctx.document
+        val project = ctx.project
+        val psiDocumentManager = PsiDocumentManager.getInstance(project)
+        psiDocumentManager.doPostponedOperationsAndUnblockDocument(document)
+
+        val classRange = targetClass.textRange ?: return null
+        val fullText = document.text
+        val regex = Regex("@Adapter(\\s*\\(([^)]*)\\))?")
+
+        val prefixMatches = regex.findAll(fullText.substring(0, classRange.startOffset))
+            .map { it to 0 }
+            .toList()
+        val classMatches = regex.findAll(fullText.substring(classRange.startOffset, classRange.endOffset))
+            .map { it to classRange.startOffset }
+            .toList()
+
+        val allMatches = prefixMatches + classMatches
+        if (allMatches.isEmpty()) return null
+
+        val params = allMatches.mapNotNull { (match, _) ->
+            match.groupValues.getOrNull(2)?.takeIf { it.isNotBlank() }
+        }.lastOrNull()
+        val config = AdapterConfig.fromParameters(params)
+
+        val chars = document.charsSequence
+        allMatches.asReversed().forEach { (match, base) ->
+            val start = base + match.range.first
+            var end = base + match.range.last + 1
+            if (end < chars.length && chars[end] == '\r') {
+                end++
+            }
+            if (end < chars.length && chars[end] == '\n') {
+                end++
+            }
+            document.deleteString(start, end)
+        }
+
+        psiDocumentManager.commitDocument(document)
+        return config
+    }
+
+    private fun generateAdapter(targetClass: PsiClass, ctx: InsertionContext, config: AdapterConfig) {
+        val adapterName = targetClass.name?.let { name ->
+            if (name.endsWith("Adapter")) name else name + "Adapter"
+        } ?: return
+
+        val adapterCode = buildAdapterClassText(targetClass, adapterName, config) ?: return
+        val project = ctx.project
+        val factory = JavaPsiFacade.getElementFactory(project)
+        val psiFileFactory = PsiFileFactory.getInstance(project)
+        val tempFile = psiFileFactory.createFileFromText(
+            "${adapterName}_.java",
+            JavaLanguage.INSTANCE,
+            adapterCode
+        )
+        val adapterPsiClass = PsiTreeUtil.findChildOfType(tempFile, PsiClass::class.java) ?: return
+        val parent = targetClass.parent
+
+        removeExistingAdapter(parent, adapterName)
+
+        val parserFacade = PsiParserFacade.SERVICE.getInstance(project)
+        val whitespace = parserFacade.createWhiteSpaceFromText("\n\n")
+        val addedWhitespace = parent.addAfter(whitespace, targetClass)
+        val inserted = parent.addAfter(adapterPsiClass, addedWhitespace)
+
+        PsiDocumentManager.getInstance(project).commitAllDocuments()
+
+        JavaCodeStyleManager.getInstance(project).shortenClassReferences(inserted)
+        CodeStyleManager.getInstance(project).reformat(inserted)
+    }
+
+    private fun removeExistingAdapter(parent: PsiElement, adapterName: String) {
+        when (parent) {
+            is PsiJavaFile -> parent.classes.filter { it.name == adapterName }.forEach { it.delete() }
+            is PsiClass -> parent.innerClasses.filter { it.name == adapterName }.forEach { it.delete() }
+        }
+    }
+
+    private fun buildAdapterClassText(targetClass: PsiClass, adapterName: String, config: AdapterConfig): String? {
+        val typeParametersDeclaration = targetClass.typeParameterList?.text ?: ""
+        val typeParameterUsage = targetClass.typeParameters.takeIf { it.isNotEmpty() }
+            ?.joinToString(prefix = "<", postfix = ">") { it.name ?: "" }
+            ?: ""
+
+        val extendsOrImplements = when {
+            targetClass.isInterface -> " implements ${targetClass.name}${typeParameterUsage}"
+            targetClass.hasModifierProperty(PsiModifier.ABSTRACT) -> " extends ${targetClass.name}${typeParameterUsage}"
+            else -> return null
+        }
+
+        val visibility = when {
+            targetClass.hasModifierProperty(PsiModifier.PUBLIC) -> "public "
+            targetClass.hasModifierProperty(PsiModifier.PROTECTED) -> "protected "
+            targetClass.hasModifierProperty(PsiModifier.PRIVATE) -> "private "
+            else -> ""
+        }
+
+        val classModifiers = buildString {
+            append(visibility)
+            if (targetClass.containingClass != null) {
+                append("static ")
+            }
+        }
+
+        val methods = collectAbstractMethods(targetClass)
+        val methodBlocks = methods.joinToString(separator = "\n\n") { method ->
+            buildMethodStub(method, config)
+        }
+
+        return buildString {
+            append(classModifiers)
+            append("class ")
+            append(adapterName)
+            append(typeParametersDeclaration)
+            append(extendsOrImplements)
+            append(" {\n")
+            if (methodBlocks.isNotBlank()) {
+                append(methodBlocks.prependIndent("    "))
+                append('\n')
+            }
+            append('}')
+        }
+    }
+
+    private fun collectAbstractMethods(targetClass: PsiClass): List<PsiMethod> {
+        return targetClass.allMethods
+            .filter { method ->
+                !method.isConstructor &&
+                method.containingClass?.let { containing ->
+                    (containing == targetClass || containing.isInterface || containing.hasModifierProperty(PsiModifier.ABSTRACT)) &&
+                        method.hasModifierProperty(PsiModifier.ABSTRACT)
+                } ?: false
+            }
+            .distinctBy { it.getSignature(PsiSubstitutor.EMPTY) }
+    }
+
+    private fun buildMethodStub(method: PsiMethod, config: AdapterConfig): String {
+        val visibility = when {
+            method.hasModifierProperty(PsiModifier.PUBLIC) -> "public "
+            method.hasModifierProperty(PsiModifier.PROTECTED) -> "protected "
+            method.hasModifierProperty(PsiModifier.PRIVATE) -> "private "
+            else -> if (method.containingClass?.isInterface == true) "public " else ""
+        }
+
+        val typeParameters = method.typeParameterList?.text?.let { if (it.isNotBlank()) "$it " else "" } ?: ""
+        val returnTypeText = method.returnTypeElement?.text ?: "void"
+        val parameters = method.parameterList.parameters
+            .mapIndexed { index, parameter ->
+                val name = parameter.name ?: "param$index"
+                val typeText = parameter.typeElement?.text ?: parameter.type.presentableText
+                buildString {
+                    if (parameter.modifierList?.annotations?.isNotEmpty() == true) {
+                        append(parameter.modifierList!!.annotations.joinToString(separator = " ") { it.text })
+                        append(' ')
+                    }
+                    if (parameter.hasModifierProperty(PsiModifier.FINAL)) {
+                        append("final ")
+                    }
+                    append(typeText)
+                    append(' ')
+                    append(name)
+                }
+            }
+            .joinToString(", ")
+        val throwsClause = method.throwsList.referenceElements.takeIf { it.isNotEmpty() }
+            ?.joinToString(prefix = " throws ") { it.text }
+            ?: ""
+
+        val body = buildMethodBody(method.returnType, config)
+
+        return buildString {
+            append("@Override\n")
+            append(visibility)
+            append(typeParameters)
+            append(returnTypeText)
+            append(' ')
+            append(method.name)
+            append('(')
+            append(parameters)
+            append(')')
+            append(throwsClause)
+            append(" {\n")
+            body?.takeIf { it.isNotBlank() }?.let {
+                append(it.prependIndent("        "))
+                append('\n')
+            }
+            append("    }")
+        }
+    }
+
+    private fun buildMethodBody(returnType: PsiType?, config: AdapterConfig): String? {
+        if (config.throwException) {
+            return "throw new UnsupportedOperationException();"
+        }
+
+        if (returnType == null || returnType == PsiType.VOID) {
+            return null
+        }
+
+        val value = defaultValue(returnType, config.primitiveWrapperDefaults)
+        return if (value != null) {
+            "return $value;"
+        } else {
+            "return null;"
+        }
+    }
+
+    private fun defaultValue(type: PsiType, primitiveWrapperDefaults: Boolean): String? {
+        return when (type) {
+            PsiType.BOOLEAN -> "false"
+            PsiType.CHAR -> "'\\0'"
+            PsiType.BYTE, PsiType.SHORT, PsiType.INT -> "0"
+            PsiType.LONG -> "0L"
+            PsiType.FLOAT -> "0.0f"
+            PsiType.DOUBLE -> "0.0d"
+            else -> when (val canonical = type.canonicalText) {
+                "java.lang.Boolean" -> if (primitiveWrapperDefaults) "false" else null
+                "java.lang.Character" -> if (primitiveWrapperDefaults) "'\\0'" else null
+                "java.lang.Byte", "java.lang.Short", "java.lang.Integer" -> if (primitiveWrapperDefaults) "0" else null
+                "java.lang.Long" -> if (primitiveWrapperDefaults) "0L" else null
+                "java.lang.Float" -> if (primitiveWrapperDefaults) "0.0f" else null
+                "java.lang.Double" -> if (primitiveWrapperDefaults) "0.0d" else null
+                else -> null
+            }
+        }
+    }
+
+    private data class AdapterConfig(
+        val throwException: Boolean,
+        val primitiveWrapperDefaults: Boolean
+    ) {
+        companion object {
+            fun fromParameters(parameters: String?): AdapterConfig {
+                var throwException = false
+                var primitiveWrapperDefaults = false
+
+                parameters
+                    ?.split(',')
+                    ?.map { it.trim() }
+                    ?.filter { it.isNotEmpty() }
+                    ?.forEach { pair ->
+                        val parts = pair.split('=', limit = 2)
+                        val name = parts.getOrNull(0)?.trim()
+                        val value = parts.getOrNull(1)?.trim()?.removeSurrounding("\"")
+
+                        when (name) {
+                            "throw" -> throwException = value.equals("true", ignoreCase = true)
+                            "primitiveWrapperReturns" -> primitiveWrapperDefaults = value
+                                ?.substringAfterLast('.')
+                                ?.equals("DEFAULT", ignoreCase = true)
+                                ?: false
+                        }
+                    }
+
+                return AdapterConfig(throwException, primitiveWrapperDefaults)
+            }
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,7 +273,7 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Adapter") {
             example("PseudoAnnotationsMainTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }

--- a/test/com/intellij/advancedExpressionFolding/AdapterAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/AdapterAnnotationCompletionContributorTest.kt
@@ -1,0 +1,219 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.application.ApplicationManager
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class AdapterAnnotationCompletionContributorTest : BaseTest() {
+
+    companion object {
+        private var originalPseudoAnnotationsValue: Boolean = false
+
+        @JvmStatic
+        fun testCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                TestCase(
+                    name = "Interface Basic",
+                    input = """
+                        @<caret>
+                        public interface ClickListener {
+                            void onClick();
+                            void onValue(Integer value, boolean flag, long id);
+                        }
+                    """.trimIndent(),
+                    expected = """
+                    public interface ClickListener {
+                        void onClick();
+                        void onValue(Integer value, boolean flag, long id);
+                    }
+
+                    public class ClickListenerAdapter implements ClickListener {
+                        @Override
+                        public void onClick() {
+                        }
+
+                        @Override
+                        public void onValue(Integer value, boolean flag, long id) {
+                        }
+                    }
+                    """.trimIndent()
+                )
+            ),
+            Arguments.of(
+                TestCase(
+                    name = "Throwing Implementation",
+                    input = """
+                        @Adapter(throw = true)
+                        @<caret>
+                        public interface Worker {
+                            int compute();
+                            String describe() throws Exception;
+                        }
+                    """.trimIndent(),
+                    expected = """
+                    public interface Worker {
+                        int compute();
+                        String describe() throws Exception;
+                    }
+
+                    public class WorkerAdapter implements Worker {
+                        @Override
+                        public int compute() {
+                            throw new UnsupportedOperationException();
+                        }
+
+                        @Override
+                        public String describe() throws Exception {
+                            throw new UnsupportedOperationException();
+                        }
+                    }
+                    """.trimIndent()
+                )
+            ),
+            Arguments.of(
+                TestCase(
+                    name = "Primitive Wrapper Defaults",
+                    input = """
+                        @Adapter(primitiveWrapperReturns = DEFAULT)
+                        @<caret>
+                        public interface ValueProvider {
+                            Boolean flag();
+                            Long count();
+                            Double rate();
+                            Character marker();
+                        }
+                    """.trimIndent(),
+                    expected = """
+                    public interface ValueProvider {
+                        Boolean flag();
+                        Long count();
+                        Double rate();
+                        Character marker();
+                    }
+
+                    public class ValueProviderAdapter implements ValueProvider {
+                        @Override
+                        public Boolean flag() {
+                            return false;
+                        }
+
+                        @Override
+                        public Long count() {
+                            return 0L;
+                        }
+
+                        @Override
+                        public Double rate() {
+                            return 0.0d;
+                        }
+
+                        @Override
+                        public Character marker() {
+                            return '\0';
+                        }
+                    }
+                    """.trimIndent()
+                )
+            ),
+            Arguments.of(
+                TestCase(
+                    name = "Abstract Class",
+                    input = """
+                        @<caret>
+                        public abstract class Processor<T> {
+                            public abstract T transform(String value);
+                            protected abstract int cost();
+                        }
+                    """.trimIndent(),
+                    expected = """
+                    public abstract class Processor<T> {
+                        public abstract T transform(String value);
+                        protected abstract int cost();
+                    }
+
+                    public class ProcessorAdapter<T> extends Processor<T> {
+                        @Override
+                        public T transform(String value) {
+                            return null;
+                        }
+
+                        @Override
+                        protected int cost() {
+                            return 0;
+                        }
+                    }
+                    """.trimIndent()
+                )
+            )
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        originalPseudoAnnotationsValue = settings.state.pseudoAnnotations
+        settings.state.pseudoAnnotations = true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.state.pseudoAnnotations = originalPseudoAnnotationsValue
+    }
+
+    @Test
+    fun `should offer @Adapter in completion for annotation above type`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                @<caret>
+                public interface Demo {
+                    void run();
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+        assertTrue(completions.any { it.lookupString == "Adapter" })
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    fun `should generate adapter when selecting @Adapter from completion`(testCase: TestCase) {
+        fixture.configureByText("Test.java", testCase.input)
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val adapterCompletion = completions.find { it.lookupString == "Adapter" }
+        assertNotNull(adapterCompletion)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = adapterCompletion
+            fixture.finishLookup('\n')
+        }
+
+        val actual = fixture.file.text
+        assertEquals(testCase.expected, actual)
+    }
+
+    data class TestCase(
+        val name: String,
+        @param:Language("JAVA") val input: String,
+        @param:Language("JAVA") val expected: String
+    ) {
+        override fun toString(): String = name
+    }
+}

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -277,10 +277,10 @@ Simplifies constructor references and inline field initialization.
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/methodDefaultParameters)
 
 ## pseudoAnnotations
-### Pseudo-annotations for main method generation
-Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
-- [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+### Pseudo-annotations for main methods and adapter scaffolding
+Provides pseudo-annotations like @Main and @Adapter that scaffold boilerplate for testing and listener implementations.
+- [Examples](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java), [Adapter](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsAdapterTestData.java)
+- [Tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt), [Adapter](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/AdapterAnnotationCompletionContributorTest.kt)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/pseudoAnnotations)
 
 ## overrideHide

--- a/wiki-clone/docs/features/pseudoAnnotations.md
+++ b/wiki-clone/docs/features/pseudoAnnotations.md
@@ -75,3 +75,90 @@ public class Person {
 - The generated main method is fully functional and can be run immediately
 - Only works when `pseudoAnnotations` setting is enabled
 - Designed for rapid prototyping and testing
+
+### @Adapter
+
+Generates a default adapter implementation for interfaces and abstract classes so you can override only the methods you care about.
+
+#### How it works:
+1. **Completion trigger**: Type `@Adapter` above an interface or abstract class to see the completion suggestion
+2. **Class generation**: Selecting `@Adapter` creates a sibling `<TypeName>Adapter` class that implements or extends the annotated type
+3. **Method stubs**: Every abstract method is overridden with a stub that either returns default values or throws
+4. **Cleanup**: The pseudo-annotation is removed after generation and existing adapter classes with the same name are replaced
+
+#### Configuration options:
+- `@Adapter(throw = true)` – Generates bodies that throw `UnsupportedOperationException`
+- `@Adapter(primitiveWrapperReturns = DEFAULT)` – Returns default primitive values for wrapper types (e.g., `Integer` → `0`)
+
+#### Return value defaults:
+- Primitives (`boolean`, `int`, `long`, etc.) → Same defaults as the language (`false`, `0`, `0L`, `0.0f`, `0.0d`)
+- Primitive wrappers (`Boolean`, `Integer`, etc.) → `null` unless `primitiveWrapperReturns = DEFAULT` is set
+- Other reference types → `null`
+- `void` methods → Empty body
+
+#### Example:
+```java
+@Adapter(primitiveWrapperReturns = DEFAULT)
+public interface ChangeListener {
+    void onCreated();
+    Integer onUpdated();
+}
+```
+
+After accepting the completion:
+
+```java
+public interface ChangeListener {
+    void onCreated();
+    Integer onUpdated();
+}
+
+public class ChangeListenerAdapter implements ChangeListener {
+
+    @Override
+    public void onCreated() {
+    }
+
+    @Override
+    public Integer onUpdated() {
+        return 0;
+    }
+}
+```
+
+You can also combine flags. The snippet below generates stubs that both throw and return wrapper defaults:
+
+```java
+@Adapter(throw = true, primitiveWrapperReturns = DEFAULT)
+public abstract class SafeProcessor {
+    public abstract Integer execute();
+    protected abstract boolean enabled();
+}
+```
+
+After completion the adapter looks like this:
+
+```java
+public abstract class SafeProcessor {
+    public abstract Integer execute();
+    protected abstract boolean enabled();
+}
+
+public class SafeProcessorAdapter extends SafeProcessor {
+
+    @Override
+    public Integer execute() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean enabled() {
+        throw new UnsupportedOperationException();
+    }
+}
+```
+
+#### Notes:
+- Works for both interfaces and abstract classes
+- Generated classes inherit generic type parameters from the source type
+- Only available when the `pseudoAnnotations` setting is enabled


### PR DESCRIPTION
## Summary
- add an Adapter pseudo-annotation completion contributor that scaffolds adapter classes with configurable defaults
- register the contributor, expose it via settings, docs, and examples, and cover it with targeted tests
- expand the pseudo-annotation documentation with a combined flag example for throw + wrapper defaults

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68eec3894474832eaaf63e39baa24683