### PR TITLE
Fix folding for quoted interpolated strings (#715)

### DIFF
--- a/examples/data/InterpolatedStringTestData.java
+++ b/examples/data/InterpolatedStringTestData.java
@@ -11,8 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, " + name + "!");
         System.out.println(name + ", hello!");
         System.out.println(name + ", " + name);
-        System.out.println('"' + name + " says hi"); //TODO: it should be folded as "\"$name says hi"
-        System.out.println("Hi " + name + '"');      //TODO: it should be folded as "Hi $name\""
+        System.out.println('"' + name + " says hi");
+        System.out.println("Hi " + name + '"');
         System.out.println("Unicode: " + '\u0041');
         System.out.println("Next: " + (char)('A' + 1));
         System.out.println("Length: " + args.length);

--- a/folded/InterpolatedStringTestData-folded.java
+++ b/folded/InterpolatedStringTestData-folded.java
@@ -11,8 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, $name!");
         System.out.println("$name, hello!");
         System.out.println("$name, $name");
-        System.out.println("$name says hi"); //TODO: it should be folded as "\"$name says hi"
-        System.out.println("Hi $name");      //TODO: it should be folded as "Hi $name\""
+        System.out.println("\"$name says hi");
+        System.out.println("Hi $name\"");
         System.out.println("Unicode: ${'\u0041'}");
         System.out.println("Next: ${(char)('A' + 1)}");
         System.out.println("Length: ${args.length}");

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/InterpolatedString.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/InterpolatedString.kt
@@ -46,7 +46,7 @@ class InterpolatedString(
                 element.node,
                 TextRange.create(first.textRange.startOffset, first.textRange.endOffset),
                 group,
-                "\""
+                "\\\""
             )
         } else if (first !is CharSequenceLiteral) {
             val startOffset = first.textRange.startOffset
@@ -125,7 +125,7 @@ class InterpolatedString(
                 element.node,
                 TextRange.create(last.textRange.startOffset, last.textRange.endOffset),
                 group,
-                "\""
+                "\\\""
             )
         } else if (last !is CharSequenceLiteral && document.textLength > last.textRange.endOffset + 1) {
             val overflowRightRange = TextRange.create(last.textRange.endOffset, last.textRange.endOffset + 1)

--- a/testData/InterpolatedStringTestData-all.java
+++ b/testData/InterpolatedStringTestData-all.java
@@ -11,8 +11,8 @@ public class InterpolatedStringTestData {
         <fold text='' expand='false'>System.out.</fold>println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         <fold text='' expand='false'>System.out.</fold>println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
-        <fold text='' expand='false'>System.out.</fold>println(<fold text='"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi"); //TODO: it should be folded as "\"$name says hi"
-        <fold text='' expand='false'>System.out.</fold>println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='"' expand='false'>'"'</fold>);      //TODO: it should be folded as "Hi $name\""
+        <fold text='' expand='false'>System.out.</fold>println(<fold text='\"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi");
+        <fold text='' expand='false'>System.out.</fold>println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='\"' expand='false'>'"'</fold>);
         <fold text='' expand='false'>System.out.</fold>println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println("Next: <fold text='${' expand='false'>" + </fold><fold text='' expand='false'>(char)(</fold>'A' + 1<fold text='' expand='false'>)</fold><fold text='}")' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;

--- a/testData/InterpolatedStringTestData.java
+++ b/testData/InterpolatedStringTestData.java
@@ -11,8 +11,8 @@ public class InterpolatedStringTestData {
         System.out.println("Hello, <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + "</fold>!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, hello!");
         System.out.println<fold text='("$' expand='false'>(</fold>name<fold text='' expand='false'> + "</fold>, <fold text='$' expand='false'>" + </fold>name<fold text='")' expand='false'>)</fold>;
-        System.out.println(<fold text='"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi"); //TODO: it should be folded as "\"$name says hi"
-        System.out.println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='"' expand='false'>'"'</fold>);      //TODO: it should be folded as "Hi $name\""
+        System.out.println(<fold text='\"' expand='false'>'"'</fold><fold text='$' expand='false'> + </fold>name<fold text='' expand='false'> + "</fold> says hi");
+        System.out.println("Hi <fold text='$' expand='false'>" + </fold>name<fold text='' expand='false'> + </fold><fold text='\"' expand='false'>'"'</fold>);
         System.out.println("Unicode: <fold text='${' expand='false'>" + </fold>'\u0041'<fold text='}")' expand='false'>)</fold>;
         System.out.println("Next: <fold text='${' expand='false'>" + </fold>(char)('A' + 1)<fold text='}")' expand='false'>)</fold>;
         System.out.println("Length: <fold text='${' expand='false'>" + </fold>args.length<fold text='}")' expand='false'>)</fold>;


### PR DESCRIPTION
## Summary
- ensure interpolated string folding preserves escaped quote characters at the edges
- update samples and folding test data to match the new behavior (Fixes #715)

## Testing
- ./gradlew --no-daemon --console=plain clean build test --no-build-cache *(fails: persistent IDE cache/indexing errors surface during the test task)*

------
https://chatgpt.com/codex/tasks/task_e_68fdbb0faf64832e98653f04c5f34144