### PR TITLE
Refactor folding service around domain-driven design layers

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingBatchExecutor.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingBatchExecutor.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.application.port.out
+
+import com.intellij.openapi.editor.Editor
+
+fun interface FoldingBatchExecutor {
+    fun execute(editor: Editor, operation: () -> Unit)
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingGroupFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/FoldingGroupFactory.kt
@@ -1,0 +1,8 @@
+package com.intellij.advancedExpressionFolding.application.port.out
+
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.openapi.editor.Editor
+
+interface FoldingGroupFactory {
+    fun create(editor: Editor): FoldingGroup
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/out/KeyAwareElementProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/KeyAwareElementProvider.kt
@@ -1,0 +1,8 @@
+package com.intellij.advancedExpressionFolding.application.port.out
+
+import com.intellij.advancedExpressionFolding.domain.model.KeyAwareElement
+import com.intellij.openapi.editor.Editor
+
+interface KeyAwareElementProvider {
+    fun provide(editor: Editor): KeyAwareElement?
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/out/ProjectEditorsProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/out/ProjectEditorsProvider.kt
@@ -1,0 +1,8 @@
+package com.intellij.advancedExpressionFolding.application.port.out
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+
+interface ProjectEditorsProvider {
+    fun getEditors(project: Project): List<Editor>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/service/FoldingToggleApplicationService.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/service/FoldingToggleApplicationService.kt
@@ -1,0 +1,23 @@
+package com.intellij.advancedExpressionFolding.application.service
+
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingBatchExecutor
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingGroupFactory
+import com.intellij.advancedExpressionFolding.domain.model.FoldingToggleState
+import com.intellij.advancedExpressionFolding.domain.service.FoldingDomainService
+import com.intellij.openapi.editor.Editor
+
+class FoldingToggleApplicationService(
+    private val batchExecutor: FoldingBatchExecutor,
+    private val groupFactory: FoldingGroupFactory,
+    private val domainService: FoldingDomainService
+) {
+    fun toggle(editor: Editor, state: FoldingToggleState) {
+        if (editor.isDisposed) {
+            return
+        }
+        batchExecutor.execute(editor) {
+            val group = groupFactory.create(editor)
+            domainService.applyState(group, state)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/application/service/KeyCleanupApplicationService.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/service/KeyCleanupApplicationService.kt
@@ -1,0 +1,27 @@
+package com.intellij.advancedExpressionFolding.application.service
+
+import com.intellij.advancedExpressionFolding.application.port.out.KeyAwareElementProvider
+import com.intellij.advancedExpressionFolding.application.port.out.ProjectEditorsProvider
+import com.intellij.advancedExpressionFolding.domain.service.KeyClearanceDomainService
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+
+class KeyCleanupApplicationService(
+    private val projectEditorsProvider: ProjectEditorsProvider,
+    private val keyAwareElementProvider: KeyAwareElementProvider,
+    private val domainService: KeyClearanceDomainService
+) {
+    fun clear(editor: Editor) {
+        if (editor.isDisposed) {
+            return
+        }
+        val element = keyAwareElementProvider.provide(editor) ?: return
+        domainService.clear(element)
+    }
+
+    fun clear(project: Project) {
+        projectEditorsProvider.getEditors(project).forEach { editor ->
+            clear(editor)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/FoldingGroup.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/FoldingGroup.kt
@@ -1,0 +1,6 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+class FoldingGroup(private val regions: List<FoldingRegionPort>) {
+    val managedRegions: List<FoldingRegionPort>
+        get() = regions.filter(FoldingRegionPort::isManagedByPlugin)
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/FoldingRegionPort.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/FoldingRegionPort.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+interface FoldingRegionPort {
+    val isManagedByPlugin: Boolean
+    fun collapse()
+    fun expand()
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/FoldingToggleState.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/FoldingToggleState.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+enum class FoldingToggleState {
+    COLLAPSED,
+    EXPANDED;
+
+    val shouldCollapse: Boolean
+        get() = this == COLLAPSED
+
+    companion object {
+        fun from(enabled: Boolean): FoldingToggleState = if (enabled) COLLAPSED else EXPANDED
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/KeyAwareElement.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/KeyAwareElement.kt
@@ -1,0 +1,6 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+interface KeyAwareElement {
+    fun clearKeys()
+    fun children(): Sequence<KeyAwareElement>
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/service/FoldingDomainService.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/service/FoldingDomainService.kt
@@ -1,0 +1,16 @@
+package com.intellij.advancedExpressionFolding.domain.service
+
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.advancedExpressionFolding.domain.model.FoldingToggleState
+
+class FoldingDomainService {
+    fun applyState(group: FoldingGroup, state: FoldingToggleState) {
+        group.managedRegions.forEach { region ->
+            if (state.shouldCollapse) {
+                region.collapse()
+            } else {
+                region.expand()
+            }
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/service/KeyClearanceDomainService.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/service/KeyClearanceDomainService.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.domain.service
+
+import com.intellij.advancedExpressionFolding.domain.model.KeyAwareElement
+
+class KeyClearanceDomainService {
+    fun clear(element: KeyAwareElement) {
+        element.clearKeys()
+        element.children().forEach { child ->
+            clear(child)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/EditorFoldingBatchExecutor.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/EditorFoldingBatchExecutor.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingBatchExecutor
+import com.intellij.openapi.editor.Editor
+
+class EditorFoldingBatchExecutor : FoldingBatchExecutor {
+    override fun execute(editor: Editor, operation: () -> Unit) {
+        editor.foldingModel.runBatchFoldingOperation(operation)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/EditorFoldingGroupFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/EditorFoldingGroupFactory.kt
@@ -1,0 +1,30 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.application.port.out.FoldingGroupFactory
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.advancedExpressionFolding.domain.model.FoldingRegionPort
+import com.intellij.advancedExpressionFolding.isAdvancedExpressionFoldingGroup
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.FoldRegion
+
+class EditorFoldingGroupFactory : FoldingGroupFactory {
+    override fun create(editor: Editor): FoldingGroup {
+        val ports = editor.foldingModel.allFoldRegions.map(::EditorFoldingRegionPort)
+        return FoldingGroup(ports)
+    }
+
+    private class EditorFoldingRegionPort(
+        private val delegate: FoldRegion
+    ) : FoldingRegionPort {
+        override val isManagedByPlugin: Boolean
+            get() = delegate.isAdvancedExpressionFoldingGroup
+
+        override fun collapse() {
+            delegate.isExpanded = false
+        }
+
+        override fun expand() {
+            delegate.isExpanded = true
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/ProjectOpenEditorsProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/ProjectOpenEditorsProvider.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.application.port.out.ProjectEditorsProvider
+import com.intellij.advancedExpressionFolding.openTextEditors
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+
+class ProjectOpenEditorsProvider : ProjectEditorsProvider {
+    override fun getEditors(project: Project): List<Editor> = project.openTextEditors
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/psi/PsiKeyAwareElementProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/psi/PsiKeyAwareElementProvider.kt
@@ -1,0 +1,27 @@
+package com.intellij.advancedExpressionFolding.infrastructure.psi
+
+import com.intellij.advancedExpressionFolding.application.port.out.KeyAwareElementProvider
+import com.intellij.advancedExpressionFolding.domain.model.KeyAwareElement
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+
+class PsiKeyAwareElementProvider : KeyAwareElementProvider {
+    override fun provide(editor: Editor): KeyAwareElement? {
+        val project = editor.project ?: return null
+        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return null
+        return PsiKeyAwareElement(psiFile)
+    }
+
+    private class PsiKeyAwareElement(
+        private val element: PsiElement
+    ) : KeyAwareElement {
+        override fun clearKeys() {
+            Keys.clearAll(element)
+        }
+
+        override fun children(): Sequence<KeyAwareElement> =
+            element.children.asSequence().map(::PsiKeyAwareElement)
+    }
+}


### PR DESCRIPTION
twin
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/711

## Summary
- introduce domain-driven design domain models for folding state and key-aware elements
- add application services and infrastructure adapters to orchestrate folding toggles and key cleanup
- update FoldingService to delegate to the new domain-driven design architecture

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68ef67dbac28832e97251a59884546a9