### PR TITLE
Automate dev mode regeneration PR creation

### DIFF
--- a/.github/workflows/dev-mode-test-regeneration.yml
+++ b/.github/workflows/dev-mode-test-regeneration.yml
@@ -1,0 +1,48 @@
+name: Dev Mode Test Regeneration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dev-mode-tests:
+    name: Regenerate tests in dev mode
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+        with:
+          gradle-home-cache-cleanup: true
+
+      - name: Run tests with dev mode
+        env:
+          dev-mode: "1"
+          DEV_MODE: "1"
+        run: ./gradlew clean build --no-daemon --console=plain
+
+      - name: Determine branch name
+        id: branch
+        run: echo "name=dev-mode-regeneration-$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Regenerate tests in dev mode"
+          branch: ${{ steps.branch.outputs.name }}
+          delete-branch: true
+          title: "Regenerate tests in dev mode"
+          body: |
+            ## Summary
+            - rerun the Gradle build with dev mode enabled to refresh generated test data
+
+            ## Testing
+            - ./gradlew clean build --no-daemon --console=plain


### PR DESCRIPTION
## Summary
- rerun the Gradle build in dev mode during the workflow to refresh generated artifacts
- automatically create a dated branch with the refreshed results and open a pull request

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fdc0b80d0c832e88f8a596a26ebb56