### PR TITLE
Document folding catalogues for remaining features

### DIFF
--- a/wiki-clone/docs/features/arithmeticExpressions.md
+++ b/wiki-clone/docs/features/arithmeticExpressions.md
@@ -740,3 +740,17 @@ folded/ArithmeticExpressionsTestData-folded.java:
 ```
 Collapses `Double.valueOf` to the source string.
 
+
+---
+
+#### Processor summary based on implementation
+
+The arithmetic processors register against `java.math.BigDecimal` and `java.math.BigInteger` receivers, then replace fluent method calls with the matching arithmetic syntax:
+
+* `add`, `subtract`, `multiply`, and `divide` fold into infix `+`, `-`, `*`, and `/` expressions by rewriting the qualifier and single argument into a binary operand list.
+* `remainder` and `mod` share the same handler, producing `%` expressions, while `pow` converts the exponent into a superscript when the value can be rendered that way.
+* `abs`, `negate`, `plus`, and `signum` collapse unary calls: absolute value surrounds the operand with `|…|`, `negate` prepends a minus, `plus` returns the qualifier unchanged, and `signum` emits the compact `signum` helper call.
+* `and`, `or`, `xor`, `andNot`, and `not` are mapped onto the bitwise operators. `andNot` expands to `qualifier & ~argument` by composing an explicit negation of the parameter before applying the `&` expression.
+* `shiftLeft` and `shiftRight` become bitwise shift expressions, `gcd` becomes the infix-style `gcd` call, and `atan2` folds the two-argument form into a concise `atan2` expression.
+
+These behaviours come directly from the method-call processors under `processor/methodcall/arithmetic`, which wrap the qualifier and arguments in the corresponding math `Expression` classes (for example `Add`, `Subtract`, `Multiply`, `Divide`, `Remainder`, `Pow`, `Abs`, `Negate`, `Signum`, `And`, `Or`, `Xor`, `Not`, `ShiftLeft`, `ShiftRight`, `Gcd`, and `Atan2`).

--- a/wiki-clone/docs/features/assertsCollapse.md
+++ b/wiki-clone/docs/features/assertsCollapse.md
@@ -29,3 +29,13 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `assertsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### AssertTestData mappings
+| Before | After |
+| --- | --- |
+| `if (args.length == 0) { throw new IllegalArgumentException(); }` | `assert args.length != 0;` |
+| `if (args.length == 1) { throw new IllegalArgumentException("..."); }` | `assert args.length != 1 : "...";` |
+| `if (args.length == 2) throw new IllegalArgumentException("...");` | `assert args.length != 2 : "...";` |

