### PR TITLE
Refactor folding builder around hexagonal layers

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -1,118 +1,33 @@
 package com.intellij.advancedExpressionFolding
 
-import com.google.common.collect.Lists
-import com.google.common.collect.Sets
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.asInstance
-import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
-import com.intellij.advancedExpressionFolding.processor.cache.Keys
-import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.application.FoldingApplicationServiceFactory
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
 import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.FoldingGroup
-import com.intellij.openapi.project.IndexNotReadyException
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiJavaFile
 
-class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance().state) : FoldingBuilderEx(), IConfig by config {
+class AdvancedExpressionFoldingBuilder(
+    private val config: IConfig = getInstance().state,
+) : FoldingBuilderEx(), IConfig by config {
+
     override fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
-        if (!globalOn || isFoldingFile(element)) {
-            return store.store(Expression.EMPTY_ARRAY, document)
-        }
+        val service = FoldingApplicationServiceFactory.create(config)
         if (debugFolding) {
-            preview(element, document)
+            service.preview(element, document)
         }
-
-        val cachedDescriptors = when {
-            memoryImprovement -> readCache(element, quick, document)
-            else -> null
-        }
-        val foldingDescriptors = cachedDescriptors ?: collect(element, document)
-        if (memoryImprovement && !quick && cachedDescriptors !== foldingDescriptors) {
-            writeCache(element, foldingDescriptors)
-        }
-        return store.store(foldingDescriptors, document)
+        return service.buildFoldRegions(element, document, quick)
     }
 
-    private fun isFoldingFile(element: PsiElement) =
-        element.asInstance<PsiJavaFile>()?.name?.endsWith("-folded.java") == true
-
-    private fun readCache(
-        element: PsiElement,
-        quick: Boolean,
-        document: Document
-    ): Array<FoldingDescriptor>? {
-        if (!quick) {
-            (element as? PsiJavaFile)?.let { file ->
-                if (!file.invalidateExpired(document, false)) {
-                    return file.getUserData(Keys.FULL_CACHE)
-                }
-            }
-        }
-        return null
-    }
-
-    private fun writeCache(
-        element: PsiElement,
-        foldingDescriptors: Array<FoldingDescriptor>
-    ) {
-        (element as? PsiJavaFile)?.run {
-            putUserData(Keys.FULL_CACHE, foldingDescriptors)
-        }
-    }
-
-    fun preview(element: PsiElement, document: Document): List<String> {
-        val groupIds = Sets.newIdentityHashSet<FoldingGroup>()
-        return collect(element, document).map { descriptor ->
-            descriptor.group?.let(groupIds::add)
-            buildString {
-                append(descriptor.range.substring(document.text))
-                append(" => ")
-                append(descriptor.placeholderText)
-                append('[')
-                append(groupIds.size)
-                append("-")
-                append(descriptor.group?.run {
-                    toString().substringAfterLast(".")
-                } ?: "null")
-                append(']')
-            }
-        }
-    }
-
-    private fun collect(
-        element: PsiElement,
-        document: Document
-    ): Array<FoldingDescriptor> {
-        //TODO: default list size based on file size
-        val allDescriptors = Lists.newArrayListWithCapacity<FoldingDescriptor>(1_000)
-        BuildExpressionExt.collectFoldRegionsRecursively(element, document, Sets.newIdentityHashSet(), allDescriptors)
-        return allDescriptors.toTypedArray()
-    }
+    fun preview(element: PsiElement, document: Document): List<String> =
+        FoldingApplicationServiceFactory.create(config).preview(element, document)
 
     override fun getPlaceholderText(astNode: ASTNode) = null
 
-    // TODO: Collapse everything by default but use these settings when actually building the folding descriptors
-    override fun isCollapsedByDefault(astNode: ASTNode): Boolean {
-        try {
-            val element = astNode.psi
-            val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
-            document?.let {
-                val expression = BuildExpressionExt.getNonSyntheticExpression(element, it)
-                return expression?.isCollapsedByDefault() == true
-            }
-        } catch (_: IndexNotReadyException) {
-            return false
-        }
-        return false
-    }
+    override fun isCollapsedByDefault(astNode: ASTNode): Boolean =
+        FoldingApplicationServiceFactory.create(config).isCollapsedByDefault(astNode)
 
     private val debugFolding = false
 }
-
-var store: Storage = EmptyStorage

