### PR TITLE
Suppress unchecked cast warning in settings test

### DIFF
--- a/test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt
@@ -10,6 +10,7 @@ import kotlin.reflect.full.memberProperties
 
 class SettingsTest {
 
+    @Suppress("UNCHECKED_CAST")
     private fun booleanProperties(): List<KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean>> =
         AdvancedExpressionFoldingSettings.State::class.memberProperties
             .filterIsInstance<KMutableProperty1<AdvancedExpressionFoldingSettings.State, *>>()


### PR DESCRIPTION
## Summary
- suppress the unchecked cast warning in `SettingsTest.booleanProperties`

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68fdc1edc860832e8f202ae7f6727fa3