### PR TITLE
Simplify suppress warnings example data

### DIFF
--- a/examples/data/SuppressWarningsHideTestData.java
+++ b/examples/data/SuppressWarningsHideTestData.java
@@ -4,41 +4,35 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-@SuppressWarnings("rawtypes")
+@SuppressWarnings("ALL")
 public class SuppressWarningsHideTestData {
 
-    @SuppressWarnings("unused")
     private int unusedField;
 
-    @SuppressWarnings("unchecked")
     private static List rawStaticList = new ArrayList();
 
-    @SuppressWarnings("deprecation")
     public SuppressWarningsHideTestData() {
         Date date = new Date();
-        date.getYear();
+        date.toInstant();
     }
 
-    public SuppressWarningsHideTestData(@SuppressWarnings("unused") String ignoredParam) {
+    public SuppressWarningsHideTestData(String ignoredParam) {
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
     public void methodWithWarnings() {
         List list = new ArrayList();
         List<String> stringList = list;
     }
 
-    public void methodWithAnnotatedParam(@SuppressWarnings("unused") int unusedParam) {
+    public void methodWithAnnotatedParam(int unusedParam) {
         System.out.println("Method called");
     }
 
-    @SuppressWarnings("deprecation")
     public void methodWithAnnotatedLocalVar() {
-        @SuppressWarnings("unused")
         int unusedLocalVar = 42;
 
         Date oldDate = new Date();
-        oldDate.getMonth();
+        oldDate.toInstant();
     }
 
 }


### PR DESCRIPTION
## Summary
- broaden the class-level suppression to cover all warnings in the example
- drop redundant @SuppressWarnings usage on members and switch to modern Date APIs

## Testing
- `./gradlew clean build test --console=plain --no-daemon --no-configuration-cache --stacktrace` *(hangs: Gradle daemon repeatedly times out waiting for finished message)*

------
https://chatgpt.com/codex/tasks/task_e_690112e64220832eb184f7f13a9bbfd4