### PR TITLE
Handle indexed addAll prepends

### DIFF
--- a/examples/data/ConcatenationTestData.java
+++ b/examples/data/ConcatenationTestData.java
@@ -21,6 +21,10 @@ public class ConcatenationTestData {
         Set<String> copyOfSet = new HashSet<>();
         set.addAll(copyOfSet);
         System.out.println(copyOfSet);
+        List<Character> chars = new ArrayList<>();
+        List<Character> sequence = Arrays.asList('a', 'b');
+        chars.addAll(0, sequence);
+        chars.addAll(3, sequence);
         List<String> streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());
         System.out.println(streamToList);
         streamToList = Arrays.stream(args).map(String::toUpperCase).collect(Collectors.toList());

--- a/folded/ConcatenationTestData-folded.java
+++ b/folded/ConcatenationTestData-folded.java
@@ -21,6 +21,10 @@ public class ConcatenationTestData {
         Set<String> copyOfSet = new HashSet<>();
         set += copyOfSet;
         System.out.println(copyOfSet);
+        List<Character> chars = new ArrayList<>();
+        List<Character> sequence = Arrays.asList('a', 'b');
+        chars = sequence + chars;
+        chars.addAll(3, sequence);
         List<String> streamToList = args*.toUpperCase().toList();
         System.out.println(streamToList);
         streamToList = args*.toUpperCase().toList();

--- a/src/com/intellij/advancedExpressionFolding/expression/operation/collection/PrependAssignForCollection.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/operation/collection/PrependAssignForCollection.kt
@@ -1,0 +1,61 @@
+package com.intellij.advancedExpressionFolding.expression.operation.collection
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+
+class PrependAssignForCollection(
+    element: PsiElement,
+    textRange: TextRange,
+    private val receiver: Expression,
+    private val sequence: Expression,
+    private val receiverText: String,
+) : Expression(element, textRange) {
+
+    override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean {
+        val receiverRange = receiver.textRange
+        val sequenceRange = sequence.textRange
+        if (receiverRange.endOffset >= sequenceRange.startOffset) {
+            return false
+        }
+        if (sequenceRange.endOffset > textRange.endOffset) {
+            return false
+        }
+        return true
+    }
+
+    override fun buildFoldRegions(
+        element: PsiElement,
+        document: Document,
+        parent: Expression?,
+    ): Array<FoldingDescriptor> {
+        val group = FoldingGroup.newGroup(PrependAssignForCollection::class.java.name)
+        val descriptors = mutableListOf<FoldingDescriptor>()
+
+        val receiverRange = receiver.textRange
+        val sequenceRange = sequence.textRange
+
+        val assignmentRange = TextRange.create(receiverRange.endOffset, sequenceRange.startOffset)
+        if (!assignmentRange.isEmpty) {
+            descriptors += FoldingDescriptor(element.node, assignmentRange, group, " = ")
+        }
+
+        val trailingRange = TextRange.create(sequenceRange.endOffset, textRange.endOffset)
+        if (!trailingRange.isEmpty) {
+            descriptors += FoldingDescriptor(element.node, trailingRange, group, " + $receiverText")
+        }
+
+        if (receiver.supportsFoldRegions(document, this)) {
+            descriptors += receiver.buildFoldRegions(receiver.element, document, this).toList()
+        }
+
+        if (sequence.supportsFoldRegions(document, this)) {
+            descriptors += sequence.buildFoldRegions(sequence.element, document, this).toList()
+        }
+
+        return descriptors.toTypedArray()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt
@@ -2,9 +2,14 @@ package com.intellij.advancedExpressionFolding.processor.methodcall.collection
 
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.operation.collection.AddAssignForCollection
+import com.intellij.advancedExpressionFolding.expression.operation.collection.PrependAssignForCollection
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
+import com.intellij.advancedExpressionFolding.processor.isInt
+import com.intellij.advancedExpressionFolding.processor.util.Helper
 import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.util.TypeConversionUtil
 
 class CollectionAddAllMethodCall : AbstractCollectionMethodCall() {
     override fun canExecute() = concatenationExpressionsCollapse
@@ -30,10 +35,53 @@ class CollectionAddAllMethodCall : AbstractCollectionMethodCall() {
         a2: PsiExpression,
         a1Expression: Expression,
         a2Expression: Expression
-    ): Expression? =
-        AddAssignForCollection(
+    ): Expression? {
+        val parameters = context.method.parameterList.parameters
+        if (parameters.size == 2 && parameters[0].type.isInt()) {
+            val qualifierPsi = element.methodExpression.qualifierExpression ?: return null
+            val qualifierExpression = context.qualifierExprNullable ?: return null
+            if (!isZeroLiteral(a1)) {
+                return null
+            }
+
+            if (!areTypesCompatible(qualifierPsi, a2)) {
+                return null
+            }
+
+            if (Helper.equal(qualifierPsi, a2)) {
+                return null
+            }
+
+            return PrependAssignForCollection(
+                element,
+                element.textRange,
+                qualifierExpression,
+                a2Expression,
+                qualifierPsi.text,
+            )
+        }
+
+        return AddAssignForCollection(
             element,
             element.textRange,
             listOf(a1Expression, a2Expression)
         )
+    }
+
+    private fun isZeroLiteral(expression: PsiExpression): Boolean {
+        val literal = expression as? PsiLiteralExpression ?: return false
+        val value = literal.value as? Number ?: return false
+        return value.toInt() == 0
+    }
+
+    private fun areTypesCompatible(
+        qualifier: PsiExpression,
+        argument: PsiExpression,
+    ): Boolean {
+        val qualifierType = qualifier.type ?: return false
+        val argumentType = argument.type ?: return false
+
+        return TypeConversionUtil.isAssignable(qualifierType, argumentType) ||
+            TypeConversionUtil.isAssignable(argumentType, qualifierType)
+    }
 }

--- a/testData/ConcatenationTestData-all.java
+++ b/testData/ConcatenationTestData-all.java
@@ -21,6 +21,10 @@ public class ConcatenationTestData {
         <fold text='val' expand='false'>Set<String></fold> copyOfSet = new HashSet<>();
         set<fold text=' += ' expand='false'>.addAll(</fold>copyOfSet<fold text='' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println(copyOfSet);
+        <fold text='val' expand='false'>List<Character></fold> chars = <fold text='[]' expand='false'>new ArrayList<>()</fold>;
+        <fold text='val' expand='false'>List<Character></fold> sequence = <fold text='[' expand='false'>Arrays.asList(</fold>'a', 'b'<fold text=']' expand='false'>)</fold>;
+        chars<fold text=' = ' expand='false'>.addAll(0, </fold>sequence<fold text=' + chars' expand='false'>)</fold>;
+        chars.addAll(3, sequence);
         <fold text='var' expand='false'>List<String></fold> streamToList = <fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>.map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold><fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold>;
         <fold text='' expand='false'>System.out.</fold>println(streamToList);
         streamToList = <fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>.map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold><fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold>;

--- a/testData/ConcatenationTestData.java
+++ b/testData/ConcatenationTestData.java
@@ -21,6 +21,10 @@ public class ConcatenationTestData {
         Set<String> copyOfSet = new HashSet<>();
         set<fold text=' += ' expand='false'>.addAll(</fold>copyOfSet<fold text='' expand='false'>)</fold>;
         System.out.println(copyOfSet);
+        List<Character> chars = new ArrayList<>();
+        List<Character> sequence = Arrays.asList('a', 'b');
+        chars<fold text=' = ' expand='false'>.addAll(0, </fold>sequence<fold text=' + chars' expand='false'>)</fold>;
+        chars.addAll(3, sequence);
         List<String> streamToList = <fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>.map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold><fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold>;
         System.out.println(streamToList);
         streamToList = <fold text='' expand='false'>Arrays.stream(</fold>args<fold text='' expand='false'>)</fold><fold text='*.' expand='false'>.map(</fold><fold text='toUpperCase()' expand='false'>String::toUpperCase</fold><fold text='' expand='false'>)</fold><fold text='.' expand='false'>.collect(Collectors.</fold>toList()<fold text='' expand='false'>)</fold>;


### PR DESCRIPTION
Fixes https://github.com/cheptsov/AdvancedExpressionFolding/issues/119

## Summary
- guard indexed addAll folding to only fire for index 0 with compatible sequences and avoid self references
- introduce a dedicated prepend expression so indexed addAll displays as `seq + receiver`
- extend concatenation fixtures and folded expectations with a prepend case while keeping non-zero indices unfolded

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_690129cbecb4832e84624c9f2d8cbb88