### PR TITLE
Add changed file count to dev-mode regeneration workflow

### DIFF
--- a/.github/workflows/dev-mode-test-regeneration.yml
+++ b/.github/workflows/dev-mode-test-regeneration.yml
@@ -29,6 +29,17 @@ jobs:
           DEV_MODE: "1"
         run: ./gradlew clean build --no-daemon --console=plain
 
+      - name: Report changed file count
+        run: |
+          set -eo pipefail
+          changed=$(git status --short | wc -l | tr -d ' ')
+          echo "Changed files: ${changed}"
+          {
+            echo "### Dev mode regeneration"
+            echo ""
+            echo "${changed} file(s) changed after regeneration."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Determine branch name
         id: branch
         run: echo "name=dev-mode-regeneration-$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- add a workflow step that reports how many files changed after the dev-mode Gradle build
- publish the count to both the job logs and the workflow run summary for quick visibility

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ffaf1918e4832ea0a0b1f6a2de2452