### PR TITLE
Add issue creation summary to todo-to-issue workflow

### DIFF
--- a/.github/workflows/todo-to-issue.yml
+++ b/.github/workflows/todo-to-issue.yml
@@ -28,6 +28,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Capture workflow start time
+        id: todo-to-issue-start
+        run: echo "timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+
       - uses: "actions/checkout@v4"
       - name: "TODO to Issue"
         id: todo-to-issue
@@ -49,6 +53,52 @@ jobs:
             {{ url }}
 
             {{ snippet }}
+      - name: Summarize TODO to Issue results
+        id: summarize-todo-to-issue
+        if: ${{ steps.todo-to-issue.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          START_TIME: ${{ steps.todo-to-issue-start.outputs.timestamp }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            if command -v sudo >/dev/null 2>&1; then
+              sudo apt-get update -y >/dev/null
+              sudo apt-get install -y jq >/dev/null
+            else
+              apt-get update -y >/dev/null
+              apt-get install -y jq >/dev/null
+            fi
+          fi
+
+          if [ -z "$START_TIME" ]; then
+            START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          fi
+
+          query="repo:${REPOSITORY} label:TODO created:>=$START_TIME"
+          payload=$(jq -n --arg q "$query" '{query:"query($query:String!){ search(query:$query, type: ISSUE, first: 100) { issueCount } }", variables:{query:$q}}')
+
+          set +e
+          response=$(curl -sS -H "Authorization: Bearer ${GH_TOKEN}" -H "Content-Type: application/json" -d "$payload" https://api.github.com/graphql)
+          status=$?
+          set -e
+
+          if [ ${status} -ne 0 ] || [ -z "$response" ]; then
+            echo "Failed to retrieve issue count from GitHub GraphQL API" >&2
+            created=0
+          else
+            created=$(echo "$response" | jq -r '.data.search.issueCount // 0')
+          fi
+
+          echo "created=${created}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### TODO to Issue summary"
+            echo
+            echo "* Issues created: ${created}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          echo "Issues created: ${created}"
       - name: Set Git user
         if: steps.todo-to-issue.outputs.changes == 'true'
         run: |


### PR DESCRIPTION
## Summary
- capture the workflow start time before running the TODO to issue action
- query GitHub's GraphQL API after the action completes to count TODO-labelled issues created since the workflow started
- append the count to the job summary and log output while exposing it as a step output

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fb7624341c832ea69d4407cdde66eb