### PR TITLE
Add documentation target provider for folding details

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,6 +50,9 @@
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.pseudo.TracingLoggableAnnotationCompletionContributor"/>
+
+        <documentationTargetProvider
+                implementation="com.intellij.advancedExpressionFolding.documentation.FoldingDocTargetProvider"/>
     </extensions>
 
     <applicationListeners>

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -12,6 +12,7 @@ import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.application.WriteIntentReadAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.openapi.project.IndexNotReadyException
@@ -95,7 +96,40 @@ class AdvancedExpressionFoldingBuilder : FoldingBuilderEx(), IConfig by Advanced
         return allDescriptors.toTypedArray()
     }
 
-    override fun getPlaceholderText(astNode: ASTNode) = null
+    override fun getPlaceholderText(astNode: ASTNode): String? {
+        val psi = astNode.psi ?: return null
+        val file = psi.containingFile ?: return null
+        val project = psi.project
+        val docManager = PsiDocumentManager.getInstance(project)
+        val document = docManager.getDocument(file) ?: return null
+        if (!docManager.isCommitted(document)) {
+            WriteIntentReadAction.run<RuntimeException> {
+                docManager.commitDocument(document)
+            }
+        }
+
+        val expression = try {
+            var current: PsiElement? = psi
+            var expr = current?.let { BuildExpressionExt.getNonSyntheticExpression(it, document) }
+            while (expr == null && current != null) {
+                current = current.parent
+                expr = current?.let { BuildExpressionExt.getNonSyntheticExpression(it, document) }
+            }
+            expr
+        } catch (_: IndexNotReadyException) {
+            return null
+        } ?: return null
+
+        if (!expression.supportsFoldRegions(document, null)) {
+            return null
+        }
+
+        val descriptor = expression.buildFoldRegions(expression.element, document, null)
+            .firstOrNull { it.element == astNode }
+            ?: return null
+
+        return descriptor.getPlaceholderText()
+    }
 
     // TODO: Collapse everything by default but use these settings when actually building the folding descriptors
     override fun isCollapsedByDefault(astNode: ASTNode): Boolean {

--- a/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocTarget.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocTarget.kt
@@ -1,0 +1,100 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder
+import com.intellij.advancedExpressionFolding.isAdvancedExpressionFoldingGroup
+import com.intellij.advancedExpressionFolding.documentation.links.DocumentationLinks
+import com.intellij.advancedExpressionFolding.documentation.settings.ExpressionSettingLocator
+import com.intellij.advancedExpressionFolding.processor.core.BuildExpressionExt
+import com.intellij.openapi.application.WriteIntentReadAction
+import com.intellij.openapi.project.DumbAware
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.platform.backend.documentation.DocumentationResult
+import com.intellij.platform.backend.documentation.DocumentationTarget
+import com.intellij.platform.backend.presentation.TargetPresentation
+import com.intellij.model.Pointer
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.SmartPointerManager
+import com.intellij.xml.util.XmlStringUtil
+
+class FoldingDocTarget(private val seed: PsiElement) : DocumentationTarget, DumbAware {
+  override fun computePresentation(): TargetPresentation =
+    TargetPresentation.builder("Advanced Expression Folding").presentation()
+
+  override fun createPointer(): Pointer<out DocumentationTarget> {
+    val pointer = SmartPointerManager.getInstance(seed.project).createSmartPsiElementPointer(seed)
+    return Pointer {
+      pointer.element?.let(::FoldingDocTarget)
+    }
+  }
+
+  override fun computeDocumentation(): DocumentationResult? {
+    val file = seed.containingFile ?: return null
+    val project = seed.project
+    val docManager = PsiDocumentManager.getInstance(project)
+    val document = docManager.getDocument(file) ?: return null
+    if (!docManager.isCommitted(document)) {
+      WriteIntentReadAction.run<RuntimeException> {
+        docManager.commitDocument(document)
+      }
+    }
+
+    val builder = AdvancedExpressionFoldingBuilder()
+    val all = builder.buildFoldRegions(file, document, false)
+      .filter(FoldingDescriptor::isAdvancedExpressionFoldingGroup)
+    if (all.isEmpty()) return null
+
+    var current: PsiElement? = seed
+    var expression = current?.let { BuildExpressionExt.getNonSyntheticExpression(it, document) }
+    while (expression == null && current != null) {
+      current = current.parent
+      expression = current?.let { BuildExpressionExt.getNonSyntheticExpression(it, document) }
+    }
+    expression ?: return null
+    if (!expression.supportsFoldRegions(document, null)) return null
+
+    val inside = all.filter { expression.textRange.intersectsStrict(it.range) }
+    if (inside.isEmpty()) return null
+
+    val before = document.getText(expression.textRange)
+
+    val items = inside.mapNotNull { descriptor ->
+      val node = descriptor.element ?: return@mapNotNull null
+      val placeholder = builder.getPlaceholderText(node) ?: return@mapNotNull null
+      descriptor.range to placeholder
+    }.sortedByDescending { it.first.startOffset }
+    if (items.isEmpty()) return null
+
+    val after = StringBuilder(before).also { buffer ->
+      val base = expression.textRange.startOffset
+      for ((range, placeholder) in items) {
+        val start = range.startOffset - base
+        val end = range.endOffset - base
+        if (start >= 0 && end <= buffer.length && end >= start) {
+          buffer.replace(start, end, placeholder)
+        }
+      }
+    }.toString()
+    if (after == before) return null
+
+    val keys = ExpressionSettingLocator.settingKeysFor(expression)
+    if (keys.isEmpty()) return null
+
+    val settingsHtml = keys.joinToString(" ") { key ->
+      DocumentationLinks.urlFor(key)?.let { url ->
+        "<code>$key</code>&nbsp;<a href=\"$url\">docs</a>"
+      } ?: "<code>$key</code>"
+    }
+
+    val body = buildString {
+      append("<h3>Advanced Expression Folding</h3>")
+      append("<p>Settings: $settingsHtml</p>")
+      append("<p>Before</p>")
+      append("<pre><code>${XmlStringUtil.escapeString(before)}</code></pre>")
+      append("<p>After</p>")
+      append("<pre><code>${XmlStringUtil.escapeString(after)}</code></pre>")
+    }
+
+    return DocumentationResult.documentation(XmlStringUtil.wrapInHtml(body))
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocTargetProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/FoldingDocTargetProvider.kt
@@ -1,0 +1,13 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.platform.backend.documentation.DocumentationTarget
+import com.intellij.platform.backend.documentation.DocumentationTargetProvider
+import com.intellij.psi.PsiFile
+
+class FoldingDocTargetProvider : DocumentationTargetProvider, DumbAware {
+  override fun documentationTargets(file: PsiFile, offset: Int): List<DocumentationTarget> {
+    val element = file.findElementAt(offset) ?: return emptyList()
+    return listOf(FoldingDocTarget(element))
+  }
+}

--- a/src/com/intellij/advancedExpressionFolding/documentation/links/DocumentationLinks.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/links/DocumentationLinks.kt
@@ -1,0 +1,59 @@
+package com.intellij.advancedExpressionFolding.documentation.links
+
+object DocumentationLinks {
+  private const val BASE_URL = "https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki/docs/features/"
+
+  private val available = setOf(
+    "arithmeticExpressions",
+    "assertsCollapse",
+    "castExpressionsCollapse",
+    "checkExpressionsCollapse",
+    "compactControlFlowSyntaxCollapse",
+    "comparingExpressionsCollapse",
+    "comparingLocalDatesCollapse",
+    "concatenationExpressionsCollapse",
+    "const",
+    "constructorReferenceNotation",
+    "controlFlowMultiStatementCodeBlockCollapse",
+    "controlFlowSingleStatementCodeBlockCollapse",
+    "destructuring",
+    "dynamic",
+    "emojify",
+    "expressionFunc",
+    "experimental",
+    "fieldShift",
+    "finalEmoji",
+    "finalRemoval",
+    "getExpressionsCollapse",
+    "getSetExpressionsCollapse",
+    "globalOn",
+    "ifNullSafe",
+    "interfaceExtensionProperties",
+    "kotlinQuickReturn",
+    "localDateLiteralCollapse",
+    "localDateLiteralPostfixCollapse",
+    "logFolding",
+    "logFoldingTextBlocks",
+    "lombok",
+    "lombokDirtyOff",
+    "lombokPatternOff",
+    "memoryImprovement",
+    "methodDefaultParameters",
+    "nullable",
+    "optional",
+    "overrideHide",
+    "patternMatchingInstanceof",
+    "println",
+    "pseudoAnnotations",
+    "rangeExpressionsCollapse",
+    "semicolonsCollapse",
+    "slicingExpressionsCollapse",
+    "streamSpread",
+    "summaryParentOverride",
+    "suppressWarningsHide",
+    "varExpressionsCollapse"
+  )
+
+  fun urlFor(settingKey: String): String? =
+    if (available.contains(settingKey)) "$BASE_URL$settingKey" else null
+}

--- a/src/com/intellij/advancedExpressionFolding/documentation/settings/ExpressionSettingLocator.kt
+++ b/src/com/intellij/advancedExpressionFolding/documentation/settings/ExpressionSettingLocator.kt
@@ -1,0 +1,29 @@
+package com.intellij.advancedExpressionFolding.documentation.settings
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import java.util.HashSet
+import java.util.LinkedHashSet
+import kotlin.reflect.full.memberProperties
+
+object ExpressionSettingLocator {
+  private val knownKeys: Set<String> = AdvancedExpressionFoldingSettings.State::class.memberProperties
+    .filter { it.returnType.classifier == Boolean::class }
+    .map { it.name }
+    .toSet()
+
+  fun settingKeysFor(expression: Expression): List<String> {
+    val discovered = LinkedHashSet<String>()
+    collect(expression::class.java, discovered, HashSet())
+    return discovered.filter { it in knownKeys }
+  }
+
+  private fun collect(type: Class<*>, result: MutableSet<String>, visited: MutableSet<Class<*>>) {
+    if (!visited.add(type)) return
+    type.kotlin.memberProperties
+      .filter { it.returnType.classifier == Boolean::class }
+      .mapTo(result) { it.name }
+    type.interfaces.forEach { collect(it, result, visited) }
+    type.superclass?.let { collect(it, result, visited) }
+  }
+}

--- a/test/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/documentation/FoldingDocumentationTest.kt
@@ -1,0 +1,61 @@
+package com.intellij.advancedExpressionFolding.documentation
+
+import com.intellij.advancedExpressionFolding.AdvancedExpressionFoldingBuilder
+import com.intellij.advancedExpressionFolding.folding.BaseTest
+import com.intellij.advancedExpressionFolding.isAdvancedExpressionFoldingGroup
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.application.runReadAction
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FoldingDocumentationTest : BaseTest() {
+  @Test
+  fun documentationIncludesBeforeAfterAndSettings() {
+    assignState(state::globalOn, state::localDateLiteralCollapse, state::localDateLiteralPostfixCollapse)
+    val file = fixture.configureByText(
+      "Doc.java",
+      """
+      import java.time.LocalDate;
+      class Doc {
+        void test() {
+          LocalDate date = LocalDate.of(2024, 10, 26);
+        }
+      }
+      """.trimIndent()
+    )
+
+    val provider = FoldingDocTargetProvider()
+    val document = fixture.editor.document
+    val offset = runReadAction {
+      val descriptors = AdvancedExpressionFoldingBuilder()
+        .buildFoldRegions(file, document, false)
+        .filter(FoldingDescriptor::isAdvancedExpressionFoldingGroup)
+      check(descriptors.isNotEmpty()) { "No advanced folding descriptors available" }
+      val range = descriptors.first().range
+      (range.startOffset + range.endOffset) / 2
+    }
+
+    val targets = runReadAction { provider.documentationTargets(file, offset) }
+    assertEquals(1, targets.size) { "Expected a single documentation target at offset $offset" }
+
+    val documentation = runReadAction { targets.single().computeDocumentation() }
+    val html = extractHtml(requireNotNull(documentation))
+
+    assertTrue(html.contains("Before"))
+    assertTrue(html.contains("After"))
+    assertTrue(html.contains("localDateLiteralCollapse"))
+  }
+
+  private fun extractHtml(result: com.intellij.platform.backend.documentation.DocumentationResult): String {
+    val method = result::class.java.methods.firstOrNull { it.name == "getHtml" }
+    if (method != null) {
+      return method.invoke(result) as? String ?: ""
+    }
+    val field = result::class.java.fields.firstOrNull { it.name == "html" }
+    if (field != null) {
+      return field.get(result) as? String ?: ""
+    }
+    return result.toString()
+  }
+}


### PR DESCRIPTION
## Summary
- add a documentation target provider backed by DocumentationTarget to surface folding information
- rebuild placeholders and settings information for documentation output using new helper utilities
- cover the documentation flow with a dedicated test exercising before/after rendering

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68fdbdaab930832eb35f3ce3ef8687b8