### PR TITLE
Refactor folding builder into layered architecture

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -1,118 +1,34 @@
 package com.intellij.advancedExpressionFolding
 
-import com.google.common.collect.Lists
-import com.google.common.collect.Sets
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.asInstance
-import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
-import com.intellij.advancedExpressionFolding.processor.cache.Keys
-import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
-import com.intellij.advancedExpressionFolding.settings.IConfig
+import com.intellij.advancedExpressionFolding.adapter.storage.StorageRegistry
+import com.intellij.advancedExpressionFolding.application.port.input.BuildFoldRegionsRequest
+import com.intellij.advancedExpressionFolding.application.port.input.FoldingApplicationPort
+import com.intellij.advancedExpressionFolding.application.port.input.PreviewFoldRegionsRequest
+import com.intellij.advancedExpressionFolding.application.service.FoldingApplication
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.FoldingGroup
-import com.intellij.openapi.project.IndexNotReadyException
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiJavaFile
 
-class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance().state) : FoldingBuilderEx(), IConfig by config {
-    override fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
-        if (!globalOn || isFoldingFile(element)) {
-            return store.store(Expression.EMPTY_ARRAY, document)
-        }
-        if (debugFolding) {
-            preview(element, document)
-        }
+class AdvancedExpressionFoldingBuilder(
+    private val application: FoldingApplicationPort = FoldingApplication(storageProvider = StorageRegistry::current)
+) : FoldingBuilderEx() {
 
-        val cachedDescriptors = when {
-            memoryImprovement -> readCache(element, quick, document)
-            else -> null
-        }
-        val foldingDescriptors = cachedDescriptors ?: collect(element, document)
-        if (memoryImprovement && !quick && cachedDescriptors !== foldingDescriptors) {
-            writeCache(element, foldingDescriptors)
-        }
-        return store.store(foldingDescriptors, document)
-    }
-
-    private fun isFoldingFile(element: PsiElement) =
-        element.asInstance<PsiJavaFile>()?.name?.endsWith("-folded.java") == true
-
-    private fun readCache(
+    override fun buildFoldRegions(
         element: PsiElement,
-        quick: Boolean,
-        document: Document
-    ): Array<FoldingDescriptor>? {
-        if (!quick) {
-            (element as? PsiJavaFile)?.let { file ->
-                if (!file.invalidateExpired(document, false)) {
-                    return file.getUserData(Keys.FULL_CACHE)
-                }
-            }
-        }
-        return null
-    }
-
-    private fun writeCache(
-        element: PsiElement,
-        foldingDescriptors: Array<FoldingDescriptor>
-    ) {
-        (element as? PsiJavaFile)?.run {
-            putUserData(Keys.FULL_CACHE, foldingDescriptors)
-        }
-    }
-
-    fun preview(element: PsiElement, document: Document): List<String> {
-        val groupIds = Sets.newIdentityHashSet<FoldingGroup>()
-        return collect(element, document).map { descriptor ->
-            descriptor.group?.let(groupIds::add)
-            buildString {
-                append(descriptor.range.substring(document.text))
-                append(" => ")
-                append(descriptor.placeholderText)
-                append('[')
-                append(groupIds.size)
-                append("-")
-                append(descriptor.group?.run {
-                    toString().substringAfterLast(".")
-                } ?: "null")
-                append(']')
-            }
-        }
-    }
-
-    private fun collect(
-        element: PsiElement,
-        document: Document
+        document: Document,
+        quick: Boolean
     ): Array<FoldingDescriptor> {
-        //TODO: default list size based on file size
-        val allDescriptors = Lists.newArrayListWithCapacity<FoldingDescriptor>(1_000)
-        BuildExpressionExt.collectFoldRegionsRecursively(element, document, Sets.newIdentityHashSet(), allDescriptors)
-        return allDescriptors.toTypedArray()
+        if (debugFolding) {
+            application.preview(PreviewFoldRegionsRequest(element, document))
+        }
+        return application.build(BuildFoldRegionsRequest(element, document, quick))
     }
 
     override fun getPlaceholderText(astNode: ASTNode) = null
 
-    // TODO: Collapse everything by default but use these settings when actually building the folding descriptors
-    override fun isCollapsedByDefault(astNode: ASTNode): Boolean {
-        try {
-            val element = astNode.psi
-            val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
-            document?.let {
-                val expression = BuildExpressionExt.getNonSyntheticExpression(element, it)
-                return expression?.isCollapsedByDefault() == true
-            }
-        } catch (_: IndexNotReadyException) {
-            return false
-        }
-        return false
-    }
+    override fun isCollapsedByDefault(astNode: ASTNode): Boolean = application.isCollapsedByDefault(astNode)
 
     private val debugFolding = false
 }
-
-var store: Storage = EmptyStorage

--- a/src/com/intellij/advancedExpressionFolding/adapter/storage/EmptyStorage.kt
+++ b/src/com/intellij/advancedExpressionFolding/adapter/storage/EmptyStorage.kt
@@ -1,7 +1,8 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.adapter.storage
 
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.application.port.output.Storage
 
 /**
  * Default no-op storage used in production.

--- a/src/com/intellij/advancedExpressionFolding/adapter/storage/StorageRegistry.kt
+++ b/src/com/intellij/advancedExpressionFolding/adapter/storage/StorageRegistry.kt
@@ -1,0 +1,18 @@
+package com.intellij.advancedExpressionFolding.adapter.storage
+
+import com.intellij.advancedExpressionFolding.application.port.output.Storage
+
+object StorageRegistry {
+    @Volatile
+    private var delegate: Storage = EmptyStorage
+
+    fun use(storage: Storage) {
+        delegate = storage
+    }
+
+    fun reset() {
+        delegate = EmptyStorage
+    }
+
+    fun current(): Storage = delegate
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/input/BuildFoldRegionsUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/input/BuildFoldRegionsUseCase.kt
@@ -1,0 +1,15 @@
+package com.intellij.advancedExpressionFolding.application.port.input
+
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+data class BuildFoldRegionsRequest(
+    val element: PsiElement,
+    val document: Document,
+    val quick: Boolean
+)
+
+fun interface BuildFoldRegionsUseCase {
+    fun build(request: BuildFoldRegionsRequest): Array<FoldingDescriptor>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/input/CollapsedStateResolver.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/input/CollapsedStateResolver.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.application.port.input
+
+import com.intellij.lang.ASTNode
+
+fun interface CollapsedStateResolver {
+    fun isCollapsedByDefault(astNode: ASTNode): Boolean
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/input/FoldingApplicationPort.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/input/FoldingApplicationPort.kt
@@ -1,0 +1,6 @@
+package com.intellij.advancedExpressionFolding.application.port.input
+
+interface FoldingApplicationPort :
+    BuildFoldRegionsUseCase,
+    PreviewFoldRegionsUseCase,
+    CollapsedStateResolver

--- a/src/com/intellij/advancedExpressionFolding/application/port/input/PreviewFoldRegionsUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/input/PreviewFoldRegionsUseCase.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.application.port.input
+
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+data class PreviewFoldRegionsRequest(
+    val element: PsiElement,
+    val document: Document
+)
+
+fun interface PreviewFoldRegionsUseCase {
+    fun preview(request: PreviewFoldRegionsRequest): List<String>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/output/Storage.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/output/Storage.kt
@@ -1,9 +1,9 @@
-package com.intellij.advancedExpressionFolding
+package com.intellij.advancedExpressionFolding.application.port.output
 
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 
-interface Storage {
+fun interface Storage {
     fun store(
         foldingDescriptors: Array<FoldingDescriptor>,
         document: Document

--- a/src/com/intellij/advancedExpressionFolding/application/service/FoldingApplication.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/service/FoldingApplication.kt
@@ -1,0 +1,124 @@
+package com.intellij.advancedExpressionFolding.application.service
+
+import com.google.common.collect.Lists
+import com.google.common.collect.Sets
+import com.intellij.advancedExpressionFolding.application.port.input.BuildFoldRegionsRequest
+import com.intellij.advancedExpressionFolding.application.port.input.FoldingApplicationPort
+import com.intellij.advancedExpressionFolding.application.port.input.PreviewFoldRegionsRequest
+import com.intellij.advancedExpressionFolding.application.port.output.Storage
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.advancedExpressionFolding.settings.IConfig
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.project.IndexNotReadyException
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiJavaFile
+
+class FoldingApplication(
+    private val configSupplier: () -> IConfig = { AdvancedExpressionFoldingSettings.getInstance().state },
+    private val storageProvider: () -> Storage
+) : FoldingApplicationPort {
+
+    override fun build(request: BuildFoldRegionsRequest): Array<FoldingDescriptor> {
+        val config = configSupplier()
+        val storage = storageProvider()
+        if (!config.globalOn || isFoldingFile(request.element)) {
+            return storage.store(Expression.EMPTY_ARRAY, request.document)
+        }
+
+        val cachedDescriptors = if (config.memoryImprovement) {
+            readCache(request.element, request.quick, request.document)
+        } else {
+            null
+        }
+
+        val foldingDescriptors = cachedDescriptors ?: collect(request.element, request.document)
+
+        if (config.memoryImprovement && !request.quick && cachedDescriptors !== foldingDescriptors) {
+            writeCache(request.element, foldingDescriptors)
+        }
+
+        return storage.store(foldingDescriptors, request.document)
+    }
+
+    override fun preview(request: PreviewFoldRegionsRequest): List<String> {
+        val groupIds = Sets.newIdentityHashSet<FoldingGroup>()
+        return collect(request.element, request.document).map { descriptor ->
+            descriptor.group?.let(groupIds::add)
+            buildString {
+                append(descriptor.range.substring(request.document.text))
+                append(" => ")
+                append(descriptor.placeholderText)
+                append('[')
+                append(groupIds.size)
+                append("-")
+                append(descriptor.group?.run { toString().substringAfterLast('.') } ?: "null")
+                append(']')
+            }
+        }
+    }
+
+    override fun isCollapsedByDefault(astNode: ASTNode): Boolean {
+        return try {
+            val element = astNode.psi
+            val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
+            if (document != null) {
+                val expression = BuildExpressionExt.getNonSyntheticExpression(element, document)
+                expression?.isCollapsedByDefault() == true
+            } else {
+                false
+            }
+        } catch (_: IndexNotReadyException) {
+            false
+        }
+    }
+
+    private fun readCache(
+        element: PsiElement,
+        quick: Boolean,
+        document: Document
+    ): Array<FoldingDescriptor>? {
+        if (!quick) {
+            (element as? PsiJavaFile)?.let { file ->
+                if (!file.invalidateExpired(document, false)) {
+                    return file.getUserData(Keys.FULL_CACHE)
+                }
+            }
+        }
+        return null
+    }
+
+    private fun writeCache(
+        element: PsiElement,
+        foldingDescriptors: Array<FoldingDescriptor>
+    ) {
+        (element as? PsiJavaFile)?.run {
+            putUserData(Keys.FULL_CACHE, foldingDescriptors)
+        }
+    }
+
+    private fun collect(
+        element: PsiElement,
+        document: Document
+    ): Array<FoldingDescriptor> {
+        val allDescriptors = Lists.newArrayListWithCapacity<FoldingDescriptor>(DEFAULT_LIST_CAPACITY)
+        BuildExpressionExt.collectFoldRegionsRecursively(element, document, Sets.newIdentityHashSet(), allDescriptors)
+        return allDescriptors.toTypedArray()
+    }
+
+    private fun isFoldingFile(element: PsiElement): Boolean {
+        return (element as? PsiJavaFile)?.name?.endsWith(FOLDED_FILE_SUFFIX) == true
+    }
+
+    companion object {
+        private const val DEFAULT_LIST_CAPACITY = 1_000
+        private const val FOLDED_FILE_SUFFIX = "-folded.java"
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/BaseTest.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding
 
 import ai.grazie.utils.capitalize
+import com.intellij.advancedExpressionFolding.adapter.storage.StorageRegistry
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorExWrapper
 import com.intellij.advancedExpressionFolding.processor.off
 import com.intellij.openapi.application.WriteAction
@@ -53,7 +54,7 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
         }
 
         val store = FoldingDataStorage()
-        com.intellij.advancedExpressionFolding.store = store
+        StorageRegistry.use(store)
         try {
             action.invoke()
         } catch (e: FileComparisonFailedError) {
@@ -72,6 +73,8 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
                 createFoldedFile(fileName, actual, wrapper)
             }
             throw e
+        } finally {
+            StorageRegistry.reset()
         }
     }
 

--- a/test/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
+++ b/test/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.intellij.advancedExpressionFolding.application.port.output.Storage
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorEx
 import com.intellij.advancedExpressionFolding.diff.FoldingDescriptorExWrapper
 import com.intellij.advancedExpressionFolding.diff.Range


### PR DESCRIPTION
twin
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/708

## Summary
- delegate `AdvancedExpressionFoldingBuilder` to a dedicated `FoldingApplication` that owns the folding use cases
- introduce application input/output ports and a storage registry to decouple storage wiring from the builder
- update tests to drive the new registry instead of touching global state

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ef4d697f80832e8dd816804ea502b8