### PR TITLE
Add @Observator pseudo-annotation completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 
 - Add compatibility with IntelliJ IDEA 2025.3 EAP (253.20558.43)
+- [pseudo-annotations] Add @Observator helper generation for observable fields
 
 ## [4.2.0] - 2025-09-20
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Fork of abandoned [Advanced Java Folding](https://plugins.jetbrains.com/plugin/9
 For more information, read the [blog post](https://medium.com/@andrey_cheptsov/making-java-code-easier-to-read-without-changing-it-adeebd5c36de).
 
 ## Unreleased ##
+- [[pseudo-annotations] @Observator - field-level annotation that scaffolds property-change listeners.](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/PseudoAnnotations)
 
 ## 4.2.0 ##
 - [Add setting to prevent collapsing Java text blocks in log folding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/338)

--- a/examples/data/PseudoAnnotationsObservatorTestData.java
+++ b/examples/data/PseudoAnnotationsObservatorTestData.java
@@ -1,0 +1,7 @@
+package data;
+
+public class PseudoAnnotationsObservatorTestData {
+
+    private int counter;
+    private String status;
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,10 +36,13 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
-        <!-- Suggests the pseudo-annotation @Main used by the plugin -->
+        <!-- Suggests pseudo-annotations used by the plugin -->
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributor"/>
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.intellij.advancedExpressionFolding.ObservatorAnnotationCompletionContributor"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/ObservatorAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/ObservatorAnnotationCompletionContributor.kt
@@ -1,0 +1,200 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IState
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiModifierList
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.codeStyle.CodeStyleManager
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+
+class ObservatorAnnotationCompletionContributor(
+    private val state: IState = getInstance().state
+) : CompletionContributor(), IState by state {
+
+    init {
+        val annotationContext = PlatformPatterns.psiElement(PsiIdentifier::class.java)
+            .withParent(PsiJavaCodeReferenceElement::class.java)
+            .withSuperParent(2, PsiAnnotation::class.java)
+            .withSuperParent(3, PsiModifierList::class.java)
+
+        extend(CompletionType.BASIC, annotationContext, ObservatorCompletionProvider())
+    }
+
+    private inner class ObservatorCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            parameters: CompletionParameters,
+            context: ProcessingContext,
+            result: CompletionResultSet
+        ) {
+            if (!pseudoAnnotations) return
+
+            val annotation = PsiTreeUtil.getParentOfType(parameters.position, PsiAnnotation::class.java, false) ?: return
+            val modifierList = PsiTreeUtil.getParentOfType(annotation, PsiModifierList::class.java, false) ?: return
+            val owner = modifierList.parent
+            if (owner !is PsiField && owner !is PsiClass) return
+
+            val lookup = LookupElementBuilder.create("Observator")
+                .withLookupString("@Observator")
+                .withPresentableText("@Observator")
+                .withInsertHandler { ctx, _ ->
+                    handleInsert(ctx)
+                }
+                .withAutoCompletionPolicy(AutoCompletionPolicy.NEVER_AUTOCOMPLETE)
+
+            result.addElement(lookup)
+        }
+    }
+
+    private fun handleInsert(ctx: com.intellij.codeInsight.completion.InsertionContext) {
+        val project = ctx.project
+        val element = ctx.file.findElementAt(ctx.startOffset) ?: return
+        val annotation = PsiTreeUtil.getParentOfType(element, PsiAnnotation::class.java, false) ?: return
+        val modifierList = PsiTreeUtil.getParentOfType(annotation, PsiModifierList::class.java, false) ?: return
+        val owner = modifierList.parent as? PsiModifierListOwner ?: return
+
+        val targetClass = when (owner) {
+            is PsiField -> owner.containingClass
+            is PsiClass -> owner
+            else -> null
+        } ?: return
+
+        val targetFields = when (owner) {
+            is PsiField -> listOf(owner)
+            is PsiClass -> owner.fields.toList()
+            else -> emptyList()
+        }.filterNot { field ->
+            field.hasModifierProperty(PsiModifier.STATIC) || field.hasModifierProperty(PsiModifier.FINAL)
+        }
+
+        if (targetFields.isEmpty()) {
+            WriteCommandAction.runWriteCommandAction(project) {
+                removeAnnotation(annotation)
+            }
+            return
+        }
+
+        WriteCommandAction.runWriteCommandAction(project) {
+            removeAnnotation(annotation)
+            val elementFactory = JavaPsiFacade.getElementFactory(project)
+
+            val addedElements = mutableListOf<com.intellij.psi.PsiElement>()
+            ensureSupportField(targetClass, elementFactory)?.let(addedElements::add)
+
+            var caretTarget: com.intellij.psi.PsiElement? = null
+            targetFields.forEach { field ->
+                ensureObservationMethods(targetClass, field, elementFactory).let { generated ->
+                    addedElements += generated
+                    if (caretTarget == null) {
+                        caretTarget = generated.firstOrNull { it is PsiMethod && it.name.startsWith("set") }
+                    }
+                }
+            }
+
+            val codeStyleManager = CodeStyleManager.getInstance(project)
+            addedElements.forEach { element ->
+                codeStyleManager.reformat(element)
+            }
+            JavaCodeStyleManager.getInstance(project).shortenClassReferences(targetClass)
+
+            val caretElement = caretTarget ?: addedElements.firstOrNull()
+            caretElement?.textOffset?.let { offset ->
+                PsiDocumentManager.getInstance(project).doPostponedOperationsAndUnblockDocument(ctx.document)
+                ctx.editor.caretModel.moveToOffset(offset)
+            }
+        }
+    }
+
+    private fun ensureSupportField(psiClass: PsiClass, elementFactory: PsiElementFactory): PsiField? {
+        val existing = psiClass.fields.firstOrNull { it.name == OBSERVATOR_SUPPORT_FIELD }
+        if (existing != null) return null
+
+        val fieldText = "private final java.beans.PropertyChangeSupport $OBSERVATOR_SUPPORT_FIELD = new java.beans.PropertyChangeSupport(this);"
+        val field = elementFactory.createFieldFromText(fieldText, psiClass)
+        return psiClass.add(field) as? PsiField
+    }
+
+    private fun ensureObservationMethods(
+        psiClass: PsiClass,
+        field: PsiField,
+        elementFactory: PsiElementFactory
+    ): List<com.intellij.psi.PsiElement> {
+        val generatedElements = mutableListOf<com.intellij.psi.PsiElement>()
+        val fieldName = field.name ?: return generatedElements
+        val capitalized = fieldName.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        val typeText = field.type.presentableText
+
+        val setterName = "set$capitalized"
+        if (!hasSetter(psiClass, setterName)) {
+            val setterText = """
+                public void $setterName($typeText $fieldName) {
+                    $typeText oldValue = this.$fieldName;
+                    this.$fieldName = $fieldName;
+                    $OBSERVATOR_SUPPORT_FIELD.firePropertyChange("$fieldName", oldValue, $fieldName);
+                }
+            """.trimIndent()
+            val setter = elementFactory.createMethodFromText(setterText, psiClass)
+            generatedElements += psiClass.add(setter)
+        }
+
+        val addListenerName = "add${capitalized}Listener"
+        if (!hasMethod(psiClass, addListenerName)) {
+            val addListenerText = """
+                public void $addListenerName(java.beans.PropertyChangeListener listener) {
+                    $OBSERVATOR_SUPPORT_FIELD.addPropertyChangeListener("$fieldName", listener);
+                }
+            """.trimIndent()
+            generatedElements += psiClass.add(elementFactory.createMethodFromText(addListenerText, psiClass))
+        }
+
+        val removeListenerName = "remove${capitalized}Listener"
+        if (!hasMethod(psiClass, removeListenerName)) {
+            val removeListenerText = """
+                public void $removeListenerName(java.beans.PropertyChangeListener listener) {
+                    $OBSERVATOR_SUPPORT_FIELD.removePropertyChangeListener("$fieldName", listener);
+                }
+            """.trimIndent()
+            generatedElements += psiClass.add(elementFactory.createMethodFromText(removeListenerText, psiClass))
+        }
+
+        return generatedElements
+    }
+
+    private fun hasSetter(psiClass: PsiClass, setterName: String): Boolean {
+        return psiClass.findMethodsByName(setterName, false).any { method ->
+            method.parameterList.parametersCount == 1
+        }
+    }
+
+    private fun hasMethod(psiClass: PsiClass, methodName: String): Boolean {
+        return psiClass.findMethodsByName(methodName, false).isNotEmpty()
+    }
+
+    private fun removeAnnotation(annotation: PsiAnnotation) {
+        annotation.delete()
+    }
+
+    companion object {
+        private const val OBSERVATOR_SUPPORT_FIELD = "observatorSupport"
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -273,7 +273,7 @@ abstract class CheckboxesProvider {
             example("SuppressWarningsHideTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#suppressWarningsHide")
         }
-        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main") {
+        registerCheckbox(state::pseudoAnnotations, "Pseudo-annotations: @Main, @Observator") {
             example("PseudoAnnotationsMainTestData.java")
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }

--- a/test/com/intellij/advancedExpressionFolding/ObservatorAnnotationCompletionContributorTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/ObservatorAnnotationCompletionContributorTest.kt
@@ -1,0 +1,156 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.openapi.application.ApplicationManager
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class ObservatorAnnotationCompletionContributorTest : BaseTest() {
+
+    companion object {
+        private var originalPseudoAnnotationsValue: Boolean = false
+
+        @JvmStatic
+        fun testCases(): Stream<Arguments> = Stream.of(
+            Arguments.of(TestCase(
+                name = "Single Field",
+                input = """
+                    public class Test {
+                        @<caret>
+                        private String name;
+                    }
+                """.trimIndent(),
+                expected = """
+                public class Test {
+                    private final java.beans.PropertyChangeSupport observatorSupport = new java.beans.PropertyChangeSupport(this);
+
+                    private String name;
+
+                    public void setName(String name) {
+                        String oldValue = this.name;
+                        this.name = name;
+                        observatorSupport.firePropertyChange("name", oldValue, name);
+                    }
+
+                    public void addNameListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.addPropertyChangeListener("name", listener);
+                    }
+
+                    public void removeNameListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.removePropertyChangeListener("name", listener);
+                    }
+                }
+                """.trimIndent()
+            )),
+            Arguments.of(TestCase(
+                name = "Class Level",
+                input = """
+                    @<caret>
+                    public class Test {
+                        private int count;
+                        private String description;
+                    }
+                """.trimIndent(),
+                expected = """
+                public class Test {
+                    private final java.beans.PropertyChangeSupport observatorSupport = new java.beans.PropertyChangeSupport(this);
+
+                    private int count;
+                    private String description;
+
+                    public void setCount(int count) {
+                        int oldValue = this.count;
+                        this.count = count;
+                        observatorSupport.firePropertyChange("count", oldValue, count);
+                    }
+
+                    public void addCountListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.addPropertyChangeListener("count", listener);
+                    }
+
+                    public void removeCountListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.removePropertyChangeListener("count", listener);
+                    }
+
+                    public void setDescription(String description) {
+                        String oldValue = this.description;
+                        this.description = description;
+                        observatorSupport.firePropertyChange("description", oldValue, description);
+                    }
+
+                    public void addDescriptionListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.addPropertyChangeListener("description", listener);
+                    }
+
+                    public void removeDescriptionListener(java.beans.PropertyChangeListener listener) {
+                        observatorSupport.removePropertyChangeListener("description", listener);
+                    }
+                }
+                """.trimIndent()
+            ))
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        originalPseudoAnnotationsValue = settings.state.pseudoAnnotations
+        settings.state.pseudoAnnotations = true
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val settings = AdvancedExpressionFoldingSettings.getInstance()
+        settings.state.pseudoAnnotations = originalPseudoAnnotationsValue
+    }
+
+    @Test
+    fun `should offer @Observator in completion for field`() {
+        fixture.configureByText("Test.java", @Language("JAVA") """
+            public class Test {
+                @<caret>
+                private int count;
+            }
+        """.trimIndent())
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+        assertTrue(completions.any { it.lookupString == "Observator" })
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    fun `should generate observation helpers when selecting @Observator`(testCase: TestCase) {
+        fixture.configureByText("Test.java", testCase.input)
+
+        val completions = fixture.complete(CompletionType.BASIC)
+        assertNotNull(completions)
+
+        val completion = completions.find { it.lookupString == "Observator" }
+        assertNotNull(completion)
+
+        ApplicationManager.getApplication().invokeAndWait {
+            fixture.lookup.currentItem = completion
+            fixture.finishLookup('\n')
+        }
+
+        fixture.checkResult(testCase.expected)
+    }
+
+    data class TestCase(
+        val name: String,
+        @param:Language("JAVA") val input: String,
+        @param:Language("JAVA") val expected: String
+    ) {
+        override fun toString(): String = name
+    }
+}

--- a/wiki-clone/Home.md
+++ b/wiki-clone/Home.md
@@ -277,10 +277,11 @@ Simplifies constructor references and inline field initialization.
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/methodDefaultParameters)
 
 ## pseudoAnnotations
-### Pseudo-annotations for main method generation
-Provides pseudo-annotations like @Main that automatically generate main methods for testing and prototyping.
-- [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
-- [Test](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding/MainAnnotationCompletionContributorTest.kt)
+### Pseudo-annotations for quick scaffolding helpers
+Provides pseudo-annotations like @Main and @Observator that generate boilerplate helpers for rapid prototyping.
+- [Example - Main](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsMainTestData.java)
+- [Example - Observator](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/PseudoAnnotationsObservatorTestData.java)
+- [Tests](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/test/com/intellij/advancedExpressionFolding)
 - [Documentation](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/pseudoAnnotations)
 
 ## overrideHide

--- a/wiki-clone/docs/features/pseudoAnnotations.md
+++ b/wiki-clone/docs/features/pseudoAnnotations.md
@@ -75,3 +75,51 @@ public class Person {
 - The generated main method is fully functional and can be run immediately
 - Only works when `pseudoAnnotations` setting is enabled
 - Designed for rapid prototyping and testing
+
+### @Observator
+
+Scaffolds property-change helpers for fields to make it easy to observe updates in plain Java classes.
+
+#### How it works:
+1. **Completion trigger**: Type `@Observator` above a field or at the class declaration to see completion suggestion.
+2. **Support field**: Injects a `java.beans.PropertyChangeSupport` instance named `observatorSupport` if missing.
+3. **Setter generation**: Produces a setter that fires a property-change event when the field value changes.
+4. **Listener helpers**: Adds `add<Field>Listener` and `remove<Field>Listener` methods that delegate to the support field.
+5. **Class annotation**: When used on the class, it applies the helpers to every non-static, non-final field.
+
+#### Code example:
+
+```java
+public class CounterViewModel {
+    private int count;
+}
+```
+
+After `@Observator` on the field:
+
+```java
+public class CounterViewModel {
+    private final java.beans.PropertyChangeSupport observatorSupport = new java.beans.PropertyChangeSupport(this);
+
+    private int count;
+
+    public void setCount(int count) {
+        int oldValue = this.count;
+        this.count = count;
+        observatorSupport.firePropertyChange("count", oldValue, count);
+    }
+
+    public void addCountListener(java.beans.PropertyChangeListener listener) {
+        observatorSupport.addPropertyChangeListener("count", listener);
+    }
+
+    public void removeCountListener(java.beans.PropertyChangeListener listener) {
+        observatorSupport.removePropertyChangeListener("count", listener);
+    }
+}
+```
+
+#### Notes:
+- The annotation is removed after generation just like a live template.
+- Existing setters or listener helpers are preserved and not duplicated.
+- Fields marked `static` or `final` are skipped when generating helpers.


### PR DESCRIPTION
## Summary
- add a completion contributor for the @Observator pseudo-annotation that scaffolds PropertyChangeSupport helpers for annotated fields or classes
- expose the new pseudo-annotation in plugin registration, settings copy, changelog, and documentation, and add an example file
- cover the behaviour with a dedicated completion contributor test suite

## Testing
- `./gradlew --no-daemon test --tests com.intellij.advancedExpressionFolding.ObservatorAnnotationCompletionContributorTest --tests com.intellij.advancedExpressionFolding.MainAnnotationCompletionContributorTest --console=plain` *(fails to complete in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef42b67558832e94d302dc5420aa8a