### PR TITLE
Update integration label for workflow coverage

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -130,10 +130,11 @@ gradle:
     - 'build.gradle.kts'
     - 'settings.gradle.kts'
 
-integration-layer:
+integration-test:
 - changed-files:
   - any-glob-to-any-file:
     - '**/integration/**'
+    - '.github/workflows/integration-test.yml'
 
 action:
 - changed-files:


### PR DESCRIPTION
## Summary
- rename the integration label to "integration-test" in the labeler configuration
- ensure the integration workflow file also triggers the integration test label

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68fbb7384058832e9101037f7527eed7