### PR TITLE
Prevent Helper.findDot from reading past document bounds

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -170,16 +170,22 @@ object Helper {
         }
         if (includeNewLines) {
             var offsetWithNewLine = offset
-            do {
+            while (kotlin.math.abs(offsetWithNewLine) < 100) {
                 position += direction
                 offsetWithNewLine += direction
-                if (direction < 0 && charAt(chars, position) == '\n') {
+                if (position <= 0 || position >= length) {
+                    break
+                }
+                val currentChar = charAt(chars, position)
+                if (direction < 0 && currentChar == '\n') {
                     offset = offsetWithNewLine
-                } else if (direction > 0 && charAt(chars, position).isWhitespace()) {
+                } else if (direction > 0 && currentChar.isWhitespace()) {
                     offset = offsetWithNewLine
                 }
-            } while (kotlin.math.abs(offsetWithNewLine) < 100 && position > 0 && position < length &&
-                charAt(chars, position).isWhitespace())
+                if (!currentChar.isWhitespace()) {
+                    break
+                }
+            }
         }
         if (kotlin.math.abs(offset) >= 100) {
             return Int.MAX_VALUE


### PR DESCRIPTION
## Summary
- guard the newline scanning loop in `Helper.findDot` against walking past document boundaries
- stop scanning once the first non-whitespace character is reached to avoid spurious index errors

## Testing
- ./gradlew clean build test --console=plain --no-daemon --max-workers=1

------
https://chatgpt.com/codex/tasks/task_e_68fe03bff388832ebe93232e6aeb5473