### PR TITLE
Fix IntegrationTestApi global toggle event creation

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
@@ -20,14 +20,17 @@ object IntegrationTestApi {
     @JvmStatic
     fun toggleGlobalFolding(state: Boolean) {
         runOnEdt {
-            val action = ActionManager.getInstance().getAction(GLOBAL_TOGGLE_ACTION_ID) as? ToggleAction
+            val actionManager = ActionManager.getInstance()
+            val action = actionManager.getAction(GLOBAL_TOGGLE_ACTION_ID) as? ToggleAction
                 ?: error("Action $GLOBAL_TOGGLE_ACTION_ID not found")
-            val event = AnActionEvent.createEvent(
-                DataContext.EMPTY_CONTEXT,
+            val presentation = action.templatePresentation.clone()
+            val event = AnActionEvent(
                 null,
+                DataContext.EMPTY_CONTEXT,
                 ActionPlaces.UNKNOWN,
-                ActionUiKind.NONE,
-                null
+                presentation,
+                actionManager,
+                0
             )
             action.setSelected(event, state)
             refreshOpenEditors()


### PR DESCRIPTION
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/actions/runs/18813712646
```bash
IntegrationTest > find methods with default parameters action shows usage results() FAILED
    java.util.NoSuchElementException at TimeoutAnalyzer.kt:139
        Caused by: java.util.NoSuchElementException at TimeoutAnalyzer.kt:139
IntegrationTest > global toggle folding action switches setting() FAILED
    java.util.NoSuchElementException at TimeoutAnalyzer.kt:139
        Caused by: java.util.NoSuchElementException at TimeoutAnalyzer.kt:139
```

## Summary
- create the global toggle AnActionEvent with the legacy constructor so it works without ActionUiKind
- reuse the ActionManager instance and clone the action presentation before toggling the state

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fdb0877838832e9a5a7a62b44a80c6