### PR TITLE
Fix artifact URL reference in integration workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Upload integration artifacts
         if: always()
+        id: upload_artifacts
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-artifacts-${{ matrix.os }}
@@ -63,3 +64,14 @@ jobs:
             out/ide-tests/tests/**/screenshots/**
             out/ide-tests/tests/**/driver/**
           if-no-files-found: warn
+
+      - name: Publish artifact download link
+        if: always() && steps.upload_artifacts.outputs.artifact-url != ''
+        env:
+          ARTIFACT_URL: ${{ steps.upload_artifacts.outputs.artifact-url }}
+        run: |
+          {
+            echo "## Integration test artifacts"
+            echo
+            echo "[Download results zip](${ARTIFACT_URL})"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- fix the conditional check for the artifact URL output in the integration test workflow
- update the published summary link to read the artifact URL with the correct syntax

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fb6937d810832eb774c200b5a63bf6