### PR TITLE
Include compiled example classes in plugin resources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -209,9 +209,11 @@ tasks {
     }
 
     processResources {
+        dependsOn(":examples:testClasses")
         from("examples/data") {
             into("data")
         }
+        from(examplesTestOutput.classesDirs)
     }
 }
 


### PR DESCRIPTION
## Summary
- copy the compiled example outputs into the plugin resources so the example() loader can find them at runtime
- make the processResources task depend on :examples:testClasses to ensure the classes are built before being copied

## Testing
- ./gradlew clean --console=plain --no-daemon
- ./gradlew build --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68fd0646f77c832e9b9be4ef5e455f12