### PR TITLE
Guard manual release workflow against push triggers

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -44,6 +44,7 @@ on:
 
 jobs:
   manual-release:
+    if: github.event_name == 'workflow_dispatch'
     name: Manual Semantic Release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- add an event guard to the manual release workflow so it only runs when dispatched manually

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdc52da20c832e80866eb9ea5a2c8c