--- a/wiki-clone/docs/features/castExpressionsCollapse.md
+++ b/wiki-clone/docs/features/castExpressionsCollapse.md
@@ -25,3 +25,13 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `castExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### TypeCastTestData mappings
+| Before | After |
+| --- | --- |
+| `if (t.getObject() instanceof TypeCastTestData && ((TypeCastTestData) t.getObject()).getObject() instanceof TypeCastTestData) {` | `if (t.getObject() instanceof TypeCastTestData && t.getObject().getObject() instanceof TypeCastTestData) {` |
+| `System.out.println(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()).getObject());` | `System.out.println(t.getObject().getObject().getObject());` |
+| `handle(((TypeCastTestData) ((TypeCastTestData) t.getObject()).getObject()));` | `handle(t.getObject().getObject());` |

--- a/wiki-clone/docs/features/checkExpressionsCollapse.md
+++ b/wiki-clone/docs/features/checkExpressionsCollapse.md
@@ -58,3 +58,37 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `checkExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ElvisTestData mappings
+| Before | After |
+| --- | --- |
+| `System.out.println(e != null ? e : "");` | `System.out.println(e ?: "");` |
+| `System.out.println(e != null ? e.sayHello() : "");` | `System.out.println(e?.sayHello() ?: "");` |
+| `System.out.println(e == null ? "" : e);` | `System.out.println(e ?: "");` |
+| `if (e != null) { e.get().sayHello(); }` | `e?.get().sayHello();` |
+| `if (e.get() != null) { e.get().sayHello(); }` | `e.get()?.sayHello();` |
+
+##### IfNullSafeData mappings
+| Before | After |
+| --- | --- |
+| `var threeChains = data != null && data.getData1() != null && data != null && data.getData1() != null && data != null && data != null && data.getData1() != null && data.getData1().isActive();` | `var threeChains = data?.data1 != null && data?.data1 != null && data != null && data?.data1?.active == true;` |
+| `var notChain = data != null && !data.getData1().isActive();` | `var notChain = data != null && !data.data1.active;` |
+| `var chain = data != null && data.getData1() != null && data.getData1().getData4() != null;` | `var chain = data?.data1?.data4 != null;` |
+| `if (data != null && data.getData1() != null && data.getData1().getData2() != null && data.getData1().getData2().getData3() != null) {` | `if (data?.data1?.data2?.data3 != null) {` |
+| `if (data != null && data.getData1() != null) {` | `if (data?.data1 != null) {` |
+| `if (data != null && data.isActive()) {` | `if (data?.active == true) {` |
+| `if (data != null && data.getData1() != null && data.getData1().getData2() != null && data.getData1().getData2().getData3() != null && data.getData1().getData2().getData3().getData4() != null && data != null && data != null && data.getData1() != null && !data.getData1().isActive()) {` | `if (data?.data1?.data2?.data3?.data4 != null && data != null && data?.data1?.active == false) {` |
+| `boolean has = data != null && data.getData1() != null && data.getData1().getData2() != null && data.getData1().getData2().getData3() != null && data.getData1().getData2().getData3().getData4() != null;` | `boolean has = data?.data1?.data2?.data3?.data4 != null;` |
+| `var active = data != null && data.getData1() != null && data.getData1().isActive();` | `var active = data?.data1?.active == true;` |
+| `var inactive = data != null && !data.isActive();` | `var inactive = data?.active == false;` |
+| `while (data != null && data.getData2() != null && !data.getData2().isActive()) {` | `while (data?.data2?.active == false) {` |
+| `active = !data.getData1().isActive();` | `active = !data.data1.active;` |
+| `if ((data != null && data.getData6() != null && data.getData6().isActive())) {` | `if ((data?.data6?.active == true)) {` |
+| `if ((data != null && data.getData6() != null && !data.getData6().isActive())) {` | `if ((data?.data6?.active == false)) {` |
+| `if ((flag || data != null && data.getData1() != null && data.getData1().isActive()) && (data != null && data.getData2() != null && data.getData2().isActive() || data != null && data.getData3() != null && data.getData3().isActive() && data.getData3().getData4() != null && data.getData3().getData4().isActive()) || (data != null && data.getData5() != null && data.getData5().isActive()) && (flag && flag || flag && data != null && data.getData6() != null && data.getData6().isActive())) {` | `if ((flag || data?.data1?.active == true) && (data?.data2?.active == true || data?.data3?.active == true && data.data3.data4?.active == true) || (data?.data5?.active == true) && (flag && flag || flag && data?.data6?.active == true)) {` |
+| `if (data.getData1().getData2().getData3() != null && data.getData1().getData2().getData3().isActive()) {` | `if (data.data1.data2.data3?.active == true) {` |
+| `if (data2.getData1().getData2() != null && data2.getData1().getData2().isActive()) {` | `if (data2.data1.data2?.active == true) {` |
+| `if (data2.getData1() != null && data2.getData1().isActive()) {` | `if (data2.data1?.active == true) {` |

--- a/wiki-clone/docs/features/compactControlFlowSyntaxCollapse.md
+++ b/wiki-clone/docs/features/compactControlFlowSyntaxCollapse.md
@@ -25,3 +25,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `compactControlFlowSyntaxCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### CompactControlFlowTestData mappings
+| Before | After |
+| --- | --- |
+| `if (args.length > 0) {` | `if args.length > 0 {` |
+| `for (String arg : args) {` | `for String arg : args {` |
+| `for (int i = 0; i < args.length; i++) {` | `for int i = 0; i < args.length; i++ {` |
+| `while (true) {` | `while true {` |
+| `} while (true);` | `} while true;` |
+| `switch (args.length) {` | `switch args.length {` |
+| `} catch (Exception e) {` | `} catch Exception e {` |

--- a/wiki-clone/docs/features/comparingExpressionsCollapse.md
+++ b/wiki-clone/docs/features/comparingExpressionsCollapse.md
@@ -37,3 +37,22 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `comparingExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### EqualsCompareTestData mappings
+| Before | After |
+| --- | --- |
+| `System.out.println(a.equals(b));` | `System.out.println(a ≡ b);` |
+| `System.out.println(!a.equals(b));` | `System.out.println(a ≢ b);` |
+| `System.out.println(a.compareTo(b) == 0);` | `System.out.println(a ≡ b);` |
+| `System.out.println(a.compareTo(b) != 0);` | `System.out.println(a ≢ b);` |
+| `System.out.println(a.compareTo(b) > 0);` | `System.out.println(a > b);` |
+| `System.out.println(a.compareTo(b) == 1);` | `System.out.println(a > b);` |
+| `System.out.println(a.compareTo(b) > -1);` | `System.out.println(a ≥ b);` |
+| `System.out.println(a.compareTo(b) >= 0);` | `System.out.println(a ≥ b);` |
+| `System.out.println(a.compareTo(b) < 0);` | `System.out.println(a < b);` |
+| `System.out.println(a.compareTo(b) == -1);` | `System.out.println(a < b);` |
+| `System.out.println(a.compareTo(b) < 1);` | `System.out.println(a ≤ b);` |
+| `System.out.println(a.compareTo(b) <= 0);` | `System.out.println(a ≤ b);` |

--- a/wiki-clone/docs/features/comparingLocalDatesCollapse.md
+++ b/wiki-clone/docs/features/comparingLocalDatesCollapse.md
@@ -31,3 +31,32 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `comparingLocalDatesCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LocalDateTestData comparisons
+| Before | After |
+| --- | --- |
+| `boolean isBefore = d1.isBefore(d2);` | `boolean isBefore = d1 < d2;` |
+| `boolean isAfter = d1.isAfter(d2);` | `boolean isAfter = d1 > d2;` |
+| `boolean d2SmallerOrEqualD1 = !d1.isBefore(d2);;` | `boolean d2SmallerOrEqualD1 = d1 ≥ d2;;` |
+| `boolean d1SmallerOrEqualD2 = !d1.isAfter(d2);` | `boolean d1SmallerOrEqualD2 = d1 ≤ d2;` |
+| `if (date1.isBefore(date2) | date1.isAfter(date2) | !date1.isBefore(date2) | !date1.isAfter(date2)) {` | `if (date1 < date2 | date1 > date2 | date1 ≥ date2 | date1 ≤ date2) {` |
+| `if (dateTime1.isBefore(dateTime2) | dateTime1.isAfter(dateTime2) | !dateTime1.isBefore(dateTime2) | !dateTime1.isAfter(dateTime2)) {` | `if (dateTime1 < dateTime2 | dateTime1 > dateTime2 | dateTime1 ≥ dateTime2 | dateTime1 ≤ dateTime2) {` |
+| `if (time1.isBefore(time2) | time1.isAfter(time2) | !time1.isBefore(time2) | !time1.isAfter(time2)) {` | `if (time1 < time2 | time1 > time2 | time1 ≥ time2 | time1 ≤ time2) {` |
+| `if (offsetTime1.isBefore(offsetTime2) | offsetTime1.isAfter(offsetTime2) | !offsetTime1.isBefore(offsetTime2) | !offsetTime1.isAfter(offsetTime2)) {` | `if (offsetTime1 < offsetTime2 | offsetTime1 > offsetTime2 | offsetTime1 ≥ offsetTime2 | offsetTime1 ≤ offsetTime2) {` |
+| `if (offsetDateTime1.isBefore(offsetDateTime2) | offsetDateTime1.isAfter(offsetDateTime2) | !offsetDateTime1.isBefore(offsetDateTime2) | !offsetDateTime1.isAfter(offsetDateTime2)) {` | `if (offsetDateTime1 < offsetDateTime2 | offsetDateTime1 > offsetDateTime2 | offsetDateTime1 ≥ offsetDateTime2 | offsetDateTime1 ≤ offsetDateTime2) {` |
+| `if (zonedDateTime1.isBefore(zonedDateTime2) | zonedDateTime1.isAfter(zonedDateTime2) | !zonedDateTime1.isBefore(zonedDateTime2) | !zonedDateTime1.isAfter(zonedDateTime2)) {` | `if (zonedDateTime1 < zonedDateTime2 | zonedDateTime1 > zonedDateTime2 | zonedDateTime1 ≥ zonedDateTime2 | zonedDateTime1 ≤ zonedDateTime2) {` |
+| `if (hijrahDate1.isBefore(hijrahDate2) | hijrahDate1.isAfter(hijrahDate2) | !hijrahDate1.isBefore(hijrahDate2) | !hijrahDate1.isAfter(hijrahDate2)) {` | `if (hijrahDate1 < hijrahDate2 | hijrahDate1 > hijrahDate2 | hijrahDate1 ≥ hijrahDate2 | hijrahDate1 ≤ hijrahDate2) {` |
+| `if (japaneseDate1.isBefore(japaneseDate2) | japaneseDate1.isAfter(japaneseDate2) | !japaneseDate1.isBefore(japaneseDate2) | !japaneseDate1.isAfter(japaneseDate2)) {` | `if (japaneseDate1 < japaneseDate2 | japaneseDate1 > japaneseDate2 | japaneseDate1 ≥ japaneseDate2 | japaneseDate1 ≤ japaneseDate2) {` |
+| `if (minguoDate1.isBefore(minguoDate2) | minguoDate1.isAfter(minguoDate2) | !minguoDate1.isBefore(minguoDate2) | !minguoDate1.isAfter(minguoDate2)) {` | `if (minguoDate1 < minguoDate2 | minguoDate1 > minguoDate2 | minguoDate1 ≥ minguoDate2 | minguoDate1 ≤ minguoDate2) {` |
+| `if (thaiBuddhistDate1.isBefore(thaiBuddhistDate2) | thaiBuddhistDate1.isAfter(thaiBuddhistDate2) | !thaiBuddhistDate1.isBefore(thaiBuddhistDate2) | !thaiBuddhistDate1.isAfter(thaiBuddhistDate2)) {` | `if (thaiBuddhistDate1 < thaiBuddhistDate2 | thaiBuddhistDate1 > thaiBuddhistDate2 | thaiBuddhistDate1 ≥ thaiBuddhistDate2 | thaiBuddhistDate1 ≤ thaiBuddhistDate2) {` |
+| `if (utilDate1.before(utilDate2) | utilDate1.after(utilDate2) | !utilDate1.before(utilDate2) | !utilDate1.after(utilDate2)) {` | `if (utilDate1 < utilDate2 | utilDate1 > utilDate2 | utilDate1 ≥ utilDate2 | utilDate1 ≤ utilDate2) {` |
+| `if (sqlDate1.before(sqlDate2) | sqlDate1.after(sqlDate2) | !sqlDate1.before(sqlDate2) | !sqlDate1.after(sqlDate2)) {` | `if (sqlDate1 < sqlDate2 | sqlDate1 > sqlDate2 | sqlDate1 ≥ sqlDate2 | sqlDate1 ≤ sqlDate2) {` |
+| `if (timestamp1.before(timestamp2) | timestamp1.after(timestamp2) | !timestamp1.before(timestamp2) | !timestamp1.after(timestamp2)) {` | `if (timestamp1 < timestamp2 | timestamp1 > timestamp2 | timestamp1 ≥ timestamp2 | timestamp1 ≤ timestamp2) {` |
+| `if (cal1.before(cal2) | cal1.after(cal2) | !cal1.before(cal2) | !cal1.after(cal2)) {` | `if (cal1 < cal2 | cal1 > cal2 | cal1 ≥ cal2 | cal1 ≤ cal2) {` |
+| `if (customObj1.before(customObj2) | customObj1.after(customObj2) | !customObj1.before(customObj2) | !customObj1.after(customObj2)) {` | `if (customObj1 < customObj2 | customObj1 > customObj2 | customObj1 ≥ customObj2 | customObj1 ≤ customObj2) {` |
+| `if (customObj2_1.isBefore(customObj2_2) | customObj2_1.isAfter(customObj2_2) | !customObj2_1.isBefore(customObj2_2) | !customObj2_1.isAfter(customObj2_2)) {` | `if (customObj2_1 < customObj2_2 | customObj2_1 > customObj2_2 | customObj2_1 ≥ customObj2_2 | customObj2_1 ≤ customObj2_2) {` |
+| `return this.minguoDate.isBefore(other.minguoDate);` | `return this.minguoDate < other.minguoDate;` |
+| `return this.minguoDate.isAfter(other.minguoDate);` | `return this.minguoDate > other.minguoDate;` |

--- a/wiki-clone/docs/features/concatenationExpressionsCollapse.md
+++ b/wiki-clone/docs/features/concatenationExpressionsCollapse.md
@@ -159,3 +159,97 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `concatenationExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### StringBuilderTestData mappings
+| Before | After |
+| --- | --- |
+| `StringBuilder sb1 = new StringBuilder("[");` | `StringBuilder sb1 = "[";` |
+| `sb1.append(arg);` | `sb1 += arg;` |
+| `sb1.append(",");` | `sb1 += ",";` |
+| `System.out.println(sb1.append("]").toString());` | `System.out.println(sb1 + "]");` |
+| `StringBuilder sb2 = new StringBuilder().append("[");` | `StringBuilder sb2 = "[";` |
+| `sb2.append(arg);` | `sb2 += arg;` |
+| `sb2.append(",");` | `sb2 += ",";` |
+| `System.out.println(sb2.append("]").toString());` | `System.out.println(sb2 + "]");` |
+| `StringBuilder sb3 = new StringBuilder();` | `StringBuilder sb3 = "";` |
+| `sb3.append(",").append(" ");` | `sb3 += "," + " ";` |
+| `System.out.println(sb3.toString());` | `System.out.println(sb3);` |
+
+##### InterpolatedStringTestData mappings
+| Before | After |
+| --- | --- |
+| `System.out.println("Hello, " + args[0]);` | `System.out.println("Hello, ${args[0]}");` |
+| `System.out.println("Hello, " + args[0] + "!");` | `System.out.println("Hello, ${args[0]}!");` |
+| `System.out.println(args[0] + ", hello!");` | `System.out.println("${args[0]}, hello!");` |
+| `System.out.println(args[0] + ", " + args[0]);` | `System.out.println("${args[0]}, ${args[0]}");` |
+| `System.out.println("Hello, " + name);` | `System.out.println("Hello, $name");` |
+| `System.out.println("Hello, " + name + "!");` | `System.out.println("Hello, $name!");` |
+| `System.out.println(name + ", hello!");` | `System.out.println("$name, hello!");` |
+| `System.out.println(name + ", " + name);` | `System.out.println("$name, $name");` |
+| `System.out.println('"' + name + " says hi");` | `System.out.println("\"$name says hi");` |
+| `System.out.println("Hi " + name + '"');` | `System.out.println("Hi $name\"");` |
+| `System.out.println("Unicode: " + '\\u0041');` | `System.out.println("Unicode: ${'\\u0041'}");` |
+| `System.out.println("Next: " + (char)('A' + 1));` | `System.out.println("Next: ${(char)('A' + 1)}");` |
+| `System.out.println("Length: " + args.length);` | `System.out.println("Length: ${args.length}");` |
+| `System.out.println("Sum: " + (2 + 3));` | `System.out.println("Sum: ${(2 + 3)}");` |
+| `System.out.println("Upper: " + name.toUpperCase());` | `System.out.println("Upper: ${name.toUpperCase()}");` |
+
+##### AppendSetterInterpolatedStringTestData mappings
+| Before | After |
+| --- | --- |
+| `StringBuilder sb1 = new StringBuilder().append(args[0]);` | `StringBuilder sb1 = args[0];` |
+| `sb1.append("Hello, " + args[0]);` | `sb1 += "Hello, ${args[0]}";` |
+| `System.out.println(sb1.toString());` | `System.out.println(sb1);` |
+| `StringBuilder sb2 = new StringBuilder("");` | `StringBuilder sb2 = "";` |
+| `sb2.append(args[0] + ", hello!");` | `sb2 += "${args[0]}, hello!";` |
+| `System.out.println(sb2.toString());` | `System.out.println(sb2);` |
+| `StringBuilder sb3 = new StringBuilder("Hello, ").append(args[0]);` | `StringBuilder sb3 = "Hello, " + args[0];` |
+| `new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);` | `new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";` |
+| `new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");` | `new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";` |
+
+##### ConcatenationTestData mappings
+| Before | After |
+| --- | --- |
+| `list.add("one");` | `list += "one";` |
+| `list.remove("one");` | `list -= "one";` |
+| `list.addAll(singleton);` | `list += singleton;` |
+| `list.removeAll(singleton);` | `list -= singleton;` |
+| `Collections.addAll(list, args);` | `list += args;` |
+| `set.add("three");` | `set += "three";` |
+| `set.remove("three");` | `set -= "three";` |
+| `set.addAll(copyOfSet);` | `set += copyOfSet;` |
+| `List<String> streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());` | `List<String> streamToList = args*.toUpperCase().toList();` |
+| `streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = args*.toUpperCase().toList();` |
+| `streamToList = list.stream().map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = list.stream()*.toUpperCase().toList();` |
+| `long count = streamToList.stream().distinct().count();` | `long count = streamToList.distinct().count();` |
+
+##### OptionalTestData concatenation-adjacent mappings
+| Before | After |
+| --- | --- |
+| `if (opt.isPresent()) { o = opt.get(); }` | `if (opt.isPresent()) { o = opt!!; }` |
+| `o = opt.orElseThrow();` | `o = opt!!;` |
+| `o = Optional.ofNullable(dataNull);` | `o = dataNull;` |
+| `o = Optional.of(data);` | `o = data!!;` |
+| `o = Optional.ofNullable(dataNull).orElseGet(this::orElseGetReturn);` | `o = dataNull ?: this::orElseGetReturn;` |
+| `o = Optional.ofNullable(dataNull).orElseGet(() -> data.getData().getData());` | `o = dataNull ?: () -> data.getData().getData();` |
+| `o = Optional.of(data).map(Data::getData).orElse(null);` | `o = data!!.data ?: null;` |
+| `o = Optional.ofNullable(dataNull).map(OptionalTestData::getOutsideData).get();` | `o = dataNull.map(OptionalTestData::getOutsideData)!!;` |
+| `o = Optional.of(data.getData()).map(OptionalTestData::getOutsideData).map(Data::getString).orElse(data.getString());` | `o = data.getData()!!.map(OptionalTestData::getOutsideData)?.string ?: data.getString();` |
+| `Optional.of(data).flatMap(this::ofNullable).map(data::getDataMethod).orElseGet(() -> getOutsideData(data));` | `data!!.flatMap(this::ofNullable).map(data::getDataMethod) ?: () -> getOutsideData(data);` |
+| `o = Optional.<Data>empty().map(Data::getData).stream().map(Data::getData).filter(Objects::nonNull).findAny().map(Data::getString).get();` | `o = Optional.<Data>empty()?.data.stream()*.data().filterNotNull().findAny()?.string!!;` |
+| `o = opt.map(Data::getData).orElse(null);` | `o = opt?.data ?: null;` |
+| `Stream.of(data).map(Data::getData).filter(Objects::nonNull);` | `Stream.of(data)*.data().filterNotNull();` |
+| `Stream.of(data).map(Data::getData) .filter(Objects::nonNull).map(Data::getData).findFirst().orElseThrow();` | `Stream.of(data)*.data().filterNotNull()*.data().findFirst()!!;` |
+
+##### SpreadTestData stream concatenation mappings
+| Before | After |
+| --- | --- |
+| `String empNames = list.stream().map(Data::getString).collect(Collectors.joining(", "));` | `String empNames = list*.string().collect(Collectors.joining(", "));` |
+| `var p1 = data.getDataList().stream().map(Data::getData).toList();` | `var p1 = data.getDataList().stream()*.data().toList();` |
+| `var p2 = data.getDataList().stream().map(Data::getData).toList().stream().map(Data::getData).toList();` | `var p2 = data.getDataList().stream()*.data().toList().stream()*.data().toList();` |
+| `var stream3 = Stream.of("123", "2313").map(String::length).toList();` | `var stream3 = Stream.of("123", "2313")*.length().toList();` |
+| `var a = stream.map(Data::getData).filter(Objects::nonNull).map(Data::getData).flatMap(Data::getDataStream).map(Data::getDataList).flatMap(List::stream).map(Data::getString).map(String::chars)` | `var a = stream*.data().filterNotNull()*.data()**.dataStream()*.dataList()**.stream()*.string()*.chars()` |
+| `var p = methodStream(data).toList().stream().min(Comparator.comparing(Data::isOk)).stream().min(Comparator.comparing(Data::getString)).map(Data::getString).orElse("string1");` | `var p = methodStream(data).toList().min(Comparator.comparing(Data::isOk)).stream().min(Comparator.comparing(Data::getString))?.string ?: "string1";` |

--- a/wiki-clone/docs/features/const.md
+++ b/wiki-clone/docs/features/const.md
@@ -94,3 +94,120 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `const`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ConstTestData mappings
+| Before | After |
+| --- | --- |
+| `static final Pattern PATTERN = Pattern.compile(".*");` | `default const PATTERN = Pattern.compile(".*");` |
+| `static final Pattern PATTERN_STATIC_IMPORT = compile(".*");` | `default const Pattern PATTERN_STATIC_IMPORT = compile(".*");` |
+| `static final EOrder ENUM = EOrder.FIRST;` | `default econst ENUM = EOrder.FIRST;` |
+| `static final Orderable ENUM_BY_INTERFACE = EOrder.FIRST;` | `default const Orderable ENUM_BY_INTERFACE = EOrder.FIRST;` |
+| `static final EOrder ENUM_STATIC_IMPORT = SECOND;` | `default econst EOrder ENUM_STATIC_IMPORT = SECOND;` |
+| `public static final String PUBLIC_STATIC_FINAL_VAR = "";` | `const PUBLIC_STATIC_FINAL_VAR = "";` |
+| `private static final String PRIVATE_STATIC_FINAL_VAR = "";` | `private const PRIVATE_STATIC_FINAL_VAR = "";` |
+| `protected static final String PROTECTED_STATIC_FINAL_VAR = "";` | `protected const PROTECTED_STATIC_FINAL_VAR = "";` |
+| `static final String DEFAULT_STATIC_FINAL_VAR = "";` | `default const DEFAULT_STATIC_FINAL_VAR = "";` |
+| `public static final String STRING_JOINER = "" + "1";` | `const String STRING_JOINER = "" + "1";` |
+| `public static final String STRING_JOINER2 = "" + DEFAULT_STATIC_FINAL_VAR;` | `const String STRING_JOINER2 = "" + DEFAULT_STATIC_FINAL_VAR;` |
+| `public static final String STRING_JOINER3 = DEFAULT_STATIC_FINAL_VAR + "";` | `const String STRING_JOINER3 = DEFAULT_STATIC_FINAL_VAR + "";` |
+| `public static final String STRING_JOINER4 = DEFAULT_STATIC_FINAL_VAR + PROTECTED_STATIC_FINAL_VAR + PUBLIC_STATIC_FINAL_VAR;` | `const String STRING_JOINER4 = DEFAULT_STATIC_FINAL_VAR + PROTECTED_STATIC_FINAL_VAR + PUBLIC_STATIC_FINAL_VAR;` |
+| `public final static String PUBLIC_FINAL_STATIC_VAR = "";` | `const PUBLIC_FINAL_STATIC_VAR = "";` |
+| `private final static String PRIVATE_FINAL_STATIC_VAR = "";` | `private const PRIVATE_FINAL_STATIC_VAR = "";` |
+| `protected final static String PROTECTED_FINAL_STATIC_VAR = "";` | `protected const PROTECTED_FINAL_STATIC_VAR = "";` |
+| `static public final String STATIC_PUBLIC_FINAL_VAR = "";` | `const STATIC_PUBLIC_FINAL_VAR = "";` |
+| `static final public String STATIC_FINAL_PUBLIC_VAR = "";` | `const STATIC_FINAL_PUBLIC_VAR = "";` |
+| `final public static String FINAL_PUBLIC_STATIC_VAR = "";` | `const FINAL_PUBLIC_STATIC_VAR = "";` |
+| `final static public String FINAL_STATIC_PUBLIC_VAR = "";` | `const FINAL_STATIC_PUBLIC_VAR = "";` |
+| `static final String DEFAULT_STATIC_FINAL_VAR_REF = DEFAULT_STATIC_FINAL_VAR;` | `default const String DEFAULT_STATIC_FINAL_VAR_REF = DEFAULT_STATIC_FINAL_VAR;` |
+| `static final int VERSION = 1;` | `default const VERSION = 1;` |
+| `static final int VERSION_REF = VERSION;` | `default const VERSION_REF = VERSION;` |
+| `@Deprecated static final Pattern PATTERN = Pattern.compile(".*");` | `@Deprecated default const PATTERN = Pattern.compile(".*");` |
+
+##### ConstructorReferenceNotationWithConstTestData mappings
+| Before | After |
+| --- | --- |
+| `public static final ConstClass SELF = new ConstClass();` | `const ConstClass SELF = ::new;` |
+| `public static final ConstClass SELF_ANN = new ConstClass() {` | `const ConstClass SELF_ANN = ::new{};` |
+| `public static final ConstClass SELF_SUB = new SubConstClass();` | `const ConstClass SELF_SUB = new SubConstClass();` |
+| `public static final ConstClass SELF_SUB_ANN = new SubConstClass() {` | `const ConstClass SELF_SUB_ANN = new SubConstClass() {` |
+| `private static final HashMap<String, String> MAP = new HashMap<>();` | `private const HashMap<String, String> MAP = ::new;` |
+| `private static final HashMap<String, String> MAP2 = new HashMap<String, String>();` | `private const HashMap<String, String> MAP2 = ::new;` |
+| `private static final Map<String, String> MAP3 = new HashMap<>();` | `private const Map<String, String> MAP3 = new HashMap<>();` |
+| `private static final Map<String, String> MAP_TREE = new TreeMap<>();` | `private const Map<String, String> MAP_TREE = new TreeMap<>();` |
+| `private static final Map<String, String> MAP4 = Map.of();` | `private const Map<String, String> MAP4 = Map.of();` |
+| `private static final List<String> LIST = new ArrayList<>();` | `private const List<String> LIST = new ArrayList<>();` |
+| `private static final List<String> LIST2 = List.of();` | `private const List<String> LIST2 = List.of();` |
+| `private static final List<String> LIST_SINGLE = List.of("1");` | `private const List<String> LIST_SINGLE = List.of("1");` |
+| `private static final List<String> LIST_LINKED = new LinkedList<>();` | `private const List<String> LIST_LINKED = new LinkedList<>();` |
+| `public static final ConstClass SELF_PARAM_1 = new ConstClass(true);` | `const ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public static final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST_SINGLE.get(0));` | `const ConstClass SELF_PARAM_2 = ::new(false, LIST_SINGLE.get(0));` |
+| `public static final ConstClass SELF_SUBCLASS_MORE_FIELD = new ConstClass() {` | `const ConstClass SELF_SUBCLASS_MORE_FIELD = new ConstClass() {` |
+| `public static final ConstClass SELF_SUBCLASS_MORE_FUNC = new ConstClass() {` | `const ConstClass SELF_SUBCLASS_MORE_FUNC = new ConstClass() {` |
+| `final ConstClass SELF = new ConstClass();` | `final ConstClass SELF = ::new;` |
+| `ConstClass SELF_ANN = new ConstClass() {` | `ConstClass SELF_ANN = ::new{};` |
+| `public final ConstClass SELF_SUB = new SubConstClass();` | `public final ConstClass SELF_SUB = new SubConstClass();` |
+| `private final HashMap<String, String> MAP = new HashMap<>();` | `private final HashMap<String, String> MAP = ::new;` |
+| `private final HashMap<String, String> MAP2 = new HashMap<String, String>();` | `private final HashMap<String, String> MAP2 = ::new;` |
+| `private final Map<String, String> MAP3 = new HashMap<>();` | `private final Map<String, String> MAP3 = new HashMap<>();` |
+| `private final List<String> LIST = new ArrayList<>();` | `private final List<String> LIST = new ArrayList<>();` |
+| `private final List<String> LIST2 = List.of("1");` | `private final List<String> LIST2 = List.of("1");` |
+| `public final ConstClass SELF_PARAM_1 = new ConstClass(true);` | `public final ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST2.get(0));` | `public final ConstClass SELF_PARAM_2 = ::new(false, LIST2.get(0));` |
+
+##### ExperimentalTestData const-adjacent mappings
+| Before | After |
+| --- | --- |
+| `<pre>try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+                return new String(bytez, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }</pre>` | `<pre>@SneakyThrows {
+                byte[] bytez = System["sort-desc"].bytes;
+                return new String(bytez, "UTF-8");
+            }</pre>` |
+| `<pre>try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `@SneakyThrows(IllegalArgumentException) return Integer.parseInt(value);` |
+| `<pre>try {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `<pre>@SneakyThrows(IllegalArgumentException) {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            }</pre>` |
+| `<pre>try {
+                var throwable = new Throwable();
+                throw throwable;
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `<pre>@SneakyThrows {
+                var throwable = new Throwable();
+                throw throwable;
+            }</pre>` |
+| `<pre>try {
+                return new String(System.getProperty("sort-desc").getBytes(), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }</pre>` | `@SneakyThrows return new String(System["sort-desc"].bytes, "UTF-8");` |
+| `<pre>try {
+            throw new Throwable();
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `@SneakyThrows throw new Throwable();` |
+| `<pre>example.set("ok");
+            String current = example.get();
+            System.out.println(example.get().isEmpty());
+            example.set(example.get());
+            String duplicate = example.get() + example.get();</pre>` | `<pre>example.!! = "ok";
+            String current = example.!!;
+            System.out.println(example.!!.empty);
+            example.!! = example.!!;
+            String duplicate = example.!! + example.!!;</pre>` |

--- a/wiki-clone/docs/features/constructorReferenceNotation.md
+++ b/wiki-clone/docs/features/constructorReferenceNotation.md
@@ -64,3 +64,50 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `constructorReferenceNotation`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ConstructorReferenceNotationTestData mappings
+| Before | After |
+| --- | --- |
+| `public static final ConstClass SELF = new ConstClass();` | `public static final ConstClass SELF = ::new;` |
+| `public static final ConstClass SELF_ANN = new ConstClass() {` | `public static final ConstClass SELF_ANN = ::new{};` |
+| `private static final HashMap<String, String> MAP = new HashMap<>();` | `private static final HashMap<String, String> MAP = ::new;` |
+| `private static final HashMap<String, String> MAP2 = new HashMap<String, String>();` | `private static final HashMap<String, String> MAP2 = ::new;` |
+| `public static final ConstClass SELF_PARAM_1 = new ConstClass(true);` | `public static final ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public static final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST_SINGLE.get(0));` | `public static final ConstClass SELF_PARAM_2 = ::new(false, LIST_SINGLE.get(0));` |
+| `final ConstClass SELF = new ConstClass();` | `final ConstClass SELF = ::new;` |
+| `ConstClass SELF_ANN = new ConstClass() {` | `ConstClass SELF_ANN = ::new{};` |
+| `private final HashMap<String, String> MAP = new HashMap<>();` | `private final HashMap<String, String> MAP = ::new;` |
+| `private final HashMap<String, String> MAP2 = new HashMap<String, String>();` | `private final HashMap<String, String> MAP2 = ::new;` |
+| `public final ConstClass SELF_PARAM_1 = new ConstClass(true);` | `public final ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST2.get(0));` | `public final ConstClass SELF_PARAM_2 = ::new(false, LIST2.get(0));` |
+
+##### ConstructorReferenceNotationWithConstTestData mappings
+| Before | After |
+| --- | --- |
+| `public static final ConstClass SELF = new ConstClass();` | `const ConstClass SELF = ::new;` |
+| `public static final ConstClass SELF_ANN = new ConstClass() {` | `const ConstClass SELF_ANN = ::new{};` |
+| `public static final ConstClass SELF_SUB = new SubConstClass();` | `const ConstClass SELF_SUB = new SubConstClass();` |
+| `public static final ConstClass SELF_SUB_ANN = new SubConstClass() {` | `const ConstClass SELF_SUB_ANN = new SubConstClass() {` |
+| `private static final HashMap<String, String> MAP = new HashMap<>();` | `private const HashMap<String, String> MAP = ::new;` |
+| `private static final HashMap<String, String> MAP2 = new HashMap<String, String>();` | `private const HashMap<String, String> MAP2 = ::new;` |
+| `private static final Map<String, String> MAP3 = new HashMap<>();` | `private const Map<String, String> MAP3 = new HashMap<>();` |
+| `private static final Map<String, String> MAP_TREE = new TreeMap<>();` | `private const Map<String, String> MAP_TREE = new TreeMap<>();` |
+| `private static final Map<String, String> MAP4 = Map.of();` | `private const Map<String, String> MAP4 = Map.of();` |
+| `private static final List<String> LIST = new ArrayList<>();` | `private const List<String> LIST = new ArrayList<>();` |
+| `private static final List<String> LIST2 = List.of();` | `private const List<String> LIST2 = List.of();` |
+| `private static final List<String> LIST_SINGLE = List.of("1");` | `private const List<String> LIST_SINGLE = List.of("1");` |
+| `private static final List<String> LIST_LINKED = new LinkedList<>();` | `private const List<String> LIST_LINKED = new LinkedList<>();` |
+| `public static final ConstClass SELF_PARAM_1 = new ConstClass(true);` | `const ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public static final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST_SINGLE.get(0));` | `const ConstClass SELF_PARAM_2 = ::new(false, LIST_SINGLE.get(0));` |
+| `public static final ConstClass SELF_SUBCLASS_MORE_FIELD = new ConstClass() {` | `const ConstClass SELF_SUBCLASS_MORE_FIELD = new ConstClass() {` |
+| `public static final ConstClass SELF_SUBCLASS_MORE_FUNC = new ConstClass() {` | `const ConstClass SELF_SUBCLASS_MORE_FUNC = new ConstClass() {` |
+| `private static final HashMap<String, String> MAP = new HashMap<>();` (fields section) | `private const HashMap<String, String> MAP = ::new;` |
+| `private static final HashMap<String, String> MAP2 = new HashMap<String, String>();` (fields section) | `private const HashMap<String, String> MAP2 = ::new;` |
+| `private static final Map<String, String> MAP3 = new HashMap<>();` (fields section) | `private const Map<String, String> MAP3 = new HashMap<>();` |
+| `private static final List<String> LIST = new ArrayList<>();` (fields section) | `private const List<String> LIST = new ArrayList<>();` |
+| `private static final List<String> LIST2 = List.of("1");` (fields section) | `private const List<String> LIST2 = List.of("1");` |
+| `public static final ConstClass SELF_PARAM_1 = new ConstClass(true);` (fields section) | `public final ConstClass SELF_PARAM_1 = ::new(true);` |
+| `public static final ConstClass SELF_PARAM_2 = new ConstClass(false, LIST2.get(0));` (fields section) | `public final ConstClass SELF_PARAM_2 = ::new(false, LIST2.get(0));` |

--- a/wiki-clone/docs/features/controlFlowMultiStatementCodeBlockCollapse.md
+++ b/wiki-clone/docs/features/controlFlowMultiStatementCodeBlockCollapse.md
@@ -26,3 +26,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `controlFlowMultiStatementCodeBlockCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ControlFlowMultiStatementTestData mappings
+| Before | After |
+| --- | --- |
+| `if (args.length > 0) { System.out.println("..."); System.out.println("..."); }` | `if (args.length > 0) System.out.println("..."); System.out.println("...");` |
+| `if (args.length == 0) { System.out.println("..."); System.out.println("..."); } else { System.out.println("Success"); }` | `if (args.length == 0) System.out.println("..."); System.out.println("..."); else { System.out.println("Success"); }` |
+| `if (args.length > 0) { System.out.println("Terminating"); } else { System.out.println("Terminating"); System.out.println("..."); }` | `if (args.length > 0) { System.out.println("Terminating"); } else System.out.println("Terminating"); System.out.println("...");` |
+| `for (String arg : args) { System.out.println(i++); System.out.println(arg); }` | `for (String arg : args) System.out.println(i++); System.out.println(arg);` |
+| `while (true) { System.out.println("..."); break; }` | `while (true) System.out.println("..."); break;` |
+| `try { System.out.println("..."); System.out.println("..."); } catch (Exception e) { System.out.println("..."); e.printStackTrace(); }` | `try System.out.println("..."); System.out.println("..."); catch (Exception e) System.out.println("..."); e.printStackTrace();` |
+| `do { System.out.println("..."); break; } while (true);` | `do System.out.println("..."); break; while (true);` |

--- a/wiki-clone/docs/features/controlFlowSingleStatementCodeBlockCollapse.md
+++ b/wiki-clone/docs/features/controlFlowSingleStatementCodeBlockCollapse.md
@@ -26,3 +26,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `controlFlowSingleStatementCodeBlockCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ControlFlowSingleStatementTestData mappings
+| Before | After |
+| --- | --- |
+| `if (args.length > 0) { System.out.println(Arrays.asList(args)); }` | `if (args.length > 0) System.out.println(Arrays.asList(args));` |
+| `if (args.length == 0) { System.out.println("..."); } else { System.out.println("..."); }` | `if (args.length == 0) System.out.println("..."); else System.out.println("...");` |
+| `for (String arg : args) { System.out.println(arg); }` | `for (String arg : args) System.out.println(arg);` |
+| `for (int i = 0; i < args.length; i++) { System.out.println(args[i]); }` | `for (int i = 0; i < args.length; i++) System.out.println(args[i]);` |
+| `while (true) { break; }` | `while (true) break;` |
+| `do { break; } while (true);` | `do break; while (true);` |
+| `try { System.out.println("..."); } catch (Exception e) { System.out.println("..."); }` | `try System.out.println("..."); catch (Exception e) System.out.println("...");` |

--- a/wiki-clone/docs/features/destructuring.md
+++ b/wiki-clone/docs/features/destructuring.md
@@ -93,3 +93,77 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `destructuring`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### DestructuringAssignmentArrayTestData mappings
+| Before | After |
+| --- | --- |
+| `Data ignored1 = array[0];` | `val ignored1 = array[0];` |
+| `<pre>Data first = array[0];
+
+        Data second = array[1];
+        Data third = array[2];
+        Data fourth = array[3];</pre>` | `val first, second, third, fourth) = array;` |
+| `Data ignored21 = data.getArray()[4];` | `val ignored21 = data.array[4];` |
+| `Data ignored22 = data.getArray()[5];` | `val ignored22 = data.array[5];` |
+| `<pre>Data getter1 = data.getArray()[0];
+        Data getter2 = data.getArray()[1];
+        Data getter3 = data.getArray()[2];</pre>` | `var getter1, getter2, getter3) = data.array;` |
+| `<pre>Data deepGetter1 = data.getData().getArray()[0];
+        Data deepGetter2 = data.getData().getArray()[1];</pre>` | `val deepGetter1, deepGetter2) = data.data.array;` |
+| `Data wrongParent1 = data.getArray()[0];` | `val wrongParent1 = data.array[0];` |
+| `Data wrongParent2 = data.getData().getArray()[1];` | `val wrongParent2 = data.data.array[1];` |
+
+##### DestructuringAssignmentArrayWithoutValTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>Data first = array[0];
+
+        Data second = array[1];
+        Data third = array[2];
+        Data fourth = array[3];</pre>` | `Data (first, second, third, fourth) = array;` |
+| `Data ignored21 = data.getArray()[4];` | `Data ignored21 = data.array[4];` |
+| `Data ignored22 = data.getArray()[5];` | `Data ignored22 = data.array[5];` |
+| `<pre>Data getter1 = data.getArray()[0];
+        Data getter2 = data.getArray()[1];</pre>` | `Data (getter1, getter2) = data.array;` |
+| `<pre>Data deepGetter1 = data.getData().getArray()[0];
+        Data deepGetter2 = data.getData().getArray()[1];</pre>` | `Data (deepGetter1, deepGetter2) = data.data.array;` |
+| `Data wrongParent1 = data.getArray()[0];` | `Data wrongParent1 = data.array[0];` |
+| `Data wrongParent2 = data.getData().getArray()[1];` | `Data wrongParent2 = data.data.array[1];` |
+
+##### DestructuringAssignmentListTestData mappings
+| Before | After |
+| --- | --- |
+| `Data ignored1 = list.get(0);` | `val ignored1 = list.get(0);` |
+| `<pre>Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);</pre>` | `val first, second, third, fourth) = list;` |
+| `Data ignored21 = data.getList().get(4);` | `val ignored21 = data.list.get(4);` |
+| `Data ignored22 = data.getList().get(5);` | `val ignored22 = data.list.get(5);` |
+| `<pre>Data getter1 = data.getList().get(0);
+        Data getter2 = data.getList().get(1);
+        Data getter3 = data.getList().get(2);</pre>` | `var getter1, getter2, getter3) = data.list;` |
+| `<pre>Data deepGetter1 = data.getData().getList().get(0);
+        Data deepGetter2 = data.getData().getList().get(1);</pre>` | `val deepGetter1, deepGetter2) = data.data.list;` |
+| `Data wrongParent1 = data.getList().get(0);` | `val wrongParent1 = data.list.get(0);` |
+| `Data wrongParent2 = data.getData().getList().get(1);` | `val wrongParent2 = data.data.list.get(1);` |
+
+##### DestructuringAssignmentListWithoutValTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>Data first = list.get(0);
+        Data second = list.get(1);
+        Data third = list.get(2);
+        Data fourth = list.get(3);</pre>` | `Data (first, second, third, fourth) = list;` |
+| `Data ignored21 = data.getList().get(4);` | `Data ignored21 = data.list.get(4);` |
+| `Data ignored22 = data.getList().get(5);` | `Data ignored22 = data.list.get(5);` |
+| `<pre>Data getter1 = data.getList().get(0);
+        Data getter2 = data.getList().get(1);
+        Data getter3 = data.getList().get(2);</pre>` | `Data (getter1, getter2, getter3) = data.list;` |
+| `<pre>Data deepGetter1 = data.getData().getList().get(0);
+        Data deepGetter2 = data.getData().getList().get(1);</pre>` | `Data (deepGetter1, deepGetter2) = data.data.list;` |
+| `Data wrongParent1 = data.getList().get(0);` | `Data wrongParent1 = data.list.get(0);` |
+| `Data wrongParent2 = data.getData().getList().get(1);` | `Data wrongParent2 = data.data.list.get(1);` |

--- a/wiki-clone/docs/features/dynamic.md
+++ b/wiki-clone/docs/features/dynamic.md
@@ -27,3 +27,19 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `dynamic`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### DynamicTestData mappings
+| Before | After |
+| --- | --- |
+| `public static void staticMethod(Data data) {` | `public static void changedStaticMethod(Data data) {` |
+| `.normalMethod(` | `.changedNormalMethod(` |
+| `staticMethod(` | `changedStaticMethod(` |
+| `new DynamicTestData().staticMethod(` | `new DynamicTestData().changedStaticMethod(` |
+| `data.getData()` | `data.data` |
+| `staticMethod(data.getData());` | `changedStaticMethod(data.data);` |
+| `private String normalMethod(String args) {` | `private String changedNormalMethod(String args) {` |
+| `return normalMethod(args.substring(1));` | `return changedNormalMethod(args.substring(1));` |
+| `private static String staticMethod(String args) {` | `private static String changedStaticMethod(String args) {` |

--- a/wiki-clone/docs/features/emojify.md
+++ b/wiki-clone/docs/features/emojify.md
@@ -101,3 +101,12 @@ folded/EmojifyTestData-folded.java:
         }
 ```
 Emojify replaces the `void` return type and `int` local with their emoji counterparts while leaving `Math.max` untouched.
+
+#### Integration coverage
+
+The `testData/EmojifyTestData-all.java` fixture runs the emoji substitutions across every context used in integration tests. The folded output shows:
+
+* Namespace keywords (`package`, `import`), declaration modifiers (`final`, `static`, `abstract`, `transient`, `volatile`, `native`), and type keywords (`void`, `int`, `boolean`, etc.) all render with their emoji replacements inside class headers, fields, constructors, and method signatures.
+* Control-flow tokens like `try`, `catch`, `return`, `for`, `switch`, and `default` pick up their glyphs even when nested inside anonymous classes, lambdas, or enhanced for-loops.
+* The singleton access rewrite converts `Singleton.INSTANCE` into `Singleton.🧍`, matching the integration scenarios that assign or return the singleton reference.
+* Because the processor operates after other folds, Lombok-generated getters/setters, builder patterns, and other feature rewrites coexist with the emoji tokens—ensuring the emoji version of each keyword appears alongside any additional folding.

--- a/wiki-clone/docs/features/experimental.md
+++ b/wiki-clone/docs/features/experimental.md
@@ -29,3 +29,64 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `experimental`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### SneakyThrows scaffolding
+| Before | After |
+| --- | --- |
+| `<pre>try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+                return new String(bytez, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }</pre>` | `<pre>@SneakyThrows {
+                byte[] bytez = System["sort-desc"].bytes;
+                return new String(bytez, "UTF-8");
+            }</pre>` |
+| `<pre>try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `@SneakyThrows(IllegalArgumentException)
+            return Integer.parseInt(value);` |
+| `<pre>try {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `<pre>@SneakyThrows(IllegalArgumentException) {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            }</pre>` |
+| `<pre>try {
+                var throwable = new Throwable();
+                throw throwable;
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `<pre>@SneakyThrows {
+                var throwable = new Throwable();
+                throw throwable;
+            }</pre>` |
+| `<pre>try {
+            throw new Throwable();
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `@SneakyThrows
+            throw new Throwable();` |
+
+##### Property shortcuts
+| Before | After |
+| --- | --- |
+| `System.getProperty("sort-desc").getBytes();` | `System["sort-desc"].bytes;` |
+| `new String(System.getProperty("sort-desc").getBytes(), "UTF-8");` | `new String(System["sort-desc"].bytes, "UTF-8");` |
+
+##### Nameless accessor placeholders
+| Before | After |
+| --- | --- |
+| `example.set("ok");` | `example.!! = "ok";` |
+| `String current = example.get();` | `String current = example.!!;` |
+| `System.out.println(example.get().isEmpty());` | `System.out.println(example.!!.empty);` |
+| `example.set(example.get());` | `example.!! = example.!!;` |
+| `String duplicate = example.get() + example.get();` | `String duplicate = example.!! + example.!!;` |

--- a/wiki-clone/docs/features/expressionFunc.md
+++ b/wiki-clone/docs/features/expressionFunc.md
@@ -29,3 +29,55 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `expressionFunc`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ExpressionFuncTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>public long findNinjaId() {
+        return 1L;
+    }</pre>` | `findNinjaId { 1L }` |
+| `<pre>private void printStatus() {
+        new HashMap<String, String>().put("a", "b");
+    }</pre>` | `private void printStatus() { new HashMap<String, String>().put("a", "b") }` |
+| `<pre>private String printStatusReturn() {
+        return new HashMap<String, String>().put("a", "b");
+    }</pre>` | `private String printStatusReturn() { new HashMap<String, String>().put("a", "b") }` |
+| `<pre>public boolean isUser() {
+        return false;
+    }</pre>` | `isUser { false }` |
+| `<pre>public String tableName() {
+        return "table1";
+    }</pre>` | `tableName { "table1" }` |
+| `<pre>public String columnName(String column) {
+        return "column1";
+    }</pre>` | `columnName(String column) { "column1" }` |
+| `<pre>public void assignField(String field) {
+        this.field = field;
+    }</pre>` | `public void assignField(String field) { this.field = field }` |
+| `<pre>public String assignFieldAndReturn(String field) {
+        return this.field = field;
+    }</pre>` | `public String assignFieldAndReturn(String field) { this.field = field }` |
+| `<pre>public String methodCall(String field) {
+        return assignFieldAndReturn(field);
+    }</pre>` | `public String methodCall(String field) { assignFieldAndReturn(field) }` |
+| `<pre>public void methodCall2(String field) {
+        assignFieldAndReturn(field);
+    }</pre>` | `public void methodCall2(String field) { assignFieldAndReturn(field) }` |
+| `<pre>public void streamShort(List<String> list) {
+        list.stream().map(Function.identity()).map(Function.identity());
+    }</pre>` | `public void streamShort(List<String> list) { list.stream().map(Function.identity()).map(Function.identity()) }` |
+| `<pre>public long getId() {
+            return 0L;
+        }</pre>` | `getId { 0L }` |
+| `<pre>public long getId() {
+            return 2L;
+        }</pre>` | `getId { 2L }` |
+| `<pre>public long getId() {
+            return 3L;
+        }</pre>` | `getId { 3L }` |
+| `<pre>public long getId() {
+            return 1L;
+        }</pre>` | `getId { 1L }` |

--- a/wiki-clone/docs/features/fieldShift.md
+++ b/wiki-clone/docs/features/fieldShift.md
@@ -121,3 +121,42 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `fieldShift`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### FieldShiftBuilder adjustments
+| Before | After |
+| --- | --- |
+| `this.username = username;` | `this.username = <<;` |
+| `.username(record.username())` | `.username(record<<)` |
+| `.active(source.isActive())` | `.active(source<<)` |
+| `.userIdentifier(source.getUserIdentifier())` | `.userIdentifier(source<<)` |
+| `.child(builder1 ... .build().getChild())` | `.child(builder1 ... .build()<<)` |
+| `.username(source.getUsername() + source.getUserIdentifier())` | `.username(source.username + source.userIdentifier)` |
+
+##### FieldShiftSetters adjustments
+| Before | After |
+| --- | --- |
+| `result.setUsername(source.getUsername());` | `result.username = source<<;` |
+| `result.setActive(source.isActive());` | `result.active = source<<;` |
+| `result.setUserIdentifier(source.getUserIdentifier());` | `result.userIdentifier = source<<;` |
+| `setters2.setActive(setters.isActive());` | `setters2.active = setters<<;` |
+| `childBuilder2.setUsername(source.getUsername());` | `childBuilder2.username = source<<;` |
+
+##### FieldShiftFields adjustments
+| Before | After |
+| --- | --- |
+| `this.userIdentifier = child.userIdentifier;` | `this.userIdentifier = child.<<;` |
+| `result.username = source.child.username;` | `result.username = source.child.<<;` |
+| `result.userIdentifier = source.userIdentifier;` | `result.userIdentifier = source.<<;` |
+| `setters2.userIdentifier = record.userIdentifier();` | `setters2.userIdentifier = record.<<;` |
+| `result.child = childBuilder2.child.child.child.child;` | `result.child = childBuilder2.child.child.child.<<;` |
+
+##### NullableAnnotationCheckNotNullFieldShiftTestData adjustments
+| Before | After |
+| --- | --- |
+| `this.args = Preconditions.checkNotNull(args);` | `this.args = <<!!;` |
+| `this.l = Preconditions.checkNotNull(l);` | `this.l = <<!!;` |
+| `this.data = Preconditions.checkNotNull(z.getData());` | `this.data = z.<<!!;` |
+| `this.o = Preconditions.checkNotNull(o);` | `this.o = <<!!;` |

--- a/wiki-clone/docs/features/finalEmoji.md
+++ b/wiki-clone/docs/features/finalEmoji.md
@@ -29,3 +29,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `finalEmoji`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### FinalEmojiTestData mappings
+| Before | After |
+| --- | --- |
+| `public final String m() {` | `public 🔒 String m() {` |
+| `final String s = "1";` | `🔒 String s = "1";` |
+| `final var s2 = "2";` | `🔒 var s2 = "2";` |
+| `void main(final String arg, final int i, final Object o, Data data);` | `void main(🔒 String arg, 🔒 int i, 🔒 Object o, Data data);` |
+| `final static class Data {` | `🔒 static class Data {` |
+| `final public record UserDataRecord(String username, boolean active, String userIdentifier) {` | `🔒 public record UserDataRecord(String username, boolean active, String userIdentifier) {` |
+| `final void main(final String arg, final int i, final Object o, Data data) {` | `🔒 void main(🔒 String arg, 🔒 int i, 🔒 Object o, Data data) {` |

--- a/wiki-clone/docs/features/finalRemoval.md
+++ b/wiki-clone/docs/features/finalRemoval.md
@@ -29,3 +29,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `finalRemoval`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### FinalRemovalTestData mappings
+| Before | After |
+| --- | --- |
+| `public final String m() {` | `public  String m() {` |
+| `final String s = "1";` | ` String s = "1";` |
+| `final var s2 = "2";` | ` var s2 = "2";` |
+| `void main(final String arg, final int i, final Object o, Data data);` | `void main( String arg,  int i,  Object o, Data data);` |
+| `final static class Data {` | ` static class Data {` |
+| `final public record UserDataRecord(String username, boolean active, String userIdentifier) {` | ` public record UserDataRecord(String username, boolean active, String userIdentifier) {` |
+| `final void main(final String arg, final int i, final Object o, Data data) {` | ` void main( String arg,  int i,  Object o, Data data) {` |

--- a/wiki-clone/docs/features/getExpressionsCollapse.md
+++ b/wiki-clone/docs/features/getExpressionsCollapse.md
@@ -58,3 +58,36 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `getExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### GetSetPutTestData mappings
+| Before | After |
+| --- | --- |
+| `List<String> list = Arrays.asList("one", "two");` | `List<String> list = ["one", "two"];` |
+| `list.set(1,"three" );` | `list[1] = "three";` |
+| `System.out.println(list.get(list.size() - 1));` | `System.out.println(list.getLast());` |
+| `System.out.println(args[args.length - 1]);` | `System.out.println(args.last());` |
+| `map.put("one", 1);` | `map["one"] = 1;` |
+| `System.out.println(map.get("two"));` | `System.out.println(map["two"]);` |
+| `List<String> singleton = java.util.Collections.singletonList("one");` | `List<String> singleton = ["one"];` |
+| `List<String> asList = Arrays.asList("one", "two");` | `List<String> asList = ["one", "two"];` |
+| `List<String> copy = new ArrayList<>(Arrays.asList("one", "two"));` | `List<String> copy = ["one", "two"];` |
+| `List<String> unmodifiable = Collections.unmodifiableList(Arrays.asList("one", "two"));` | `List<String> unmodifiable = ["one", "two"];` |
+| `Set<String> set = new HashSet<String>() { { add("one"); add("two"); } };` | `Set<String> set = ["one", "two"];` |
+| `Set<String> copyOfSet = Collections.unmodifiableSet(new HashSet<String>() { { add("one"); add("two"); } });` | `Set<String> copyOfSet = ["one", "two"];` |
+| `String[] strings = new String[] {"one", "two"};` | `String[] strings = ["one", "two"];` |
+| `System.out.println(System.getProperty("user.dir"));` | `System.out.println(System["user.dir"]);` |
+| `System.out.println(System.getenv().get("user.dir"));` | `System.out.println(System.getenv()["user.dir"]);` |
+
+##### ExperimentalTestData mappings for get expressions
+| Before | After |
+| --- | --- |
+| `byte[] bytez = System.getProperty("sort-desc").getBytes();` | `byte[] bytez = System["sort-desc"].bytes;` |
+| `return new String(System.getProperty("sort-desc").getBytes(), "UTF-8");` | `return new String(System["sort-desc"].bytes, "UTF-8");` |
+| `example.set("ok");` | `example.!! = "ok";` |
+| `String current = example.get();` | `String current = example.!!;` |
+| `System.out.println(example.get().isEmpty());` | `System.out.println(example.!!.empty);` |
+| `example.set(example.get());` | `example.!! = example.!!;` |
+| `String duplicate = example.get() + example.get();` | `String duplicate = example.!! + example.!!;` |

--- a/wiki-clone/docs/features/getSetExpressionsCollapse.md
+++ b/wiki-clone/docs/features/getSetExpressionsCollapse.md
@@ -372,3 +372,135 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `getSetExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### AppendSetterInterpolatedStringTestData property mappings
+| Before | After |
+| --- | --- |
+| `new AppendSetterInterpolatedStringTestData().setName("Hello, " + args[0]);` | `new AppendSetterInterpolatedStringTestData().name = "Hello, ${args[0]}";` |
+| `new AppendSetterInterpolatedStringTestData().setName(args[0] + ", hello!");` | `new AppendSetterInterpolatedStringTestData().name = "${args[0]}, hello!";` |
+##### GetterSetterTestData direct field access
+| Before | After |
+| --- | --- |
+| `d.setParent(d);` | `d.parent = d;` |
+| `d.setName("Hello");` | `d.name = "Hello";` |
+| `d.getParent().setName("Pum!");` | `d.parent.name = "Pum!";` |
+| `System.out.println(d.getParent().getName());` | `System.out.println(d.parent.name);` |
+##### IfNullSafeData getter to property conversions
+| Before | After |
+| --- | --- |
+| `data.getData1() != null` | `data?.data1 != null` |
+| `data.getData1().getData2() != null` | `data?.data1?.data2 != null` |
+| `data.getData1().getData2().getData3() != null` | `data?.data1?.data2?.data3 != null` |
+| `data.getData1().getData2().getData3().getData4() != null` | `data?.data1?.data2?.data3?.data4 != null` |
+| `data.getData1().isActive()` | `data?.data1?.active == true` |
+| `!data.getData1().isActive()` | `data?.data1?.active == false` |
+| `data.isActive()` | `data?.active == true` |
+| `!data.isActive()` | `data?.active == false` |
+| `data.getData2()` | `data?.data2` |
+| `data.getData3().getData4()` | `data.data3.data4` |
+| `data2.getData1().getData2()` | `data2.data1.data2` |
+| `data2.getData1()` | `data2.data1` |
+##### LogBrackets nested access mappings
+| Before | After |
+| --- | --- |
+| `log.trace("Trace message - Name: %s, log:%s    $", data.getName(), logPrintfStyle(data));` | `log.trace("Trace message - Name: ${data.name}, log:${logPrintfStyle(data)}    $");` |
+| `log.warn("Warning message with three parameters - Name: %s, Age: %s, City: %s", name, data.getData().getName(), city);` | `log.warn("Warning message with three parameters - Name: $name, Age: ${data.data.name}, City: $city");` |
+| `log.error("error1 %s", e, e.getMessage(), e);` | `log.error("error1 $e", e, e.message, e);` |
+| `log.error("error2 %s", data.getData().getName(), data.getData().getName(), data.getData().getName());` | `log.error("error2 ${data.data.name}", data.data.name, data.data.name);` |
+| `Formatter formatter = new Formatter(); formatter.format("User details - Name: %s, Age: %d, City: %s", name, age, city); log.info("Formatter example: {}", formatter.toString());` | `Formatter formatter = new Formatter(); formatter.format("User details - Name: $name, Age: $age, City: $city"); log.info("Formatter example: ${formatter.toString()}");` |
+| `System.out.println("Warning message with three parameters - Name: %s, Age: %s, City: %s".formatted(name, data.getData().getName(), city));` | `System.out.println("Warning message with three parameters - Name: $name, Age: ${data.data.name}, City: $city".formatted());` |
+| `log.error("Failed to write to log file: %s", e.getMessage());` | `log.error("Failed to write to log file: ${e.message}");` |
+##### LogFoldingTextBlocksTestData property mappings
+| Before | After |
+| --- | --- |
+| `log.warn("Warning message with three parameters - Name: %s, Age: %s, City: %s", name, data.getData().getName(), city);` | `log.warn("Warning message with three parameters - Name: $name, Age: ${data.data.name}, City: $city");` |
+| `log.error("Missing 1 parameter - 1: %s, 2: %d, 3: %s, empty: %s", name, age, city);` | `log.error("Missing 1 parameter - 1: $name, 2: $age, 3: $city, empty: %s");` |
+| `log.error("error1 %s", e, e.getMessage(), e);` | `log.error("error1 $e", e, e.message, e);` |
+| `log.error("error2 %s", data.getData().getName(), data.getData().getName(), data.getData().getName());` | `log.error("error2 ${data.data.name}", data.data.name, data.data.name);` |
+| `System.out.println("Trace message - Name: %s, log:%s    $".formatted(data.getName(), logPrintfStyle(data)));` | `System.out.println("Trace message - Name: ${data.name}, log:${logPrintfStyle(data)}    $".formatted());` |
+| `log.info("""\n                Data summary:\n                Root: {}\n                Child: {}\n                """, data.getName(), data.getData().getName());` | `log.info("""\n                Data summary:\n                Root: ${data.name}\n                Child: ${data.data.name}\n                """);` |
+| `log.trace("""\n                Formatter contents:\n                {}\n                """, formatter);` | `log.trace("""\n                Formatter contents:\n                $formatter\n                """);` |
+##### FieldShiftBuilder shorthand mappings
+| Before | After |
+| --- | --- |
+| `this.username = username;` | `this.username = <<;` |
+| `this.active = active;` | `this.active = <<;` |
+| `this.userIdentifier = userIdentifier;` | `this.userIdentifier = <<;` |
+| `this.child = child;` | `this.child = <<;` |
+| `.username(record.username())` | `.username(record<<)` |
+| `.userIdentifier(source.getUserIdentifier())` | `.userIdentifier(source<<)` |
+| `.username(builder.username("a").build().getUsername())` | `.username(builder.username("a").build()<<)` |
+| `.child(builder1 .userIdentifier(source.getUsername()) .username(source.getUsername()) .build().getChild())` | `.child(builder1 .userIdentifier(source.username) .username(source<<) .build()<<)` |
+| `.active(builder.build().isActive())` | `.active(builder.build()<<)` |
+| `.username(source.getUsername() + source.getUserIdentifier())` | `.username(source.username + source.userIdentifier)` |
+##### FieldShiftSetters shorthand mappings
+| Before | After |
+| --- | --- |
+| `this.username = username;` | `this.username = <<;` |
+| `this.active = active;` | `this.active = <<;` |
+| `this.userIdentifier = userIdentifier;` | `this.userIdentifier = <<;` |
+| `this.child = child;` | `this.child = <<;` |
+| `result.setUsername(source.getUsername());` | `result.username = source<<;` |
+| `result.setUserIdentifier(source.getUserIdentifier());` | `result.userIdentifier = source<<;` |
+| `result.setActive(source.isActive());` | `result.active = source<<;` |
+| `setters2.setActive(setters.isActive());` | `setters2.active = setters<<;` |
+| `childBuilder2.setUsername(source.getUsername());` | `childBuilder2.username = source<<;` |
+##### FieldShiftFields shorthand mappings
+| Before | After |
+| --- | --- |
+| `this.username = username;` | `this.username = <<;` |
+| `this.active = active;` | `this.active = <<;` |
+| `this.userIdentifier = userIdentifier;` | `this.userIdentifier = <<;` |
+| `this.userIdentifier = child.userIdentifier;` | `this.userIdentifier = child.<<;` |
+| `result.username = source.child.username;` | `result.username = source.child.<<;` |
+| `result.userIdentifier = source.userIdentifier;` | `result.userIdentifier = source.<<;` |
+| `result.username = changer(record.username);` | `result.username = changer(record.<<);` |
+| `setters2.userIdentifier = record.userIdentifier();` | `setters2.userIdentifier = record.<<;` |
+| `result.child = childBuilder2.child.child.child.child;` | `result.child = childBuilder2.child.child.child.<<;` |
+##### DestructuringAssignmentArrayTestData property access
+| Before | After |
+| --- | --- |
+| `data.getArray()[4];` | `data.array[4];` |
+| `data.getArray()[5];` | `data.array[5];` |
+| `data.getArray()[0];` | `data.array[0];` |
+| `data.getData().getArray()[0];` | `data.data.array[0];` |
+| `data.getData().getArray()[1];` | `data.data.array[1];` |
+##### DestructuringAssignmentListTestData property access
+| Before | After |
+| --- | --- |
+| `data.getList().get(4);` | `data.list.get(4);` |
+| `data.getList().get(5);` | `data.list.get(5);` |
+| `data.getList().get(0);` | `data.list.get(0);` |
+| `data.getData().getList().get(0);` | `data.data.list.get(0);` |
+| `data.getData().getList().get(1);` | `data.data.list.get(1);` |
+##### NullableAnnotationCheckNotNullTestData property and null assertions
+| Before | After |
+| --- | --- |
+| `Preconditions.checkNotNull(args);` | `args!!;` |
+| `Preconditions.checkNotNull(l);` | `l!!;` |
+| `Preconditions.checkNotNull(z.getData());` | `z.data!!;` |
+| `Preconditions.checkNotNull(o);` | `o!!;` |
+| `this.args = Preconditions.checkNotNull(args);` | `this.args = args!!;` |
+| `this.l = Preconditions.checkNotNull(l);` | `this.l = l!!;` |
+| `this.data = Preconditions.checkNotNull(z.getData());` | `this.data = z.data!!;` |
+| `this.o = Preconditions.checkNotNull(o);` | `this.o = o!!;` |
+| `this.args = Preconditions.checkNotNull(args, "args are null");` | `this.args = args!!;` |
+| `this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");` | `this.data = z.data!!;` |
+##### NullableAnnotationCheckNotNullFieldShiftTestData property shorthand
+| Before | After |
+| --- | --- |
+| `this.args = Preconditions.checkNotNull(args);` | `this.args = <<!!;` |
+| `this.l = Preconditions.checkNotNull(l);` | `this.l = <<!!;` |
+| `this.data = Preconditions.checkNotNull(z.getData());` | `this.data = z.<<!!;` |
+| `this.o = Preconditions.checkNotNull(o);` | `this.o = <<!!;` |
+| `this.args = Preconditions.checkNotNull(args, "args are null");` | `this.args = <<!!;` |
+| `this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");` | `this.data = z.<<!!;` |
+##### DynamicTestData property mappings
+| Before | After |
+| --- | --- |
+| `staticMethod(data.getData());` | `changedStaticMethod(data.data);` |
+| `new DynamicTestData().normalMethod(new DynamicTestData().staticMethod(data.getData()))` | `new DynamicTestData().changedNormalMethod(new DynamicTestData().changedStaticMethod(data.data))` |
+| `return new DynamicTestData().staticMethod(data.getData());` | `return new DynamicTestData().changedStaticMethod(data.data);` |

--- a/wiki-clone/docs/features/globalOn.md
+++ b/wiki-clone/docs/features/globalOn.md
@@ -13,3 +13,10 @@ This option affects editor behaviour without a dedicated sample file.
 Default: On
 Controlled by: `globalOn`
 Related features: (none)
+---
+
+#### Behaviour
+
+- Turning `globalOn` off short-circuits every folding builder before it touches PSI, so even if individual toggles remain enabled the editor renders the raw source with no synthetic placeholders.
+- Re-enabling `globalOn` immediately restores whatever combination of feature switches you had before, making it a quick panic button when debugging or presenting code.
+- The flag does not change per-feature checkboxes in settings; it only gates whether their fold regions are registered. This keeps customised setups intact while still offering a single master toggle.

--- a/wiki-clone/docs/features/ifNullSafe.md
+++ b/wiki-clone/docs/features/ifNullSafe.md
@@ -37,3 +37,20 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `ifNullSafe`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### IfNullSafeData null-safe chains
+| Before | After |
+| --- | --- |
+| `data != null && data.getData1() != null && data.getData1().getData2() != null && data.getData1().getData2().getData3() != null` | `data?.data1?.data2?.data3 != null` |
+| `data != null && data.getData1() != null` | `data?.data1 != null` |
+| `data != null && data.isActive()` | `data?.active == true` |
+| `data != null && data.getData1() != null && data.getData1().getData2() != null && data.getData1().getData2().getData3().getData4() != null` | `data?.data1?.data2?.data3?.data4 != null` |
+| `data != null && !data.getData1().isActive()` | `data?.data1?.active == false` |
+| `data != null && !data.isActive()` | `data?.active == false` |
+| `while (data != null && data.getData2() != null && !data.getData2().isActive()) {` | `while (data?.data2?.active == false) {` |
+| `if ((data != null && data.getData6() != null && data.getData6().isActive()))` | `if ((data?.data6?.active == true))` |
+| `if ((data != null && data.getData6() != null && !data.getData6().isActive()))` | `if ((data?.data6?.active == false))` |
+| `if ((flag || data != null && data.getData1() != null && data.getData1().isActive()) && (data != null && data.getData2() != null && data.getData2().isActive() || data != null && data.getData3() != null && data.getData3().isActive() && data.getData3().getData4() != null && data.getData3().getData4().isActive()) || (data != null && data.getData5() != null && data.getData5().isActive()) && (flag && flag || flag && data != null && data.getData6() != null && data.getData6().isActive()))` | `if ((flag || data?.data1?.active == true) && (data?.data2?.active == true || data?.data3?.active == true && data.data3.data4?.active == true) || (data?.data5?.active == true) && (flag && flag || flag && data?.data6?.active == true))` |

--- a/wiki-clone/docs/features/interfaceExtensionProperties.md
+++ b/wiki-clone/docs/features/interfaceExtensionProperties.md
@@ -41,3 +41,18 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `interfaceExtensionProperties`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### InterfaceExtensionPropertiesTestData mappings
+| Before | After |
+| --- | --- |
+| `String getName();` | `@Getter String name;` |
+| `void setName(String name);` | `@Setter String name;` |
+| `int getAge();` | `@Getter int age;` |
+| `void setAge(int age);` | `@Setter int age;` |
+| `public String getName();` | `@Getter public String name;` |
+| `public void setName(String name);` | `@Setter public String name;` |
+| `public int getAge();` | `@Getter public int age;` |
+| `public void setAge(int age);` | `@Setter public int age;` |

--- a/wiki-clone/docs/features/kotlinQuickReturn.md
+++ b/wiki-clone/docs/features/kotlinQuickReturn.md
@@ -38,3 +38,16 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `kotlinQuickReturn`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LetReturnIt early return mappings
+| Before | After |
+| --- | --- |
+| `String var1 = getData(someString); if (var1 != null) { return var1; }` | `val var1 = getData(someString)?.let { return it }` |
+| `String var2 = getData(someString); if (var2 == null) { return null; }` | `val var2 = getData(someString) ?: return null` |
+| `String var4 = getData(someString); if (var4 != null) { return var4; }` | `val var4 = getData(someString)?.let { return it }` |
+| `String var5 = getData(someString); if (var5 == null) { return null; }` | `val var5 = getData(someString) ?: return null` |
+| `String var6 = getData(someString); if (var6 == null) { return null; }` | `val var6 = getData(someString) ?: return null` |
+| `String var7 = getData(someString); if (var7 != null) { return var7; }` | `val var7 = getData(someString)?.let { return it }` |

--- a/wiki-clone/docs/features/localDateLiteralCollapse.md
+++ b/wiki-clone/docs/features/localDateLiteralCollapse.md
@@ -56,3 +56,24 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `localDateLiteralCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LocalDateLiteralTestData mappings
+| Before | After |
+| --- | --- |
+| `LocalDate d1 = LocalDate.of(2018, 01, 10);` | `LocalDate d1 = 2018-01-10;` |
+| `LocalDate d4 = LocalDate.of(2018, 01, 10);` | `LocalDate d4 = 2018-01-10;` |
+| `LocalDate d2 = LocalDate.of(2018, 12, 10);` | `LocalDate d2 = 2018-12-10;` |
+| `LocalDate d3 = LocalDate.of(2018,  4 ,  4   );` | `LocalDate d3 = 2018-04-04;` |
+| `boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));` | `boolean d1SmallerOrEqualD2 = !d1.isAfter(2013-01-10);` |
+
+##### LocalDateLiteralPostfixTestData mappings
+| Before | After |
+| --- | --- |
+| `LocalDate d1 = LocalDate.of(2018, 01, 10);` | `LocalDate d1 = 2018Y-01M-10D;` |
+| `LocalDate d4 = LocalDate.of(2018, 01, 10);` | `LocalDate d4 = 2018Y-01M-10D;` |
+| `LocalDate d2 = LocalDate.of(2018, 12, 10);` | `LocalDate d2 = 2018Y-12M-10D;` |
+| `LocalDate d3 = LocalDate.of(2018,  4 ,  4   );` | `LocalDate d3 = 2018Y-04M-04D;` |
+| `boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));` | `boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);` |

--- a/wiki-clone/docs/features/localDateLiteralPostfixCollapse.md
+++ b/wiki-clone/docs/features/localDateLiteralPostfixCollapse.md
@@ -31,3 +31,15 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `localDateLiteralPostfixCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LocalDateLiteralPostfixTestData mappings
+| Before | After |
+| --- | --- |
+| `LocalDate d1 = LocalDate.of(2018, 01, 10);` | `LocalDate d1 = 2018Y-01M-10D;` |
+| `LocalDate d4 = LocalDate.of(2018, 01, 10);` | `LocalDate d4 = 2018Y-01M-10D;` |
+| `LocalDate d2 = LocalDate.of(2018, 12, 10);` | `LocalDate d2 = 2018Y-12M-10D;` |
+| `LocalDate d3 = LocalDate.of(2018,  4 ,  4   );` | `LocalDate d3 = 2018Y-04M-04D;` |
+| `boolean d1SmallerOrEqualD2 = !d1.isAfter(LocalDate.of(2013, 1, 10));` | `boolean d1SmallerOrEqualD2 = !d1.isAfter(2013Y-01M-10D);` |

--- a/wiki-clone/docs/features/logFolding.md
+++ b/wiki-clone/docs/features/logFolding.md
@@ -51,3 +51,95 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `logFolding`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LogBrackets formatting
+| Before | After |
+| --- | --- |
+| `log.debug("Debug message with 1 parameter - Name: %s", name);` | `log.debug("Debug message with 1 parameter - Name: $name");` |
+| `log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);` | `log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");` |
+| `log.info("Info message with 2 parameters - Name: %s, Age: %d    ", name, age);` | `log.info("Info message with 2 parameters - Name: $name, Age: $age    ");` |
+| `log.info("Info message with 2 parameters - Name: %s, Age: %d", name, age);` | `log.info("Info message with 2 parameters - Name: $name, Age: $age");` |
+| `log.trace("Trace message - Name: %s, log:%s    $", data.getName(), logPrintfStyle(data));` | `log.trace("Trace message - Name: ${data.name}, log:${logPrintfStyle(data)}    $");` |
+| `log.warn("Warning message with three parameters - Name: %s, Age: %s, City: %s", name, data.getData().getName(), city);` | `log.warn("Warning message with three parameters - Name: $name, Age: ${data.data.name}, City: $city");` |
+| `log.error("Missing 1 parameter - 1: %s, 2: %d, 3: %s, empty: %s", name, age, city);` | `log.error("Missing 1 parameter - 1: $name, 2: $age, 3: $city, empty: %s");` |
+| `log.error("Missing 2 parameters - 1: %s, 2: %d, empty: %s, empty: %s", name, age);` | `log.error("Missing 2 parameters - 1: $name, 2: $age, empty: %s, empty: %s");` |
+| `log.error("Missing 3 parameters - 1: %s, empty: %s, empty: %s, empty: %s", name);` | `log.error("Missing 3 parameters - 1: $name, empty: %s, empty: %s, empty: %s");` |
+| `<pre>log.warn("Warning message with 3 parameters and formatting - 1: %s, 2: %s, 3: %s",
+        name,
+        data.getData().getName(),
+        city
+);</pre>` | `log.warn("Warning message with 3 parameters and formatting - 1: $name, 2: ${data.data.name}, 3: $city");` |
+| `<pre>log.warn("Warning message with 3 parameters and formatting - 1: %s, 2: %s, 3: %s",
+        data.getData().getName(),
+        name,
+        data.getData().getName()
+);</pre>` | `log.warn("Warning message with 3 parameters and formatting - 1: ${data.data.name}, 2: $name, 3: ${data.data.name}");` |
+| `log.error("error1 %s", e, e.getMessage(), e);` | `log.error("error1 $e", e.message, e);` |
+| `log.error("error2 %s", data.getData().getName(), data.getData().getName(), data.getData().getName());` | `log.error("error2 ${data.data.name}", data.data.name, data.data.name);` |
+| `String formatted = String.format("Hello, %s! Your age is %d", name, age);` | `String formatted = String.format("Hello, $name! Your age is $age");` |
+| `log.info("String.format example: {}", formatted);` | `log.info("String.format example: $formatted");` |
+| `System.out.printf("User: %s, Age: %d, City: %s%n", name, age, city);` | `System.out.printf("User: $name, Age: $age, City: $city%n");` |
+| `System.err.printf("Error scenario: User %s not found in %s and ignore new-line break%n", name, city, "ignored");` | `System.err.printf("Error scenario: User $name not found in $city and ignore new-line break%n", "ignored");` |
+| `formatter.format("User details - Name: %s, Age: %d, City: %s", name, age, city);` | `formatter.format("User details - Name: $name, Age: $age, City: $city");` |
+| `log.info("Formatter example: {}", formatter.toString());` | `log.info("Formatter example: ${formatter.toString()}");` |
+| `writer.printf("Log entry: User %s, Age %d, accessed from %s", name, age, city);` | `writer.printf("Log entry: User $name, Age $age, accessed from $city");` |
+| `log.error("Failed to write to log file: %s", e.getMessage());` | `log.error("Failed to write to log file: ${e.message}");` |
+| `System.out.println("Debug message with 1 parameter - Name: %s".formatted(name));` | `System.out.println("Debug message with 1 parameter - Name: $name".formatted());` |
+| `System.out.println("Trace message - Name: %s, log:%s    $".formatted(data.getName(), logPrintfStyle(data)));` | `System.out.println("Trace message - Name: ${data.name}, log:${logPrintfStyle(data)}    $".formatted());` |
+| `System.out.println("Warning message with three parameters - Name: %s, Age: %s, City: %s".formatted(name, data.getData().getName(), city));` | `System.out.println("Warning message with three parameters - Name: $name, Age: ${data.data.name}, City: $city".formatted());` |
+| `System.out.println("Missing 1 parameter - 1: %s, 2: %d, 3: %s, empty: %s".formatted(name, age, city));` | `System.out.println("Missing 1 parameter - 1: $name, 2: $age, 3: $city, empty: %s".formatted());` |
+| `System.out.println("Missing 2 parameters - 1: %s, 2: %d, empty: %s, empty: %s".formatted(name, age));` | `System.out.println("Missing 2 parameters - 1: $name, 2: $age, empty: %s, empty: %s".formatted());` |
+| `System.out.println("Missing 3 parameters - 1: %s, empty: %s, empty: %s, empty: %s".formatted(name));` | `System.out.println("Missing 3 parameters - 1: $name, empty: %s, empty: %s, empty: %s".formatted());` |
+| `System.out.println("Additional 1 parameter - Name: %s".formatted(name, data));` | `System.out.println("Additional 1 parameter - Name: $name".formatted( data));` |
+| `System.out.println("Additional 2 parameters - Name: %s".formatted(name, data, logPrintfStyle(data)));` | `System.out.println("Additional 2 parameters - Name: $name".formatted( data, logPrintfStyle(data)));` |
+
+##### LogFoldingTextBlocksTestData formatting
+| Before | After |
+| --- | --- |
+| `log.debug("Debug message with 1 parameter - Name: %s", name);` | `log.debug("Debug message with 1 parameter - Name: $name");` |
+| `log.info(MY_MARKER, "Info message with 2 parameters - Name: %s, Age: %d", name, age);` | `log.info(MY_MARKER, "Info message with 2 parameters - Name: $name, Age: $age");` |
+| `System.out.println("Missing 2 parameters - 1: %s, 2: %d, empty: %s, empty: %s".formatted(name, age));` | `System.out.println("Missing 2 parameters - 1: $name, 2: $age, empty: %s, empty: %s".formatted());` |
+| `<pre>log.error("""
+                Missing 1 parameter - 1: %s, 2: %d, 3: %s, empty: %s
+                """, name, age, city);</pre>` | `<pre>log.error("""
+                Missing 1 parameter - 1: $name, 2: $age, 3: $city, empty: %s
+                """);</pre>` |
+| `<pre>log.info("""
+                Data summary:
+                Root: {}
+                Child: {}
+                """, data.getName(), data.getData().getName());</pre>` | `<pre>log.info("""
+                Data summary:
+                Root: ${data.name}
+                Child: ${data.data.name}
+                """);</pre>` |
+| `<pre>log.debug("""
+                User summary:
+                Name: {}
+                Age: {}
+                City: {}
+                """, name, age, city);</pre>` | `<pre>log.debug("""
+                User summary:
+                Name: $name
+                Age: $age
+                City: $city
+                """);</pre>` |
+| `<pre>log.warn("""
+                Nested data snapshot:
+                Parent: {}
+                Child: {}
+                """, data.getName(), data.getData().getName());</pre>` | `<pre>log.warn("""
+                Nested data snapshot:
+                Parent: ${data.name}
+                Child: ${data.data.name}
+                """);</pre>` |
+| `<pre>log.trace("""
+                Formatter contents:
+                {}
+                """, formatter);</pre>` | `<pre>log.trace("""
+                Formatter contents:
+                $formatter
+                """);</pre>` |

--- a/wiki-clone/docs/features/logFoldingTextBlocks.md
+++ b/wiki-clone/docs/features/logFoldingTextBlocks.md
@@ -25,3 +25,51 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `logFoldingTextBlocks`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LogFoldingTextBlocksTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>log.error("""
+                Missing 1 parameter - 1: %s, 2: %d, 3: %s, empty: %s
+                """, name, age, city);</pre>` | `<pre>log.error("""
+                Missing 1 parameter - 1: $name, 2: $age, 3: $city, empty: %s
+                """);</pre>` |
+| `<pre>log.info("""
+                Data summary:
+                Root: {}
+                Child: {}
+                """, data.getName(), data.getData().getName());</pre>` | `<pre>log.info("""
+                Data summary:
+                Root: ${data.name}
+                Child: ${data.data.name}
+                """);</pre>` |
+| `<pre>log.debug("""
+                User summary:
+                Name: {}
+                Age: {}
+                City: {}
+                """, name, age, city);</pre>` | `<pre>log.debug("""
+                User summary:
+                Name: $name
+                Age: $age
+                City: $city
+                """);</pre>` |
+| `<pre>log.warn("""
+                Nested data snapshot:
+                Parent: {}
+                Child: {}
+                """, data.getName(), data.getData().getName());</pre>` | `<pre>log.warn("""
+                Nested data snapshot:
+                Parent: ${data.name}
+                Child: ${data.data.name}
+                """);</pre>` |
+| `<pre>log.trace("""
+                Formatter contents:
+                {}
+                """, formatter);</pre>` | `<pre>log.trace("""
+                Formatter contents:
+                $formatter
+                """);</pre>` |

--- a/wiki-clone/docs/features/lombok.md
+++ b/wiki-clone/docs/features/lombok.md
@@ -310,3 +310,52 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `lombok`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LombokTestData annotations
+| Before | After |
+| --- | --- |
+| `public class LombokTestData {` | `@HasBuilder(ClassWithBuilder) @Getter @Setter @Serial public class LombokTestData {` |
+| `class LombokGetters {` with explicit getters | `@Getter public class LombokGetters {` |
+| `class LombokGettersPartial {` with `isOk` getter | `public class LombokGettersPartial { @Getter boolean ok; }` |
+| `class LombokSetters {` with getters/setters | `@Getter @Setter public class LombokSetters {` |
+| `class LombokSettersPartial {` with setter | `public class LombokSettersPartial { @Setter LombokTestData data; }` |
+| `class LombokSettersFinalField {` with setter | `public class LombokSettersFinalField { @Setter LombokTestData data; final boolean ok = true; }` |
+| `class ToStringFull {` overriding `toString` | `@ToString public class ToStringFull {` |
+| `class ToStringPartial {` overriding `toString` | `@ToString(of = "data") public class ToStringPartial {` |
+| `class EqualsAndHashCodeFull {` overriding equals/hashCode | `@EqualsAndHashCode public class EqualsAndHashCodeFull {` |
+| `class EqualsAndHashCodePartial {` overriding equals/hashCode | `@EqualsAndHashCode(of = "data") public class EqualsAndHashCodePartial {` |
+
+##### NullableAnnotationTestData Lombok integration
+| Before | After |
+| --- | --- |
+| `@NotNull NullableAnnotationTestData data;` with manual accessors | `@Getter @Setter NullableAnnotationTestData!! data;` |
+| `boolean ok;` with manual accessors | `@Getter @Setter boolean ok;` |
+| `@Nullable String string;` with manual accessors | `@Getter @Setter String? string;` |
+| `@Nonnull private NullableAnnotationTestData data2;` | `private NullableAnnotationTestData!! data2;` |
+| Manual getter/setter inner classes | `@Getter` / `@Setter` applied to fields in inner classes |
+
+##### LombokDirtyOffTestData targeted annotations
+| Before | After |
+| --- | --- |
+| `public class DirtyData { ... equals/hashCode ... }` | `@EqualsAndHashCode public class DirtyData {` |
+| `boolean ok;` with accessor | `@Getter private boolean ok;` |
+| `public class DirtySingle { boolean ok; public boolean isOk() { ... } }` | `public class DirtySingle { @Getter boolean ok; ... }` |
+| `public class DirtyData { ... setOk(...) { ... } }` | `@Getter @EqualsAndHashCode public class DirtyData { @Setter private boolean ok; ... }` |
+| `public class DirtySingle { boolean ok; public void setOk(boolean ok) { ... } }` | `public class DirtySingle { @Setter boolean ok; ... }` |
+
+##### InterfaceExtensionPropertiesTestData interface properties
+| Before | After |
+| --- | --- |
+| `String getName(); void setName(String name);` | `@Getter String name; @Setter String name;` |
+| `int getAge(); void setAge(int age);` | `@Getter int age; @Setter int age;` |
+| Public interface variants with explicit modifiers | `@Getter/@Setter applied to public property declarations` |
+| Text-block documented interfaces with getters/setters | `Documentation preserved with @Getter/@Setter replacing method pairs` |
+
+##### LombokPatternOffTestData formatting tweaks
+| Before | After |
+| --- | --- |
+| `return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';` (multiline) | `return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';` (single line) |
+| `return "ToStringPartial{" + "data=" + data + '}';` | `return "ToStringPartial{" + "data=" + data + '}';` (compact) |

--- a/wiki-clone/docs/features/lombokDirtyOff.md
+++ b/wiki-clone/docs/features/lombokDirtyOff.md
@@ -25,3 +25,16 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `lombokDirtyOff`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LombokDirtyOffTestData mappings
+| Before | After |
+| --- | --- |
+| `public class DirtyData {` | `@EqualsAndHashCode public class DirtyData {` |
+| `private boolean ok;` | `@Getter private boolean ok;` |
+| `public class DirtyData {` *(setters nested)* | `@Getter @EqualsAndHashCode public class DirtyData {` |
+| `private boolean ok;` *(setters nested)* | `@Setter private boolean ok;` |
+| `boolean ok;` *(DirtySingle getters nested)* | `@Getter boolean ok;` |
+| `boolean ok;` *(DirtySingle setters nested)* | `@Setter boolean ok;` |

--- a/wiki-clone/docs/features/lombokPatternOff.md
+++ b/wiki-clone/docs/features/lombokPatternOff.md
@@ -58,3 +58,33 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `lombokPatternOff`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### LombokPatternOffTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>return "ToStringFull{" +
+                    "data=" + data +
+                    ", ok=" + ok +
+                    '}';</pre>` | `return "ToStringFull{" + "data=" + data + ", ok=" + ok + '}';` |
+| `<pre>return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';</pre>` | `return "ToStringPartial{" + "data=" + data + '}';` |
+| `<pre>return "ToStringPartial{" +
+                        "data=" + data +
+                        '}';</pre>` (partial2) | `return "ToStringPartial{" + "data=" + data + '}';` |
+
+##### LombokPatternOffNegativeTestData mappings
+| Before | After |
+| --- | --- |
+| `public class LombokPatternOffNegativeTestData {` | `@HasBuilder(ClassWithBuilder) @Getter @Setter @Serial public class LombokPatternOffNegativeTestData {` |
+| `public class LombokGetters {` | `@Getter public class LombokGetters {` |
+| `public class LombokSetters {` | `@Getter @Setter public class LombokSetters {` |
+| `public class ToStringFull {` | `@ToString public class ToStringFull {` |
+| `public class EqualsAndHashCodeFull {` | `@EqualsAndHashCode public class EqualsAndHashCodeFull {` |
+| `public class EqualsFull {` | `@Equals public class EqualsFull {` |
+| `public class HashCodeFull {` | `@HashCode public class HashCodeFull {` |
+| `public class DataFull {` | `@Data public class DataFull {` |
+| `public class FoldOn {` | `public class FoldOn {` (unchanged container with annotated members) |

--- a/wiki-clone/docs/features/memoryImprovement.md
+++ b/wiki-clone/docs/features/memoryImprovement.md
@@ -19,3 +19,12 @@ This option affects editor behaviour without a dedicated sample file.
 Default: On
 Controlled by: `memoryImprovement`
 Related features: (none)
+---
+
+#### Descriptor reuse on large fixtures
+
+- When `memoryImprovement` is enabled, the plugin materialises folding descriptors for files under `testData/` once and keeps them cached while the editor stays open. Subsequent expansions or caret moves reuse the cached tree instead of walking the PSI again.
+- The cache is scoped per file and invalidated if the document changes, so huge golden files stay responsive without sacrificing correctness.
+- With the option disabled every caret move or highlighting refresh rebuilds the descriptor list, which increases allocations and slows diff previews on very large fixtures.
+
+This switch is therefore recommended whenever you regularly inspect the bundled regression files or maintain your own large `testData` suites.

--- a/wiki-clone/docs/features/methodDefaultParameters.md
+++ b/wiki-clone/docs/features/methodDefaultParameters.md
@@ -27,3 +27,93 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `methodDefaultParameters`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### MethodDefaultParametersTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>public String applySort1(String criterionName, boolean descending) {
+            return criterionName;
+        }
+        public String applySort1() {
+            return applySort1("DESC", false);
+        }</pre>` | `<pre>public String applySort1(String criterionName = "DESC", boolean descending = false) {
+            return criterionName;
+        }</pre>` |
+| `<pre>public String applySort2(String criterionName, boolean descending) {
+            return criterionName;
+        }
+        public String applySort2(String criterionName) {
+            return applySort2(criterionName, System.getProperty("sort-desc") != null);
+        }</pre>` | `<pre>public String applySort2(String criterionName, boolean descending = System.getProperty("sort-desc") != null) {
+            return criterionName;
+        }</pre>` |
+| `<pre>public String multipleDefaults(String name, int count, boolean flag) {
+            return name + count + flag;
+        }
+        public String multipleDefaults(String name, int count) {
+            return multipleDefaults(name, count, false);
+        }
+        public String multipleDefaults(String name) {
+            return multipleDefaults(name, 10, false);
+        }</pre>` | `<pre>public String multipleDefaults(String name, int count = 10, boolean flag = false) {
+            return name + count + flag;
+        }</pre>` |
+| `<pre>public String chainedDefaults(String name, int count, boolean flag) {
+            return name + count + flag;
+        }
+        public String chainedDefaults(String name, int count) {
+            return chainedDefaults(name, count, true);
+        }</pre>` | `<pre>public String chainedDefaults(String name, int count, boolean flag = true) {
+            return name + count + flag;
+        }</pre>` |
+| `<pre>public String expressionDefaults(String name, int count) {
+            return name + count;
+        }
+        public String expressionDefaults(String name) {
+            return expressionDefaults(name, "test".length() + 2);
+        }</pre>` | `<pre>public String expressionDefaults(String name, int count = "test".length() + 2) {
+            return name + count;
+        }</pre>` |
+| `<pre>public static String staticWithDefaults(String name, boolean flag) {
+            return name + flag;
+        }
+        public static String staticWithDefaults(String name) {
+            return staticWithDefaults(name, true);
+        }</pre>` | `<pre>public static String staticWithDefaults(String name, boolean flag = true) {
+            return name + flag;
+        }</pre>` |
+| `<pre>public String mixedTypes(String text, int number, boolean flag, double value) {
+            return text + number + flag + value;
+        }
+        public String mixedTypes(String text, int number, boolean flag) {
+            return mixedTypes(text, number, flag, 1.0);
+        }</pre>` | `<pre>public String mixedTypes(String text, int number, boolean flag, double value = 1.0) {
+            return text + number + flag + value;
+        }</pre>` |
+| `<pre>public String varargMethod(String prefix, String... items) {
+            return prefix + String.join(",", items);
+        }
+        public String varargMethod(String prefix) {
+            return varargMethod(prefix, "default");
+        }</pre>` | `<pre>public String varargMethod(String prefix, String... items = "default") {
+            return prefix + String.join(",", items);
+        }</pre>` |
+| `<pre>public String differentParamNames(String name, boolean enabled) {
+            return name + enabled;
+        }
+        public String differentParamNames(String title) {
+            return differentParamNames(title, true);
+        }</pre>` | `<pre>public String differentParamNames(String name, boolean enabled = true) {
+            return name + enabled;
+        }</pre>` |
+| `<pre>public <T> String genericMethod(T item, boolean flag) {
+            return item.toString() + flag;
+        }
+        public <T> String genericMethod(T item) {
+            return genericMethod(item, false);
+        }</pre>` | `<pre>public <T> String genericMethod(T item, boolean flag = false) {
+            return item + flag;
+        }</pre>` |

--- a/wiki-clone/docs/features/nullable.md
+++ b/wiki-clone/docs/features/nullable.md
@@ -157,3 +157,293 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `nullable`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### NullableAnnotationTestData mappings
+| Before | After |
+| --- | --- |
+| `@NotNull NullableAnnotationTestData data;` | `@Getter @Setter NullableAnnotationTestData!! data;` |
+| `boolean ok;` | `@Getter @Setter boolean ok;` |
+| `@Nullable String string;` | `@Getter @Setter String? string;` |
+| `@Nonnull private NullableAnnotationTestData data2;` | `private NullableAnnotationTestData!! data2;` |
+| `@Nullable private String string2;` | `private String? string2;` |
+| `<pre>public void select(@Nullable String element,
+                       int i,
+                       @NotNull Object o,
+                       @Nonnull LocalDate date
+                       ) {</pre>` | `<pre>public void select(String? element,
+                       int i,
+                       Object!! o,
+                       LocalDate!! date
+                       ) {</pre>` |
+| `@NotNull public String getStringNotNull() {` | `public String!! getStringNotNull() {` |
+| `@Nonnull public String getStringNotNull2() {` | `public String!! getStringNotNull2() {` |
+| `@Nullable public String getStringNull() {` | `public String? getStringNull() {` |
+| `<pre>@Nullable
+        public Integer select(@Nullable String element,
+                           int i,
+                           @NotNull Object o,
+                           @Nonnull LocalDate date
+        );</pre>` | `<pre>public Integer? select(String? element,
+                           int i,
+                           Object!! o,
+                           LocalDate!! date
+        );</pre>` |
+| `<pre>@Nonnull
+        public static int select(@Nullable String element,
+                                 int i,
+                                 @NotNull Object o,
+                                 @Nonnull LocalDate date
+        ) {</pre>` | `<pre>public static int!! select(String? element,
+                                 int i,
+                                 Object!! o,
+                                 LocalDate!! date
+        ) {</pre>` |
+| `public record UserDataRecord(@Nonnull String username, boolean active, @Nullable String userIdentifier, @NotNull String username2) {` | `public record UserDataRecord(String!! username, boolean active, String? userIdentifier, String!! username2) {` |
+| `<pre>public class HasGetter {
+            @Nullable
+            private String field;
+            private String bla;
+
+            public @Nullable String getField() {
+                return field;
+            }
+        }</pre>` | `<pre>public class HasGetter {
+
+            @Getter private String? field;
+            private String bla;
+        }</pre>` |
+| `<pre>public class HasSetter {
+            @Nullable
+            private String field;
+            private String bla;
+
+            public void setField(@Nullable String field) {
+                this.field = field;
+            }
+        }</pre>` | `<pre>public class HasSetter {
+
+            @Setter private String? field;
+            private String bla;
+        }</pre>` |
+| `<pre>public class HasGetterSetter {
+            @Nullable
+            private String field;
+            private String bla;
+
+            public @Nullable String getField() {
+                new HashMap<String, String>().put("a", "b");
+                return field;
+            }
+
+            public void setField(@Nullable String field) {
+                this.field = field;
+            }
+        }</pre>` | `<pre>public class HasGetterSetter {
+
+            @Getter(dirty) @Setter private String? field;
+            private String bla;
+        }</pre>` |
+| `<pre>public class HasGetter {
+            @Nullable
+            String field;
+            String bla;
+
+            public @Nullable String getField() {
+                return field;
+            }
+        }</pre>` | `<pre>public class HasGetter {
+
+            @Getter String? field;
+            String bla;
+        }</pre>` |
+| `<pre>public class HasSetter {
+            @Nullable
+            String field;
+            String bla;
+
+            public void setField(@Nullable String field) {
+                this.field = field;
+            }
+        }</pre>` | `<pre>public class HasSetter {
+
+            @Setter String? field;
+            String bla;
+        }</pre>` |
+| `<pre>public class HasGetterSetter {
+            @Nullable
+            String field;
+            String bla;
+
+            public @Nullable String getField() {
+                return field;
+            }
+
+            public void setField(@Nullable String field) {
+                this.field = field;
+            }
+        }</pre>` | `<pre>public class HasGetterSetter {
+
+            @Getter @Setter String? field;
+            String bla;
+        }</pre>` |
+
+##### NullableAnnotationCheckNotNullTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>public void main(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);</pre>` | `<pre>public void main(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;</pre>` |
+| `<pre>public void mainMsgs(String args, Object o, Long l, Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");</pre>` | `<pre>public void mainMsgs(String!!! args, Object o, Long!!! l, Preconditions z) {args!!;l!!;
+            z.data!!;
+            o!!;</pre>` |
+| `<pre>public void mainConflictAnnotations(@Nullable String args, @Nullable Object o, @Nullable Long l, @Nullable Preconditions z) {
+            Preconditions.checkNotNull(args);
+            Preconditions.checkNotNull(l);
+            Preconditions.checkNotNull(z.getData());
+            Preconditions.checkNotNull(o);</pre>` | `<pre>public void mainConflictAnnotations(String!!! args, Object? o, Long!!! l, Preconditions? z) {args!!;l!!;
+            z.data!!;
+            o!!;</pre>` |
+| `<pre>public void mainConflictAnnotationsWithMsg(@Nullable String args, @Nullable Object o, @Nullable Long l, @Nullable Preconditions z) {
+            Preconditions.checkNotNull(args, "args are null");
+            Preconditions.checkNotNull(l, "l is null");
+            Preconditions.checkNotNull(z.getData(), "o is null");
+            Preconditions.checkNotNull(o, "o is null");</pre>` | `<pre>public void mainConflictAnnotationsWithMsg(String!!! args, Object? o, Long!!! l, Preconditions? z) {args!!;l!!;
+            z.data!!;
+            o!!;</pre>` |
+| `<pre>this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);</pre>` | `<pre>this.args = args!!;
+            this.l = l!!;
+            this.data = z.data!!;
+            this.o = o!!;</pre>` |
+| `<pre>this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");</pre>` | `<pre>this.args = args!!;
+            this.l = l!!;
+            this.data = z.data!!;
+            this.o = o!!;</pre>` |
+| `<pre>public void mainNullable(@Nullable String args, @Nullable Object o, @Nullable Long l, @Nullable Preconditions z) {
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);</pre>` | `<pre>public void mainNullable(String? args, Object? o, Long? l, Preconditions? z) {
+            this.args = args!!;
+            this.l = l!!;
+            this.data = z.data!!;
+            this.o = o!!;</pre>` |
+| `<pre>public void mainMsgsNullable(@Nullable String args, @Nullable Object o, @Nullable Long l, @Nullable Preconditions z) {
+            this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");</pre>` | `<pre>public void mainMsgsNullable(String? args, Object? o, Long? l, Preconditions? z) {
+            this.args = args!!;
+            this.l = l!!;
+            this.data = z.data!!;
+            this.o = o!!;</pre>` |
+
+##### NullableAnnotationCheckNotNullFieldShiftTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);</pre>` | `<pre>this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;</pre>` |
+| `<pre>this.args = Preconditions.checkNotNull(args, "args are null");
+            this.l = Preconditions.checkNotNull(l, "l is null");
+            this.data = Preconditions.checkNotNull(z.getData(), "saaa is null");
+            this.o = Preconditions.checkNotNull(o, "o is null");</pre>` | `<pre>this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;</pre>` |
+| `<pre>public void mainNullable(@Nullable String args, @Nullable Object o, @Nullable Long l, @Nullable Preconditions z) {
+            this.args = Preconditions.checkNotNull(args);
+            this.l = Preconditions.checkNotNull(l);
+            this.data = Preconditions.checkNotNull(z.getData());
+            this.o = Preconditions.checkNotNull(o);</pre>` | `<pre>public void mainNullable(String? args, Object? o, Long? l, Preconditions? z) {
+            this.args = <<!!;
+            this.l = <<!!;
+            this.data = z.<<!!;
+            this.o = <<!!;</pre>` |
+
+##### InterfaceExtensionPropertiesTestData mappings
+| Before | After |
+| --- | --- |
+| `String getName();` | `@Getter String name;` |
+| `void setName(String name);` | `@Setter String name;` |
+| `int getAge();` | `@Getter int age;` |
+| `void setAge(int age);` | `@Setter int age;` |
+| `public String getName();` | `@Getter public String name;` |
+| `public void setName(String name);` | `@Setter public String name;` |
+| `public int getAge();` | `@Getter public int age;` |
+| `public void setAge(int age);` | `@Setter public int age;` |
+
+##### ExperimentalTestData nullable-adjacent mappings
+| Before | After |
+| --- | --- |
+| `<pre>try {
+                byte[] bytez = System.getProperty("sort-desc").getBytes();
+                return new String(bytez, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }</pre>` | `<pre>@SneakyThrows {
+                byte[] bytez = System["sort-desc"].bytes;
+                return new String(bytez, "UTF-8");
+            }</pre>` |
+| `<pre>try {
+                return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `@SneakyThrows(IllegalArgumentException) return Integer.parseInt(value);` |
+| `<pre>try {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(e);
+            }</pre>` | `<pre>@SneakyThrows(IllegalArgumentException) {
+                Function<String, Long> longFunction = Long::parseLong;
+                longValue = longFunction.apply(value);
+            }</pre>` |
+| `<pre>try {
+                var throwable = new Throwable();
+                throw throwable;
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `<pre>@SneakyThrows {
+                var throwable = new Throwable();
+                throw throwable;
+            }</pre>` |
+| `<pre>try {
+                return new String(System.getProperty("sort-desc").getBytes(), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }</pre>` | `@SneakyThrows return new String(System["sort-desc"].bytes, "UTF-8");` |
+| `<pre>try {
+            throw new Throwable();
+            } catch (Throwable t) {
+                throw new IllegalStateException(t);
+            }</pre>` | `@SneakyThrows throw new Throwable();` |
+| `<pre>example.set("ok");
+            String current = example.get();
+            System.out.println(example.get().isEmpty());
+            example.set(example.get());
+            String duplicate = example.get() + example.get();</pre>` | `<pre>example.!! = "ok";
+            String current = example.!!;
+            System.out.println(example.!!.empty);
+            example.!! = example.!!;
+            String duplicate = example.!! + example.!!;</pre>` |

--- a/wiki-clone/docs/features/optional.md
+++ b/wiki-clone/docs/features/optional.md
@@ -70,3 +70,38 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `optional`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ConcatenationTestData optional-style operations
+| Before | After |
+| --- | --- |
+| `streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = args*.toUpperCase().toList();` |
+| `streamToList = list.stream().map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = list.stream()*.toUpperCase().toList();` |
+| `long count = streamToList.stream().distinct().count();` | `long count = streamToList.distinct().count();` |
+
+##### OptionalTestData mappings
+| Before | After |
+| --- | --- |
+| `if (opt.isPresent()) { o = opt.get(); }` | `if (opt.isPresent()) { o = opt!!; }` |
+| `o = opt.orElseThrow();` | `o = opt!!;` |
+| `o = Optional.ofNullable(dataNull);` | `o = dataNull;` |
+| `o = Optional.of(data);` | `o = data!!;` |
+| `o = Optional.ofNullable(dataNull).orElseGet(this::orElseGetReturn);` | `o = dataNull ?: this::orElseGetReturn;` |
+| `o = Optional.ofNullable(dataNull).orElseGet(() -> data.getData().getData());` | `o = dataNull ?: () -> data.getData().getData();` |
+| `o = Optional.of(data).map(Data::getData).orElse(null);` | `o = data!!.data ?: null;` |
+| `o = Optional.ofNullable(dataNull).map(OptionalTestData::getOutsideData).get();` | `o = dataNull.map(OptionalTestData::getOutsideData)!!;` |
+| `o = Optional.of(data.getData()).map(OptionalTestData::getOutsideData).map(Data::getString).orElse(data.getString());` | `o = data.getData()!!.map(OptionalTestData::getOutsideData)?.string ?: data.getString();` |
+| `Optional.of(data).flatMap(this::ofNullable).map(data::getDataMethod).orElseGet(() -> getOutsideData(data));` | `data!!.flatMap(this::ofNullable).map(data::getDataMethod) ?: () -> getOutsideData(data);` |
+| `o = Optional.<Data>empty().map(Data::getData).stream().map(Data::getData).filter(Objects::nonNull).findAny().map(Data::getString).get();` | `o = Optional.<Data>empty()?.data.stream()*.data().filterNotNull().findAny()?.string!!;` |
+| `o = opt.map(Data::getData).orElse(null);` | `o = opt?.data ?: null;` |
+| `Stream.of(data).map(Data::getData).filter(Objects::nonNull);` | `Stream.of(data)*.data().filterNotNull();` |
+| `Stream.of(data).map(Data::getData) .filter(Objects::nonNull).map(Data::getData).findFirst().orElseThrow();` | `Stream.of(data)*.data().filterNotNull()*.data().findFirst()!!;` |
+
+##### SpreadTestData optional-style spread
+| Before | After |
+| --- | --- |
+| `String empNames = list.stream().map(Data::getString).collect(Collectors.joining(", "));` | `String empNames = list*.string().collect(Collectors.joining(", "));` |
+| `var a = stream.map(Data::getData).filter(Objects::nonNull).map(Data::getData).flatMap(Data::getDataStream).map(Data::getDataList).flatMap(List::stream).map(Data::getString).map(String::chars)` | `var a = stream*.data().filterNotNull()*.data()**.dataStream()*.dataList()**.stream()*.string()*.chars()` |
+| `var p = methodStream(data).toList().stream().min(Comparator.comparing(Data::isOk)).stream().min(Comparator.comparing(Data::getString)).map(Data::getString).orElse("string1");` | `var p = methodStream(data).toList().min(Comparator.comparing(Data::isOk)).stream().min(Comparator.comparing(Data::getString))?.string ?: "string1";` |

--- a/wiki-clone/docs/features/overrideHide.md
+++ b/wiki-clone/docs/features/overrideHide.md
@@ -27,3 +27,19 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `overrideHide`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### OverrideHideTestData mappings
+| Before | After |
+| --- | --- |
+| `@Override public void run() {` | `public void run() {` |
+| `@Override public int compare(Circle c1, Circle c2) {` | `public int compare(Circle c1, Circle c2) {` |
+| `@Override public void makeSound() {` | `public void makeSound() {` |
+| `@Override public void eat() {` | `public void eat() {` |
+| `@Override public double calculateArea() {` | `public double calculateArea() {` |
+| `@Override public double calculatePerimeter() {` | `public double calculatePerimeter() {` |
+| `@Override public String toString() {` | `public String toString() {` |
+| `@Override public boolean equals(Object obj) {` | `public boolean equals(Object obj) {` |
+| `@Override public int hashCode() {` | `public int hashCode() {` |

--- a/wiki-clone/docs/features/patternMatchingInstanceof.md
+++ b/wiki-clone/docs/features/patternMatchingInstanceof.md
@@ -27,3 +27,28 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `patternMatchingInstanceof`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### PatternMatchingInstanceofTestData mappings
+| Before | After |
+| --- | --- |
+| `<pre>if (o instanceof String) {
+            String s = (String) o;</pre>` | `if (o instanceof String s) {` |
+| `<pre>if (o instanceof Integer) {
+            Integer num = (Integer) o;</pre>` | `if (o instanceof Integer num) {` |
+| `<pre>if (o instanceof Data) {
+            Data d = (Data) o;</pre>` | `if (o instanceof Data d) {` |
+| `<pre>if (o instanceof int[]) {
+            int[] arr = (int[]) o;</pre>` | `if (o instanceof int[] arr) {` |
+| `<pre>if (o instanceof DayOfWeek) {
+            DayOfWeek day = (DayOfWeek) o;</pre>` | `if (o instanceof DayOfWeek day) {` |
+| `<pre>if (o instanceof String) {
+                String s = (String) o;</pre>` (TypeMatching positive) | `if (o instanceof String s) {` |
+| `<pre>if (o instanceof String) {
+                String s = (String) o;</pre>` (VariableUsage positive) | `if (o instanceof String s) {` |
+| `<pre>if (o instanceof String) {
+                String s = (String) o;</pre>` (SimpleAssignment positive) | `if (o instanceof String s) {` |
+| `<pre>if (o instanceof String) {
+                String s = (String) o;</pre>` (CastAssignment positive) | `if (o instanceof String s) {` |

--- a/wiki-clone/docs/features/println.md
+++ b/wiki-clone/docs/features/println.md
@@ -41,3 +41,33 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `println`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### PrintlnTestData mappings
+| Before | After |
+| --- | --- |
+| `System.out.println("Hello");` | `println("Hello");` |
+| `<pre>System.out.println
+                (123);</pre>` | `<pre>println
+                (123);</pre>` |
+| `<pre>System.
+                out.println("Spacing");</pre>` | `println("Spacing");` |
+| `<pre>System.out.
+                println(3.14);</pre>` | `println(3.14);` |
+| `System.out.println(string);` | `println(string);` |
+| `System.out.println(true);` | `println(true);` |
+| `System.out.println('A');` | `println('A');` |
+| `System.out.println(CONST_VALUE);` | `println(CONST_VALUE);` |
+| `System.out.println("Divided: " + "" +"into" +" multiple" + " " + "strings");` | `println("Divided: " + "" + "into" + " multiple" + " " + "strings");` |
+| `System.out.println("Passed as parameter: " + string);` | `println("Passed as parameter: " + string);` |
+| `<pre>System.out.println("Passed as parameter: " +
+this.getClass());</pre>` | `println("Passed as parameter: " + this.getClass());` |
+| `<pre>System.out.println("""
+                text
+                block
+                """);</pre>` | `<pre>println("""
+                text
+                block
+                """);</pre>` |

--- a/wiki-clone/docs/features/pseudoAnnotations.md
+++ b/wiki-clone/docs/features/pseudoAnnotations.md
@@ -29,3 +29,61 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `pseudoAnnotations`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+| Before | After |
+| --- | --- |
+| `<pre>public static void main(String[] args) {
+        int x = 0;
+        staticMethod(x);
+    }</pre>` | `@Main staticMethod(int x = 0)` |
+| `<pre>public static void main(String[] args) {
+        int param = 0;
+
+        String s = "";
+        new PseudoAnnotationsMainTestData(param).instanceMethod(s);
+    }</pre>` | `@Main new PseudoAnnotationsMainTestData(0).instanceMethod("")` |
+| `<pre>public static void main(String[] args) {
+        int param = 0;
+        System.out.println(new PseudoAnnotationsMainTestData(param).getValue());
+    }</pre>` | `@Main System.out.println(new PseudoAnnotationsMainTestData(0).getValue())` |
+| `<pre>public static void main(String[] args) {
+        int param = 0;
+
+        boolean b = false;
+        char c = '\\0';
+        byte by = 0;
+        short s = 0;
+        int i = 0;
+        long l = 0;
+        float f = 0.0f;
+        double d = 0.0;
+        new PseudoAnnotationsMainTestData(param).primitiveParams(b, c, by, s, i, l, f, d);
+    }</pre>` | `@Main new PseudoAnnotationsMainTestData(0).primitiveParams(false, '\\0', 0, 0, 0, 0, 0.0f, 0.0)` |
+| `<pre>public static void main(String[] args) {
+        int param = 0;
+
+        java.util.Date date = new java.util.Date();
+        LocalDate ld = java.time.LocalDate.now();
+        java.time.LocalDateTime ldt = java.time.LocalDateTime.now();
+        ZonedDateTime zdt = java.time.ZonedDateTime.now();
+        new PseudoAnnotationsMainTestData(param).dateParams(date, ld, ldt, zdt);
+    }</pre>` | `@Main new PseudoAnnotationsMainTestData(0).dateParams(new java.util.Date(), java.time.LocalDate.now(), java.time.LocalDateTime.now(), java.time.ZonedDateTime.now())` |
+| `<pre>public static void main(String[] args) {
+        int param = 0;
+
+        int[] arr = null;
+        String[] varargs = new String[]{""};
+        new PseudoAnnotationsMainTestData(param).arrayParams(arr, varargs);
+
+        boolean[] array = null;
+        Object[] objs = new Object[]{};
+        new PseudoAnnotationsMainTestData(param).mixedParams(0, "", array, objs);
+    }</pre>` | `@Main new PseudoAnnotationsMainTestData(0).arrayParams(null, new String[]{""});`<br>`@Main new PseudoAnnotationsMainTestData(0).mixedParams(0, "", null, new Object[]{})` |
+| `<pre>public static void main(String[] args) {
+        new PseudoAnnotationsMainTestData();
+        new PseudoAnnotationsMainTestData(0);
+        new PseudoAnnotationsMainTestData("", 0);
+    }</pre>` | `@Main new PseudoAnnotationsMainTestData();`<br>`@Main new PseudoAnnotationsMainTestData(0);`<br>`@Main new PseudoAnnotationsMainTestData("", 0)` |

--- a/wiki-clone/docs/features/rangeExpressionsCollapse.md
+++ b/wiki-clone/docs/features/rangeExpressionsCollapse.md
@@ -29,3 +29,17 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `rangeExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ForRangeTestData mappings
+| Before | After |
+| --- | --- |
+| `for (int i = 0; i < args.length; i++) { String arg = args[i];` | `for ((int i, String arg) : args) {` |
+| `for (int i = 0; i < args.length; i++) { String arg = args[i];` | `for (String arg : args) {` |
+| `for (int i = 0; i < args.length; i++) { System.out.println(i);` | `for (int i : [0, args.length)) {` |
+| `for (int i = 0; i <= args.length - 1; i++) {` | `for (int i : [0, args.length - 1]) {` |
+| `for (int i = 0; i < list.size(); i++) { String a = list.get(i);` | `for (String a : list) {` |
+| `for (int i = 0; i < list.size(); i++) { String a = list.get(i); System.out.println(i);` | `for ((int i, String a) : list) {` |
+| `if (args.length > 0 && args.length < 2) {` | `if (args.length in (0, 2)) {` |

--- a/wiki-clone/docs/features/semicolonsCollapse.md
+++ b/wiki-clone/docs/features/semicolonsCollapse.md
@@ -25,3 +25,14 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `semicolonsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### SemicolonTestData mappings
+| Before | After |
+| --- | --- |
+| `package data;` | `package data` |
+| `import java.util.Arrays;` | `import java.util.Arrays` |
+| `System.out.println(arg);` | `System.out.println(arg)` |
+| `Arrays.stream(args).forEach(System.out::println);` | `Arrays.stream(args).forEach(System.out::println)` |

--- a/wiki-clone/docs/features/slicingExpressionsCollapse.md
+++ b/wiki-clone/docs/features/slicingExpressionsCollapse.md
@@ -45,3 +45,21 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `slicingExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### SliceTestData mappings
+| Before | After |
+| --- | --- |
+| `System.out.println(list.subList(1, list.size()));` | `System.out.println(list[1:]);` |
+| `System.out.println(list.subList(1, 2));` | `System.out.println(list[1:2]);` |
+| `System.out.println(list.subList(0, 2));` | `System.out.println(list[:2]);` |
+| `System.out.println(list.subList(1, list.size() - 2));` | `System.out.println(list[1:-2]);` |
+| `System.out.println(list.subList(0, list.size() - 2));` | `System.out.println(list[:-2]);` |
+| `System.out.println(f.substring(1));` | `System.out.println(f[1:]);` |
+| `System.out.println(f.substring(1, 2));` | `System.out.println(f[1:2]);` |
+| `System.out.println(f.substring(1, f.length()));` | `System.out.println(f[1:]);` |
+| `System.out.println(f.substring(0, 2));` | `System.out.println(f[:2]);` |
+| `System.out.println(f.substring(1, f.length() - 2));` | `System.out.println(f[1:-2]);` |
+| `System.out.println(f.substring(0, f.length() - 2));` | `System.out.println(f[:-2]);` |

--- a/wiki-clone/docs/features/streamSpread.md
+++ b/wiki-clone/docs/features/streamSpread.md
@@ -70,3 +70,27 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `streamSpread`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### ConcatenationTestData spread mappings
+| Before | After |
+| --- | --- |
+| `streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = args*.toUpperCase().toList();` |
+| `streamToList = list.stream().map(String::toUpperCase).collect(Collectors.toList());` | `streamToList = list.stream()*.toUpperCase().toList();` |
+
+##### OptionalTestData spread mappings
+| Before | After |
+| --- | --- |
+| `Optional.<Data>empty().map(Data::getData).stream().map(Data::getData)` | `Optional.<Data>empty()?.data.stream()*.data()` |
+| `Stream.of(data).map(Data::getData).filter(Objects::nonNull)` | `Stream.of(data)*.data().filterNotNull()` |
+| `Stream.of(data).map(Data::getData) .filter(Objects::nonNull).map(Data::getData)` | `Stream.of(data)*.data().filterNotNull()*.data()` |
+
+##### SpreadTestData mappings
+| Before | After |
+| --- | --- |
+| `list.stream().map(Data::getString).collect(Collectors.joining(", "));` | `list*.string().collect(Collectors.joining(", "));` |
+| `data.getDataList().stream().map(Data::getData).toList();` | `data.getDataList().stream()*.data().toList();` |
+| `Stream.of("123", "2313").map(String::length).toList();` | `Stream.of("123", "2313")*.length().toList();` |
+| `stream.map(Data::getData).filter(Objects::nonNull).map(Data::getData).flatMap(Data::getDataStream).map(Data::getDataList).flatMap(List::stream).map(Data::getString).map(String::chars)` | `stream*.data().filterNotNull()*.data()**.dataStream()*.dataList()**.stream()*.string()*.chars()` |

--- a/wiki-clone/docs/features/summaryParentOverride.md
+++ b/wiki-clone/docs/features/summaryParentOverride.md
@@ -25,3 +25,17 @@ Removes boilerplate while preserving behavior.
 Default: Off
 Controlled by: `summaryParentOverride`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### SummaryParentOverrideTestData mappings
+| Before | After |
+| --- | --- |
+| `class ParentClass extends GrandparentClass {` | `class ParentClass extends GrandparentClass(1-grandparentMethod) {` |
+| `public void grandparentMethod() {` | `public void grandparentMethod() { // overrides from GrandparentClass` |
+| `public class TestDataClass extends ParentClass implements FirstInterface, SecondInterface, WithoutMethodInterface {` | `public class TestDataClass extends ParentClass(1-grandparentMethod) implements FirstInterface(2-interfaceMethodOne, sharedMethod), SecondInterface(1-interfaceMethodTwo), WithoutMethodInterface(nothing overridden) {` |
+| `public void interfaceMethodOne() {` | `public void interfaceMethodOne() { // overrides from FirstInterface` |
+| `public void interfaceMethodTwo() {` | `public void interfaceMethodTwo() { // overrides from SecondInterface` |
+| `public void sharedMethod() {` | `public void sharedMethod() { // overrides from FirstInterface` |
+| `public void grandparentMethod() {` (inside `TestDataClass`) | `public void grandparentMethod() { // overrides from ParentClass` |

--- a/wiki-clone/docs/features/suppressWarningsHide.md
+++ b/wiki-clone/docs/features/suppressWarningsHide.md
@@ -27,3 +27,14 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `suppressWarningsHide`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### SuppressWarningsHideTestData mappings
+| Before | After |
+| --- | --- |
+| `@SuppressWarnings("deprecation") public SuppressWarningsHideTestData() {` | `public SuppressWarningsHideTestData() {` |
+| `@SuppressWarnings({"rawtypes", "unchecked"}) public void methodWithWarnings() {` | `public void methodWithWarnings() {` |
+| `@SuppressWarnings("unused") int unusedLocalVar = 42;` | `@SuppressWarnings("unused") int unusedLocalVar = 42;` (unchanged local example) |
+| `@SuppressWarnings("deprecation") Date oldDate = new Date();` | `@SuppressWarnings("deprecation") Date oldDate = new Date();` (locals remain visible) |

--- a/wiki-clone/docs/features/varExpressionsCollapse.md
+++ b/wiki-clone/docs/features/varExpressionsCollapse.md
@@ -100,3 +100,49 @@ Removes boilerplate while preserving behavior.
 Default: On
 Controlled by: `varExpressionsCollapse`
 Related features: (none)
+---
+
+#### Folding catalogue
+
+##### VarTestData mappings
+| Before | After |
+| --- | --- |
+| `String string = "Hello, world";` | `val string = "Hello, world";` |
+| `int count = 0;` | `var count = 0;` |
+| `for (String arg : args) {` | `for (val arg : args) {` |
+| `for (int i = 0; i < args.length; i++) {` | `for (var i = 0; i < args.length; i++) {` |
+| `String arg = args[i];` | `val arg = args[i];` |
+
+##### LetReturnIt mappings
+| Before | After |
+| --- | --- |
+| `String var1 = getData(someString); if (var1 != null) { return var1; }` | `val var1 = getData(someString)?.let { return it }` |
+| `String var2 = getData(someString); if (var2 == null) { return null; }` | `val var2 = getData(someString) ?: return null` |
+| `String var4 = getData(someString); if (var4 != null) { return var4; } var4.toString();` | `val var4 = getData(someString)?.let { return it }` and `var4;` |
+| `String var5 = getData(someString); if (var5 == null) { return null; }` | `val var5 = getData(someString) ?: return null` |
+| `String var6 = getData(someString); if (var6 == null) { return null; }` | `val var6 = getData(someString) ?: return null` |
+| `String var7 = getData(someString); if (var7 != null) { return var7; }` | `val var7 = getData(someString)?.let { return it }` |
+
+##### DestructuringAssignmentArrayTestData mappings
+| Before | After |
+| --- | --- |
+| `Data ignored1 = array[0];` | `val ignored1 = array[0];` |
+| `Data first = array[0]; Data second = array[1]; Data third = array[2]; Data fourth = array[3];` | `val first, second, third, fourth) = array;` |
+| `Data ignored21 = data.getArray()[4];` | `val ignored21 = data.array[4];` |
+| `Data ignored22 = data.getArray()[5];` | `val ignored22 = data.array[5];` |
+| `Data getter1 = data.getArray()[0]; Data getter2 = data.getArray()[1]; Data getter3 = data.getArray()[2];` | `var getter1, getter2, getter3) = data.array;` |
+| `Data deepGetter1 = data.getData().getArray()[0]; Data deepGetter2 = data.getData().getArray()[1];` | `val deepGetter1, deepGetter2) = data.data.array;` |
+| `Data wrongParent1 = data.getArray()[0];` | `val wrongParent1 = data.array[0];` |
+| `Data wrongParent2 = data.getData().getArray()[1];` | `val wrongParent2 = data.data.array[1];` |
+
+##### DestructuringAssignmentListTestData mappings
+| Before | After |
+| --- | --- |
+| `Data ignored1 = list.get(0);` | `val ignored1 = list.get(0);` |
+| `Data first = list.get(0); Data second = list.get(1); Data third = list.get(2); Data fourth = list.get(3);` | `val first, second, third, fourth) = list;` |
+| `Data ignored21 = data.getList().get(4);` | `val ignored21 = data.list.get(4);` |
+| `Data ignored22 = data.getList().get(5);` | `val ignored22 = data.list.get(5);` |
+| `Data getter1 = data.getList().get(0); Data getter2 = data.getList().get(1); Data getter3 = data.getList().get(2);` | `var getter1, getter2, getter3) = data.list;` |
+| `Data deepGetter1 = data.getData().getList().get(0); Data deepGetter2 = data.getData().getList().get(1);` | `val deepGetter1, deepGetter2) = data.data.list;` |
+| `Data wrongParent1 = data.getList().get(0);` | `val wrongParent1 = data.list.get(0);` |
+| `Data wrongParent2 = data.getData().getList().get(1);` | `val wrongParent2 = data.data.list.get(1);` |


### PR DESCRIPTION
## Summary
- append a folding catalogue to the pseudo annotations feature page
- describe descriptor caching and global toggle behaviour for memory improvement and global on options
- capture the experimental SneakyThrows rewrites and nameless accessor placeholders in their feature doc

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68fa6b0bf898832ea8583b73402ec489