### PR TITLE
Use data context to trigger folding actions in integration tests

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
@@ -7,35 +7,43 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.atomic.AtomicReference
 
 @TestOnly
 object IntegrationTestApi {
-    private const val GLOBAL_TOGGLE_ACTION_ID =
-        "com.intellij.advancedExpressionFolding.action.GlobalToggleFoldingAction"
-
     @JvmStatic
     fun toggleGlobalFolding(state: Boolean) {
-        runOnEdt {
-            val action = ActionManager.getInstance().getAction(GLOBAL_TOGGLE_ACTION_ID) as? ToggleAction
-                ?: error("Action $GLOBAL_TOGGLE_ACTION_ID not found")
-            val event = AnActionEvent.createFromAnAction(
-                action,
-                null,
-                ActionPlaces.UNKNOWN,
-                DataContext.EMPTY_CONTEXT
-            )
-            action.update(event)
-            action.setSelected(event, state)
+        runInEdt {
+            val project = ProjectManager.getInstance().openProjects.firstOrNull { !it.isDisposed }
+                ?: return@runInEdt
+            val ctx = SimpleDataContext.getProjectContext(project)
+            val actionId = if (state) "AdvancedFolding.EnableAll" else "AdvancedFolding.DisableAll"
+            fireAction(actionId, project, ctx)
             refreshOpenEditors()
         }
+    }
+
+    private fun fireAction(actionId: String, project: Project, dataContext: DataContext) {
+        if (project.isDisposed) {
+            return
+        }
+        val action = ActionManager.getInstance().getAction(actionId) ?: return
+        val event = AnActionEvent.createFromDataContext(
+            ActionPlaces.UNKNOWN,
+            Presentation(),
+            dataContext
+        )
+        action.actionPerformed(event)
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary
- update the integration toggle helper to execute the enable/disable actions created from a data context
- add a shared `fireAction` helper so integration tests no longer depend on `ActionUiKind` or the deprecated event factory

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_6900ebc4be60832eab796348941c4982