### PR TITLE
Add screenshot label count output to PR labeler

### DIFF
--- a/.github/workflows/pr-screenshot-labeler.yml
+++ b/.github/workflows/pr-screenshot-labeler.yml
@@ -29,12 +29,16 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
+    outputs:
+      screenshot_labels_added: ${{ steps.apply.outputs.labels_added }}
     steps:
       - name: Apply screenshot label when needed
+        id: apply
         uses: actions/github-script@v8
         with:
           script: |
             const LABEL_NAME = 'screenshot';
+            let appliedCount = 0;
 
             const hasScreenshot = (body) => {
               if (!body) {
@@ -83,6 +87,7 @@ jobs:
 
             if (prNumbers.length === 0) {
               core.info('No pull requests to process.');
+              core.setOutput('labels_added', String(appliedCount));
               return;
             }
 
@@ -117,4 +122,9 @@ jobs:
               });
 
               core.info(`Applied "${LABEL_NAME}" label to PR #${number}.`);
+              appliedCount += 1;
             }
+
+            core.setOutput('labels_added', String(appliedCount));
+      - name: Display screenshot labels added
+        run: echo "Screenshot labels added: ${{ steps.apply.outputs.labels_added }}"


### PR DESCRIPTION
## Summary
- capture how many screenshot labels the workflow applies and expose it as a job output
- add a follow-up step that logs the total count for easier inspection

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_6901269bbb68832ea1b08b0c59fe066b