### PR TITLE
Use AdvancedExpressionFoldingSettings.State for state delegation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -7,7 +7,7 @@ import com.intellij.advancedExpressionFolding.processor.asInstance
 import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
 import com.intellij.advancedExpressionFolding.processor.cache.Keys
 import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
@@ -19,7 +19,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaFile
 
-class AdvancedExpressionFoldingBuilder(private val config: IConfig = getInstance().state) : FoldingBuilderEx(), IConfig by config {
+class AdvancedExpressionFoldingBuilder : FoldingBuilderEx(), IConfig by AdvancedExpressionFoldingSettings.State()() {
     override fun buildFoldRegions(element: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
         if (!globalOn || isFoldingFile(element)) {
             return store.store(Expression.EMPTY_ARRAY, document)

--- a/src/com/intellij/advancedExpressionFolding/action/FoldingOnAction.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/FoldingOnAction.kt
@@ -7,12 +7,13 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 
-class FoldingOnAction(private val state: IConfig = AdvancedExpressionFoldingSettings.getInstance().state) :
-    AnAction(), IConfig by state {
+class FoldingOnAction :
+    AnAction(),
+    IConfig by AdvancedExpressionFoldingSettings.State()() {
 
     override fun actionPerformed(e: AnActionEvent) {
-        if (!state.globalOn) {
-            state.globalOn = true
+        if (!globalOn) {
+            globalOn = true
         }
         e.getData(CommonDataKeys.EDITOR)?.let {
             FoldingService.get().fold(it, true)

--- a/src/com/intellij/advancedExpressionFolding/action/GlobalToggleFoldingAction.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/GlobalToggleFoldingAction.kt
@@ -7,8 +7,10 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.ToggleAction
 import com.intellij.openapi.project.DumbAware
 
-class GlobalToggleFoldingAction(private val state: IConfig = AdvancedExpressionFoldingSettings.getInstance().state) :
-    ToggleAction(), IConfig by state, DumbAware {
+class GlobalToggleFoldingAction :
+    ToggleAction(),
+    IConfig by AdvancedExpressionFoldingSettings.State()(),
+    DumbAware {
 
     override fun isSelected(e: AnActionEvent): Boolean = globalOn
 

--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachIndexedStatement.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachIndexedStatement.kt
@@ -19,8 +19,7 @@ class ForEachIndexedStatement(
     private val arrayTextRange: TextRange,
     private val varSyntax: Boolean,
     private val isFinal: Boolean,
-    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state
-) : Expression(statement, textRange), IControlFlowState by state {
+) : Expression(statement, textRange), IControlFlowState by AdvancedExpressionFoldingSettings.State()() {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 

--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt
@@ -16,8 +16,7 @@ class ForEachStatement(
     private val declarationTextRange: TextRange,
     private val variableTextRange: TextRange,
     private val arrayTextRange: TextRange,
-    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state
-) : Expression(forStatement, textRange), IControlFlowState by state {
+) : Expression(forStatement, textRange), IControlFlowState by AdvancedExpressionFoldingSettings.State()() {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 

--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt
@@ -19,9 +19,8 @@ class ForStatement(
     startInclusive: Boolean,
     endRange: Expression,
     endInclusive: Boolean,
-    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state
 ) : Range(statement, textRange, operand, startRange, startInclusive, endRange, endInclusive),
-    IControlFlowState by state {
+    IControlFlowState by AdvancedExpressionFoldingSettings.State()() {
 
     init {
         separator = FOR_SEPARATOR

--- a/src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt
@@ -23,11 +23,10 @@ import java.util.ArrayList
 class IfExpression(
     private val ifStatement: PsiIfStatement,
     textRange: TextRange,
-    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state
 ) : Expression(ifStatement, textRange),
-    IControlFlowState by state,
-    IKotlinLanguageState by state,
-    IUnclassifiedFeatureState by state {
+    IControlFlowState by AdvancedExpressionFoldingSettings.State()(),
+    IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()(),
+    IUnclassifiedFeatureState by AdvancedExpressionFoldingSettings.State()() {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean {
         return isAssertExpression(ifStatement) || isCompactExpression(ifStatement)

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt
@@ -16,8 +16,7 @@ class LocalDateLiteral(
     private val year: PsiLiteralExpression,
     private val month: PsiLiteralExpression,
     private val day: PsiLiteralExpression,
-    private val state: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state,
-) : Expression(element, textRange), IDateOperationsState by state {
+) : Expression(element, textRange), IDateOperationsState by AdvancedExpressionFoldingSettings.State()() {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean = true
 

--- a/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt
@@ -17,7 +17,7 @@ import com.intellij.psi.*
 import com.intellij.psi.util.elementType
 
 
-object IfNullSafeExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.getInstance().state {
+object IfNullSafeExt : IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()() {
 
     @JvmStatic
     fun createExpression(element: PsiPolyadicExpression, document: Document): Expression? {

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/AbstractMethodCall.kt
@@ -8,18 +8,15 @@ import com.intellij.advancedExpressionFolding.settings.IDateOperationsState
 import com.intellij.advancedExpressionFolding.settings.IExpressionCollapseState
 import com.intellij.advancedExpressionFolding.settings.IGlobalSettingsState
 import com.intellij.advancedExpressionFolding.settings.IKotlinLanguageState
-import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiMethodCallExpression
 
-abstract class AbstractMethodCall(
-    private val state: IState = AdvancedExpressionFoldingSettings.getInstance().state,
-) :
-    ICollectionsStreamsState by state,
-    IDateOperationsState by state,
-    IKotlinLanguageState by state,
-    IExpressionCollapseState by state,
-    IGlobalSettingsState by state {
+abstract class AbstractMethodCall :
+    ICollectionsStreamsState by AdvancedExpressionFoldingSettings.State()(),
+    IDateOperationsState by AdvancedExpressionFoldingSettings.State()(),
+    IKotlinLanguageState by AdvancedExpressionFoldingSettings.State()(),
+    IExpressionCollapseState by AdvancedExpressionFoldingSettings.State()(),
+    IGlobalSettingsState by AdvancedExpressionFoldingSettings.State()() {
     open fun canExecute(): Boolean = true
 
     open fun execute(

--- a/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt
@@ -1,8 +1,7 @@
 package com.intellij.advancedExpressionFolding.pseudo
 
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.ILombokState
-import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
@@ -28,9 +27,9 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.util.ProcessingContext
 
-abstract class AbstractLoggingAnnotationCompletionContributor(
-    private val state: IState = getInstance().state
-) : CompletionContributor(), ILombokState by state {
+abstract class AbstractLoggingAnnotationCompletionContributor :
+    CompletionContributor(),
+    ILombokState by AdvancedExpressionFoldingSettings.State()() {
 
     protected abstract val annotationName: String
 

--- a/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt
@@ -1,9 +1,8 @@
 package com.intellij.advancedExpressionFolding.pseudo
 
 import com.intellij.advancedExpressionFolding.processor.isVoid
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.Companion.getInstance
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.ILombokState
-import com.intellij.advancedExpressionFolding.settings.IState
 import com.intellij.codeInsight.completion.*
 import com.intellij.codeInsight.lookup.AutoCompletionPolicy
 import com.intellij.codeInsight.lookup.LookupElementBuilder
@@ -15,8 +14,8 @@ import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
 
-class MainAnnotationCompletionContributor(private val state: IState = getInstance().state) : CompletionContributor(),
-    ILombokState by state {
+class MainAnnotationCompletionContributor : CompletionContributor(),
+    ILombokState by AdvancedExpressionFoldingSettings.State()() {
     init {
         extend(
             CompletionType.BASIC,

--- a/test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt
@@ -36,9 +36,7 @@ abstract class BaseTest : LightJavaCodeInsightFixtureTestCase5(TEST_JDK) {
     class TooComplexException : TestAbortedException("TOO COMPLEX FOLDING")
     class FoldingChangedException : AssertionError()
 
-    protected val state: State by lazy {
-        getInstance().state
-    }
+    protected val state: State by State()
 
     open fun assignState(vararg turnOnProperties: KMutableProperty0<Boolean>,) {
         getInstance().disableAll()

--- a/test/com/intellij/advancedExpressionFolding/folding/base/folding/FoldingTestState.kt
+++ b/test/com/intellij/advancedExpressionFolding/folding/base/folding/FoldingTestState.kt
@@ -3,11 +3,10 @@ package com.intellij.advancedExpressionFolding.folding.base.folding
 import com.intellij.advancedExpressionFolding.folding.BaseTest
 import com.intellij.advancedExpressionFolding.folding.util.TestDynamicDataProvider
 import com.intellij.advancedExpressionFolding.processor.methodcall.dynamic.IDynamicDataProvider
-import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings.State
 import kotlin.reflect.KMutableProperty0
 
-internal fun foldingState(): State = AdvancedExpressionFoldingSettings.getInstance().state
+internal fun foldingState(): State = State()()
 
 interface FoldingTestSection {
     val testCase: FoldingFeatureTestCase

--- a/test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt
@@ -37,7 +37,7 @@ class PlaceholderFoldingBuilderTest : BaseTest() {
             val file = fixture.file
             val document = fixture.getDocument(file)
 
-            val builder = AdvancedExpressionFoldingBuilder(settings.state)
+            val builder = AdvancedExpressionFoldingBuilder()
             val preview = ReadAction.compute<List<String>, RuntimeException> {
                 builder.preview(file, document)
             }


### PR DESCRIPTION
## Summary
- replace direct state fields in builders, actions, and contributors with delegation to `AdvancedExpressionFoldingSettings.State()()`
- delegate control-flow and literal expression classes to the shared settings state
- update helpers and tests to access the new delegation pattern

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fbe3b921e4832e9d103bb8daaad9dd