### PR TITLE
Ensure semantic release installs conventional commit preset

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -108,7 +108,9 @@ jobs:
           semantic_version: ${{ inputs.semantic_version }}
           branches: ${{ inputs.branches }}
           branch: ${{ inputs.branch }}
-          extra_plugins: ${{ inputs.extra_plugins }}
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+            ${{ inputs.extra_plugins }}
           dry_run: ${{ inputs.dry_run }}
           ci: ${{ inputs.ci }}
           unset_gha_env: ${{ inputs.unset_gha_env }}


### PR DESCRIPTION
## Summary
- ensure the semantic-release workflow installs the conventional commits changelog preset before running
- allow additional user-specified plugins to be appended after the required preset

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fe011c3964832eae8255ad8f3f9e46