### PR TITLE
Handle breakpoint grouping via reflection

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointUtil.kt
+++ b/src/com/intellij/advancedExpressionFolding/pseudo/BreakpointUtil.kt
@@ -12,7 +12,6 @@ import com.intellij.xdebugger.XDebuggerUtil
 import com.intellij.xdebugger.breakpoints.SuspendPolicy
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint
 import com.intellij.xdebugger.evaluation.EvaluationMode
-import com.intellij.xdebugger.impl.breakpoints.XBreakpointBase
 import kotlin.math.max
 
 object BreakpointUtil {
@@ -33,12 +32,22 @@ object BreakpointUtil {
             bpMgr.allBreakpoints.find { it.sourcePosition?.file == file && it.sourcePosition?.line == line }
                 ?.let { bpMgr.removeBreakpoint(it) }
                 ?: bpMgr.addLineBreakpoint(bpType, file.url, line, bpType.createBreakpointProperties(file, line)).apply {
-                    (this as? XBreakpointBase<*, *, *>)?.group = groupName
+                    addGroup(groupName)
                     logExpression ?: return@apply
                     suspendPolicy = SuspendPolicy.NONE
                     isLogMessage = true
                     logExpressionObject = util.createExpression(logExpression, JavaLanguage.INSTANCE, null, EvaluationMode.EXPRESSION)
                 }
+        }
+    }
+
+    fun XLineBreakpoint<*>.addGroup(groupName: String?) {
+        try {
+            val method = javaClass.getMethod("setGroup", String::class.java)
+            method.isAccessible = true
+            method.invoke(this, groupName)
+        } catch (_: Exception) {
+            // ignore
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the direct use of `XBreakpointBase` with a reflective helper on `XLineBreakpoint`
- ensure breakpoint grouping still occurs before configuring log-only breakpoints

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_68ffab07d87c832e9fdfd9e838af2b8b