### PR TITLE
Adopt DDD structure for folding orchestration

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/application/port/output/EditorPsiProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/output/EditorPsiProvider.kt
@@ -1,0 +1,8 @@
+package com.intellij.advancedExpressionFolding.application.port.output
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+
+interface EditorPsiProvider {
+    fun getPsiFile(editor: Editor): PsiFile?
+}

--- a/src/com/intellij/advancedExpressionFolding/application/port/output/FoldingGroupRepository.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/port/output/FoldingGroupRepository.kt
@@ -1,0 +1,8 @@
+package com.intellij.advancedExpressionFolding.application.port.output
+
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.openapi.editor.Editor
+
+interface FoldingGroupRepository {
+    fun load(editor: Editor): List<FoldingGroup>
+}

--- a/src/com/intellij/advancedExpressionFolding/application/usecase/ClearEditorKeysUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/usecase/ClearEditorKeysUseCase.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.application.usecase
+
+import com.intellij.advancedExpressionFolding.application.port.output.EditorPsiProvider
+import com.intellij.advancedExpressionFolding.domain.service.KeyCleanupService
+import com.intellij.openapi.editor.Editor
+
+class ClearEditorKeysUseCase(
+    private val editorPsiProvider: EditorPsiProvider,
+    private val keyCleanupService: KeyCleanupService
+) {
+    fun execute(editor: Editor) {
+        if (editor.isDisposed) return
+
+        val psiFile = editorPsiProvider.getPsiFile(editor) ?: return
+        keyCleanupService.clear(psiFile)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/application/usecase/ToggleEditorFoldingUseCase.kt
+++ b/src/com/intellij/advancedExpressionFolding/application/usecase/ToggleEditorFoldingUseCase.kt
@@ -1,0 +1,22 @@
+package com.intellij.advancedExpressionFolding.application.usecase
+
+import com.intellij.advancedExpressionFolding.application.port.output.FoldingGroupRepository
+import com.intellij.advancedExpressionFolding.domain.model.FoldingState
+import com.intellij.advancedExpressionFolding.domain.service.FoldingGroupToggler
+import com.intellij.openapi.editor.Editor
+
+class ToggleEditorFoldingUseCase(
+    private val foldingGroupRepository: FoldingGroupRepository,
+    private val foldingGroupToggler: FoldingGroupToggler
+) {
+    fun execute(editor: Editor, state: FoldingState) {
+        if (editor.isDisposed) return
+
+        val groups = foldingGroupRepository.load(editor)
+        if (groups.isEmpty()) return
+
+        editor.foldingModel.runBatchFoldingOperation {
+            foldingGroupToggler.toggle(groups, state)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/AdvancedFoldRegion.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/AdvancedFoldRegion.kt
@@ -1,0 +1,9 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+import com.intellij.openapi.editor.FoldRegion
+
+class AdvancedFoldRegion(private val delegate: FoldRegion) {
+    fun apply(state: FoldingState) {
+        delegate.isExpanded = state.isExpanded
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/FoldingGroup.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/FoldingGroup.kt
@@ -1,0 +1,14 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+class FoldingGroup(private val regions: List<AdvancedFoldRegion>) {
+    fun apply(state: FoldingState) {
+        regions.forEach { region ->
+            region.apply(state)
+        }
+    }
+
+    companion object {
+        fun fromRegions(regions: List<AdvancedFoldRegion>): FoldingGroup? =
+            regions.takeIf { it.isNotEmpty() }?.let(::FoldingGroup)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/model/FoldingState.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/model/FoldingState.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.domain.model
+
+enum class FoldingState(val isCollapsed: Boolean) {
+    COLLAPSED(true),
+    EXPANDED(false);
+
+    val isExpanded: Boolean
+        get() = !isCollapsed
+
+    companion object {
+        fun fromCollapseFlag(collapse: Boolean): FoldingState = if (collapse) COLLAPSED else EXPANDED
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/repository/AdvancedExpressionKeyRepository.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/repository/AdvancedExpressionKeyRepository.kt
@@ -1,0 +1,7 @@
+package com.intellij.advancedExpressionFolding.domain.repository
+
+import com.intellij.psi.PsiElement
+
+fun interface AdvancedExpressionKeyRepository {
+    fun clear(element: PsiElement)
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/service/FoldingGroupToggler.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/service/FoldingGroupToggler.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.domain.service
+
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.advancedExpressionFolding.domain.model.FoldingState
+
+class FoldingGroupToggler {
+    fun toggle(groups: List<FoldingGroup>, state: FoldingState) {
+        groups.forEach { group ->
+            group.apply(state)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/domain/service/KeyCleanupService.kt
+++ b/src/com/intellij/advancedExpressionFolding/domain/service/KeyCleanupService.kt
@@ -1,0 +1,16 @@
+package com.intellij.advancedExpressionFolding.domain.service
+
+import com.intellij.advancedExpressionFolding.domain.repository.AdvancedExpressionKeyRepository
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementVisitor
+
+class KeyCleanupService(private val repository: AdvancedExpressionKeyRepository) {
+    fun clear(element: PsiElement) {
+        element.accept(object : PsiRecursiveElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                repository.clear(element)
+                super.visitElement(element)
+            }
+        })
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijAdvancedExpressionKeyRepository.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijAdvancedExpressionKeyRepository.kt
@@ -1,0 +1,11 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.domain.repository.AdvancedExpressionKeyRepository
+import com.intellij.advancedExpressionFolding.processor.cache.Keys
+import com.intellij.psi.PsiElement
+
+class IntellijAdvancedExpressionKeyRepository : AdvancedExpressionKeyRepository {
+    override fun clear(element: PsiElement) {
+        Keys.clearAll(element)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijEditorPsiProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijEditorPsiProvider.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.application.port.output.EditorPsiProvider
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+
+class IntellijEditorPsiProvider : EditorPsiProvider {
+    override fun getPsiFile(editor: Editor): PsiFile? {
+        val project = editor.project ?: return null
+        return PsiDocumentManager.getInstance(project).getPsiFile(editor.document)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijFoldingGroupRepository.kt
+++ b/src/com/intellij/advancedExpressionFolding/infrastructure/editor/IntellijFoldingGroupRepository.kt
@@ -1,0 +1,21 @@
+package com.intellij.advancedExpressionFolding.infrastructure.editor
+
+import com.intellij.advancedExpressionFolding.application.port.output.FoldingGroupRepository
+import com.intellij.advancedExpressionFolding.domain.model.AdvancedFoldRegion
+import com.intellij.advancedExpressionFolding.domain.model.FoldingGroup
+import com.intellij.advancedExpressionFolding.isAdvancedExpressionFoldingGroup
+import com.intellij.openapi.editor.Editor
+
+class IntellijFoldingGroupRepository : FoldingGroupRepository {
+    override fun load(editor: Editor): List<FoldingGroup> {
+        if (editor.isDisposed) return emptyList()
+
+        val regions = editor.foldingModel.allFoldRegions
+            .asSequence()
+            .filter { region -> region.isAdvancedExpressionFoldingGroup }
+            .map(::AdvancedFoldRegion)
+            .toList()
+
+        return FoldingGroup.fromRegions(regions)?.let(::listOf) ?: emptyList()
+    }
+}


### PR DESCRIPTION
twin
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/710

## Summary
- introduce domain, application, and infrastructure layers for folding and key cleanup logic
- add dedicated use cases for toggling folding groups and clearing cached keys
- refactor the FoldingService to compose the new DDD components

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ef67dbac28832e97251a59884546a9