--- a/src/com/intellij/advancedExpressionFolding/adapter/cache/PsiFileFoldingCache.kt
+++ b/src/com/intellij/advancedExpressionFolding/adapter/cache/PsiFileFoldingCache.kt
@@ -1,0 +1,26 @@
+package com.intellij.advancedExpressionFolding.adapter.cache
+
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingCache
+import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+
+class PsiFileFoldingCache : FoldingCache {
+    override fun read(element: PsiElement, quick: Boolean, document: Document): Array<FoldingDescriptor>? {
+        if (quick) {
+            return null
+        }
+        val psiFile = element as? PsiJavaFile ?: return null
+        if (!psiFile.invalidateExpired(document, false)) {
+            return psiFile.getUserData(Keys.FULL_CACHE)
+        }
+        return null
+    }
+
+    override fun write(element: PsiElement, foldingDescriptors: Array<FoldingDescriptor>) {
+        (element as? PsiJavaFile)?.putUserData(Keys.FULL_CACHE, foldingDescriptors)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/adapter/storage/ApplicationStorageRegistry.kt
+++ b/src/com/intellij/advancedExpressionFolding/adapter/storage/ApplicationStorageRegistry.kt
@@ -1,0 +1,30 @@
+package com.intellij.advancedExpressionFolding.adapter.storage
+
+import com.intellij.advancedExpressionFolding.application.port.out.Storage
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import java.util.concurrent.atomic.AtomicReference
+
+@Service(Service.Level.APP)
+class ApplicationStorageRegistry {
+    private val storageRef = AtomicReference<Storage>(EmptyStorage)
+
+    fun current(): Storage = storageRef.get()
+
+    fun set(storage: Storage) {
+        storageRef.set(storage)
+    }
+
+    fun reset() {
+        storageRef.set(EmptyStorage)
+    }
+
+    fun override(storage: Storage): AutoCloseable {
+        val previous = storageRef.getAndSet(storage)
+        return AutoCloseable { storageRef.set(previous) }
+    }
+
+    companion object {
+        fun instance(): ApplicationStorageRegistry = service()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/adapter/storage/EmptyStorage.kt
+++ b/src/com/intellij/advancedExpressionFolding/adapter/storage/EmptyStorage.kt
@@ -1,5 +1,6 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.adapter.storage
 
+import com.intellij.advancedExpressionFolding.application.port.out.Storage
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 
@@ -13,4 +14,3 @@ object EmptyStorage : Storage {
         document: Document
     ): Array<FoldingDescriptor> = foldingDescriptors
 }
-

--- a/src/com/intellij/advancedExpressionFolding/application/FoldingApplicationService.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/FoldingApplicationService.kt
@@ -1,0 +1,47 @@
+package com.intellij.advancedExpressionFolding.application
+
+import com.intellij.advancedExpressionFolding.application.port.`in`.BuildFoldRegionsUseCase
+import com.intellij.advancedExpressionFolding.application.port.`in`.PreviewFoldRegionsUseCase
+import com.intellij.advancedExpressionFolding.application.port.`in`.ResolveCollapsedByDefaultUseCase
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingCache
+import com.intellij.advancedExpressionFolding.application.port.out.Storage
+import com.intellij.advancedExpressionFolding.domain.FoldRegionsCollector
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.settings.IConfig
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+class FoldingApplicationService(
+    private val config: IConfig,
+    private val collector: FoldRegionsCollector,
+    private val cache: FoldingCache,
+    private val storage: Storage,
+) : BuildFoldRegionsUseCase,
+    PreviewFoldRegionsUseCase,
+    ResolveCollapsedByDefaultUseCase {
+
+    override fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        if (!config.globalOn || collector.isFoldingFile(element)) {
+            return storage.store(Expression.EMPTY_ARRAY, document)
+        }
+
+        val cachedDescriptors = if (config.memoryImprovement) {
+            cache.read(element, quick, document)
+        } else {
+            null
+        }
+
+        val foldingDescriptors = cachedDescriptors ?: collector.collect(element, document)
+        if (config.memoryImprovement && !quick && cachedDescriptors !== foldingDescriptors) {
+            cache.write(element, foldingDescriptors)
+        }
+        return storage.store(foldingDescriptors, document)
+    }
+
+    override fun preview(element: PsiElement, document: Document): List<String> =
+        collector.preview(element, document)
+
+    override fun isCollapsedByDefault(astNode: ASTNode): Boolean = collector.isCollapsedByDefault(astNode)
+}

--- a/src/com/intellij/advancedExpressionFolding/application/FoldingApplicationServiceFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/FoldingApplicationServiceFactory.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.application
+
+import com.intellij.advancedExpressionFolding.adapter.cache.PsiFileFoldingCache
+import com.intellij.advancedExpressionFolding.adapter.storage.ApplicationStorageRegistry
+import com.intellij.advancedExpressionFolding.domain.DefaultFoldRegionsCollector
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.IConfig
+
+object FoldingApplicationServiceFactory {
+    private val collector = DefaultFoldRegionsCollector()
+    private val cache = PsiFileFoldingCache()
+
+    fun create(config: IConfig = getInstance().state): FoldingApplicationService {
+        val storage = ApplicationStorageRegistry.instance().current()
+        return FoldingApplicationService(config, collector, cache, storage)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/in/BuildFoldRegionsUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/in/BuildFoldRegionsUseCase.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.application.port.`in`
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+/**
+ * Driving port that exposes the main folding workflow to adapters.
+ */
+fun interface BuildFoldRegionsUseCase {
+    fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/in/PreviewFoldRegionsUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/in/PreviewFoldRegionsUseCase.kt
@@ -1,0 +1,11 @@
+package com.intellij.advancedExpressionFolding.application.port.`in`
+
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+/**
+ * Driving port that exposes debugging preview of folding descriptors.
+ */
+fun interface PreviewFoldRegionsUseCase {
+    fun preview(element: PsiElement, document: Document): List<String>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/in/ResolveCollapsedByDefaultUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/in/ResolveCollapsedByDefaultUseCase.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.application.port.`in`
+
+import com.intellij.lang.ASTNode
+
+/**
+ * Driving port that decides whether a fold should be collapsed by default.
+ */
+fun interface ResolveCollapsedByDefaultUseCase {
+    fun isCollapsedByDefault(astNode: ASTNode): Boolean
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingCache.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingCache.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.application.port.out
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+interface FoldingCache {
+    fun read(element: PsiElement, quick: Boolean, document: Document): Array<FoldingDescriptor>?
+    fun write(element: PsiElement, foldingDescriptors: Array<FoldingDescriptor>)
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/out/Storage.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/Storage.kt
@@ -1,4 +1,4 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.application.port.out
 
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
@@ -9,4 +9,3 @@ interface Storage {
         document: Document
     ): Array<FoldingDescriptor>
 }
-

--- a/src/com/intellij/advancedExpressionFolding/domain/DefaultFoldRegionsCollector.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/DefaultFoldRegionsCollector.kt
@@ -1,0 +1,59 @@
+package com.intellij.advancedExpressionFolding.domain
+
+import com.google.common.collect.Lists
+import com.google.common.collect.Sets
+import com.intellij.advancedExpressionFolding.processor.asInstance
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+
+class DefaultFoldRegionsCollector : FoldRegionsCollector {
+    override fun collect(element: PsiElement, document: Document): Array<FoldingDescriptor> {
+        val allDescriptors = Lists.newArrayListWithCapacity<FoldingDescriptor>(1_000)
+        BuildExpressionExt.collectFoldRegionsRecursively(element, document, Sets.newIdentityHashSet(), allDescriptors)
+        return allDescriptors.toTypedArray()
+    }
+
+    override fun preview(element: PsiElement, document: Document): List<String> {
+        val groupIds = Sets.newIdentityHashSet<FoldingGroup>()
+        return collect(element, document).map { descriptor ->
+            descriptor.group?.let(groupIds::add)
+            buildString {
+                append(descriptor.range.substring(document.text))
+                append(" => ")
+                append(descriptor.placeholderText)
+                append('[')
+                append(groupIds.size)
+                append("-")
+                append(descriptor.group?.run {
+                    toString().substringAfterLast(".")
+                } ?: "null")
+                append(']')
+            }
+        }
+    }
+
+    override fun isFoldingFile(element: PsiElement): Boolean =
+        element.asInstance<PsiJavaFile>()?.name?.endsWith("-folded.java") == true
+
+    override fun isCollapsedByDefault(astNode: ASTNode): Boolean {
+        return try {
+            val element = astNode.psi
+            val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
+            if (document != null) {
+                val expression = BuildExpressionExt.getNonSyntheticExpression(element, document)
+                expression?.isCollapsedByDefault() == true
+            } else {
+                false
+            }
+        } catch (_: IndexNotReadyException) {
+            false
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/FoldRegionsCollector.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/FoldRegionsCollector.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.domain
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+interface FoldRegionsCollector {
+    fun collect(element: PsiElement, document: Document): Array<FoldingDescriptor>
+    fun preview(element: PsiElement, document: Document): List<String>
+    fun isFoldingFile(element: PsiElement): Boolean
+    fun isCollapsedByDefault(astNode: ASTNode): Boolean
+}

--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding
 
 import ai.grazie.utils.capitalize
+import com.intellij.advancedExpressionFolding.adapter.storage.ApplicationStorageRegistry
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorExWrapper
 import com.intellij.advancedExpressionFolding.processor.off
 import com.intellij.openapi.application.WriteAction
@@ -53,7 +54,7 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
         }
 
         val store = FoldingDataStorage()
-        com.intellij.advancedExpressionFolding.store = store
+        val storageOverride = ApplicationStorageRegistry.instance().override(store)
         try {
             action.invoke()
         } catch (e: FileComparisonFailedError) {
@@ -72,6 +73,8 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
                 createFoldedFile(fileName, actual, wrapper)
             }
             throw e
+        } finally {
+            storageOverride.close()
         }
     }
 

--- a/test/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.intellij.advancedExpressionFolding.application.port.out.Storage
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorEx
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorExWrapper
 import com.intellij.advancedExpressionFolding.diff.Range


### PR DESCRIPTION
twin
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/709

## Summary
- Extract the folding workflows into dedicated application ports and the `FoldingApplicationService`
- Provide domain collectors plus cache and storage adapters to decouple infrastructure concerns
- Adjust the IntelliJ folding builder and tests to resolve dependencies through the new ports

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ef4d697f80832e8dd816804ea502b8