### PR TITLE
Expand @Visitor completion to entire hierarchies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 - Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+- [pseudo-annotations] Introduce @Visitor to generate visitor interfaces and accept methods
 
 ## [4.2.0] - 2025-09-20
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For more information, read the [blog post](https://medium.com/@andrey_cheptsov/m
 
 ## Unreleased ##
 
+- [[pseudo-annotations] @Visitor - class-level annotation that injects visitor boilerplate and updates the target interface.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
+
 ## 4.2.0 ##
 - [Add setting to prevent collapsing Java text blocks in log folding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/338)
 - [Bugfix/log folding strings no params](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/341)

--- a/examples/data/PseudoAnnotationsVisitorTestData.java
+++ b/examples/data/PseudoAnnotationsVisitorTestData.java
@@ -1,0 +1,25 @@
+package data;
+
+interface Visitor {
+    void visit(Shape shape);
+    void visit(Circle circle);
+    void visit(Rectangle rectangle);
+}
+
+abstract class Shape {
+    public abstract void accept(Visitor visitor);
+}
+
+class Circle extends Shape {
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}
+
+class Rectangle extends Shape {
+    @Override
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,10 +36,13 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
-        <!-- Suggests the pseudo-annotation @Main used by the plugin -->
+        <!-- Suggests the pseudo-annotations used by the plugin -->
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.VisitorAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/VisitorAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/VisitorAnnotationCompletionContributor.kt
@@ -1,0 +1,196 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IState
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.PsiClassObjectAccessExpression
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.search.searches.ClassInheritorsSearch
+import com.intellij.util.ProcessingContext
+
+class VisitorAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(), IState by state {
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement(PsiIdentifier::class.java)
+                .withParent(PsiJavaCodeReferenceElement::class.java)
+                .withSuperParent(2, PsiAnnotation::class.java)
+                .withSuperParent(3, com.intellij.psi.PsiModifierList::class.java)
+                .withSuperParent(4, PsiClass::class.java),
+            object : CompletionProvider<CompletionParameters>() {
+                override fun addCompletions(
+                    parameters: CompletionParameters,
+                    context: ProcessingContext,
+                    result: CompletionResultSet
+                ) {
+                    if (!pseudoAnnotations) return
+
+                    val lookup = LookupElementBuilder.create("Visitor")
+                        .withLookupString("@Visitor")
+                        .withPresentableText("@Visitor")
+                        .withInsertHandler { ctx, _ ->
+                            handleVisitorInsert(ctx)
+                        }
+                        .withAutoCompletionPolicy(AutoCompletionPolicy.NEVER_AUTOCOMPLETE)
+
+                    result.addElement(lookup)
+                }
+            }
+        )
+    }
+
+    private fun handleVisitorInsert(ctx: InsertionContext) {
+        val file = ctx.file
+        val project = file.project
+        val document = ctx.document
+        val elementAtStart = file.findElementAt(ctx.startOffset) ?: return
+        val annotation = PsiTreeUtil.getParentOfType(elementAtStart, PsiAnnotation::class.java, false) ?: return
+        val ownerClass = PsiTreeUtil.getParentOfType(annotation, PsiClass::class.java, false) ?: return
+        val annotationOffset = annotation.textOffset
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            val insertion = "(Visitor.class)"
+            document.insertString(ctx.tailOffset, insertion)
+            PsiDocumentManager.getInstance(project).commitDocument(document)
+
+            val refreshedAnnotation = PsiTreeUtil.getParentOfType(file.findElementAt(annotationOffset), PsiAnnotation::class.java, false)
+                ?: return@runWriteCommandAction
+
+            val elementFactory = JavaPsiFacade.getElementFactory(project)
+            val (visitorType, visitorClass) = findVisitorTarget(refreshedAnnotation, elementFactory) ?: run {
+                refreshedAnnotation.delete()
+                return@runWriteCommandAction
+            }
+            refreshedAnnotation.delete()
+
+            val hierarchy = collectHierarchy(ownerClass)
+
+            hierarchy.forEachIndexed { index, elementClass ->
+                val shouldAnnotateOverride = index != 0
+                ensureAcceptMethod(
+                    elementClass,
+                    visitorType,
+                    visitorClass,
+                    elementFactory,
+                    shouldAnnotateOverride
+                )
+                ensureVisitMethod(visitorClass, elementClass, elementFactory)
+            }
+        }
+    }
+
+    private fun collectHierarchy(root: PsiClass): List<PsiClass> {
+        val inheritors = ClassInheritorsSearch.search(root, root.useScope, true)
+            .toList()
+            .sortedBy { it.qualifiedName ?: it.name ?: "" }
+        return listOf(root) + inheritors
+    }
+
+    private fun resolveVisitorType(annotation: PsiAnnotation): PsiClassType? {
+        val attribute = annotation.parameterList.attributes.firstOrNull()?.value as? PsiClassObjectAccessExpression ?: return null
+        val type = attribute.operand.type
+        return type as? PsiClassType
+    }
+
+    private fun findVisitorTarget(annotation: PsiAnnotation, elementFactory: PsiElementFactory): Pair<PsiClassType, PsiClass>? {
+        val resolvedType = resolveVisitorType(annotation)
+        val resolvedClass = resolvedType?.resolve()
+        if (resolvedClass != null && resolvedClass.isInterface) {
+            return elementFactory.createType(resolvedClass) to resolvedClass
+        }
+
+        val file = annotation.containingFile ?: return null
+        val candidate = PsiTreeUtil.findChildrenOfType(file, PsiClass::class.java)
+            .filter { it.isInterface }
+            .minWithOrNull(
+                compareBy<PsiClass> { it.name != "Visitor" }
+                    .thenBy { !(it.name?.endsWith("Visitor") ?: false) }
+                    .thenBy { it.name ?: it.qualifiedName ?: "" }
+            )
+            ?: return null
+
+        return elementFactory.createType(candidate) to candidate
+    }
+
+    private fun ensureAcceptMethod(
+        ownerClass: PsiClass,
+        visitorType: PsiClassType,
+        visitorClass: PsiClass,
+        elementFactory: PsiElementFactory,
+        shouldAnnotateOverride: Boolean
+    ) {
+        val existing = ownerClass.findMethodsByName("accept", false).firstOrNull { method ->
+            val parameters = method.parameterList.parameters
+            parameters.size == 1 && parameters[0].type.canonicalText == visitorType.canonicalText
+        }
+        if (existing != null) return
+
+        val parameterName = StringUtil.decapitalize(visitorClass.name ?: "visitor").ifEmpty { "visitor" }
+        val methodText = when {
+            ownerClass.isInterface -> "void accept(${visitorType.presentableText} $parameterName);"
+            ownerClass.hasModifierProperty(PsiModifier.ABSTRACT) -> "public abstract void accept(${visitorType.presentableText} $parameterName);"
+            else -> buildString {
+                if (shouldAnnotateOverride) {
+                    append("@Override\n")
+                }
+                append("public void accept(")
+                append(visitorType.presentableText)
+                append(' ')
+                append(parameterName)
+                append(") {\n")
+                append("    ")
+                append(parameterName)
+                append(".visit(this);\n")
+                append('}')
+            }
+        }
+
+        val method = elementFactory.createMethodFromText(methodText, ownerClass)
+        val added = ownerClass.add(method) as PsiMethod
+        JavaCodeStyleManager.getInstance(ownerClass.project).shortenClassReferences(added)
+        CodeStyleManager.getInstance(ownerClass.project).reformat(added)
+    }
+
+    private fun ensureVisitMethod(
+        visitorInterface: PsiClass,
+        elementClass: PsiClass,
+        elementFactory: PsiElementFactory
+    ) {
+        val elementType = elementFactory.createType(elementClass)
+        val alreadyExists = visitorInterface.findMethodsByName("visit", false).any { method ->
+            val parameters = method.parameterList.parameters
+            parameters.size == 1 && parameters[0].type.canonicalText == elementType.canonicalText
+        }
+        if (alreadyExists) return
+
+        val parameterName = StringUtil.decapitalize(elementClass.name ?: "element").ifEmpty { "element" }
+        val methodText = "void visit(${elementType.presentableText} $parameterName);"
+
+        val method = elementFactory.createMethodFromText(methodText, visitorInterface)
+        val added = visitorInterface.add(method) as PsiMethod
+        JavaCodeStyleManager.getInstance(visitorInterface.project).shortenClassReferences(added)
+        CodeStyleManager.getInstance(visitorInterface.project).reformat(added)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,8 +273,9 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Visitor") {
             example("PseudoAnnotationsMainTestData.java")
+            example("PseudoAnnotationsVisitorTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
         // NEW OPTION

--- a/test/com/intellij/advancedExpressionFolding/VisitorAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/VisitorAnnotationCompletionContributorTest.kt
@@ -1,0 +1,194 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.application.ApplicationManager
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class VisitorAnnotationCompletionContributorTest : BaseTest() {
+
+    private var originalPseudoAnnotationsValue: Boolean = false
+
+    @BeforeEach
+    fun setUp() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        originalPseudoAnnotationsValue = settings.state.pseudoAnnotations
+        settings.state.pseudoAnnotations = true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.state.pseudoAnnotations = originalPseudoAnnotationsValue
+    }
+
+    @Test
+    fun `should offer @Visitor in completion for annotation above class`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                interface Visitor {
+                }
+
+                @<caret>
+                class ConcreteElement {
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+        assertTrue(completions.any { it.lookupString == "Visitor" })
+    }
+
+    @Test
+    fun `should generate visitor boilerplate when selecting @Visitor from completion`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                interface Visitor {
+                }
+
+                @<caret>
+                class ConcreteElement {
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val visitorCompletion = completions.find { it.lookupString == "Visitor" }
+        assertNotNull(visitorCompletion)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = visitorCompletion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                interface Visitor {
+                    void visit(ConcreteElement concreteElement);
+                }
+
+                class ConcreteElement {
+                    public void accept(Visitor visitor) {
+                        visitor.visit(this);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should not duplicate accept or visit methods when already present`() {
+        fixture.configureByText(
+            "Test.java",
+            @Language("JAVA") """
+                interface Visitor {
+                    void visit(ConcreteElement concreteElement);
+                }
+
+                @<caret>
+                class ConcreteElement {
+                    public void accept(Visitor visitor) {
+                        visitor.visit(this);
+                    }
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val visitorCompletion = completions.find { it.lookupString == "Visitor" }
+        assertNotNull(visitorCompletion)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = visitorCompletion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                interface Visitor {
+                    void visit(ConcreteElement concreteElement);
+                }
+
+                class ConcreteElement {
+                    public void accept(Visitor visitor) {
+                        visitor.visit(this);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `should update entire hierarchy when base class is annotated`() {
+        fixture.configureByText(
+            "Hierarchy.java",
+            @Language("JAVA") """
+                interface Visitor {
+                }
+
+                @<caret>
+                abstract class Shape {
+                }
+
+                class Circle extends Shape {
+                }
+
+                class Rectangle extends Shape {
+                }
+            """.trimIndent()
+        )
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val visitorCompletion = completions.find { it.lookupString == "Visitor" }
+        assertNotNull(visitorCompletion)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = visitorCompletion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(
+            @Language("JAVA") """
+                interface Visitor {
+                    void visit(Shape shape);
+
+                    void visit(Circle circle);
+
+                    void visit(Rectangle rectangle);
+                }
+
+                abstract class Shape {
+                    public abstract void accept(Visitor visitor);
+                }
+
+                class Circle extends Shape {
+                    @Override
+                    public void accept(Visitor visitor) {
+                        visitor.visit(this);
+                    }
+                }
+
+                class Rectangle extends Shape {
+                    @Override
+                    public void accept(Visitor visitor) {
+                        visitor.visit(this);
+                    }
+                }
+            """.trimIndent()
+        )
+    }
+}

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -277,10 +277,12 @@ Simplifies constructor references and inline field initialization.
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/methodDefaultParameters)
 
 ## pseudoAnnotations
-### Pseudo-annotations for main method generation
-Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
-- [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+### Pseudo-annotations for rapid method and visitor scaffolding
+Provides pseudo-annotations like @Main and @Visitor that automatically generate runnable entry points and visitor boilerplate.
+- [@Main example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
+- [@Visitor example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsVisitorTestData.java)
+- [@Main test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+- [@Visitor test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/VisitorAnnotationCompletionContributorTest.kt)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/pseudoAnnotations)
 
 ## overrideHide

--- a/wiki-clone/docs/features/pseudoAnnotations.md
+++ b/wiki-clone/docs/features/pseudoAnnotations.md
@@ -75,3 +75,51 @@ public class Person {
 - The generated main method is fully functional and can be run immediately
 - Only works when `pseudoAnnotations` setting is enabled
 - Designed for rapid prototyping and testing
+
+### @Visitor
+
+Generates visitor pattern boilerplate by wiring `accept` methods on the annotated elements and adding matching `visit` signatures to the designated visitor interface.
+
+#### How it works:
+1. **Interface placeholder**: Create an empty visitor interface up front (for example `interface ShapeVisitor { }`).
+2. **Annotate elements**: Type `@Visitor(ShapeVisitor.class)` above every class that should participate in the visitor pattern.
+3. **Auto-generation**: Selecting `@Visitor` from completion removes the pseudo-annotation, creates `accept(ShapeVisitor visitor)` calling `visitor.visit(this)`, and injects `void visit(ClassName element);` into the target interface.
+
+#### Code example:
+```java
+interface ShapeVisitor {
+}
+
+@Visitor(ShapeVisitor.class)
+class Circle {
+}
+
+@Visitor(ShapeVisitor.class)
+class Rectangle {
+}
+```
+
+After accepting the completion for each class:
+```java
+interface ShapeVisitor {
+    void visit(Circle circle);
+    void visit(Rectangle rectangle);
+}
+
+class Circle {
+    public void accept(ShapeVisitor visitor) {
+        visitor.visit(this);
+    }
+}
+
+class Rectangle {
+    public void accept(ShapeVisitor visitor) {
+        visitor.visit(this);
+    }
+}
+```
+
+#### Notes:
+- The visitor interface must already exist so the generator can append the `visit` methods.
+- Existing `accept` and `visit` methods are respected and never duplicated.
+- Works when the `pseudoAnnotations` option is enabled in settings.


### PR DESCRIPTION
## Summary
- update the visitor completion to walk the whole class hierarchy, generating accept overrides and visitor methods with a fallback when the annotation lacks a class literal
- add a regression test covering an abstract base plus subclasses to ensure the visitor boilerplate is emitted everywhere
- refresh the pseudo-annotation example to illustrate the new hierarchy-aware visitor output

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68eec471a378832ea0c893eacbb9b90a