### PR TITLE
Visualize newline escapes in string folding

### DIFF
--- a/examples/data/StringEscapesDisabledTestData.java
+++ b/examples/data/StringEscapesDisabledTestData.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesDisabledTestData {
+    public void sample() {
+        String lf = "a\nb";
+        String crlf = "a\r\nb";
+        String cr = "a\rb";
+        String tab = "a\tb";
+        String space = "a b";
+    }
+}

--- a/examples/data/StringEscapesTestData.java
+++ b/examples/data/StringEscapesTestData.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesTestData {
+    public void sample() {
+        String lf = "a\nb";
+        String crlf = "a\r\nb";
+        String cr = "a\rb";
+        String tab = "a\tb";
+        String space = "a b";
+    }
+}

--- a/folded/StringEscapesDisabledTestData-folded.java
+++ b/folded/StringEscapesDisabledTestData-folded.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesDisabledTestData {
+    public void sample() {
+        String lf = "a\nb";
+        String crlf = "a\r\nb";
+        String cr = "a\rb";
+        String tab = "a	b";
+        String space = "a b";
+    }
+}

--- a/folded/StringEscapesTestData-folded.java
+++ b/folded/StringEscapesTestData-folded.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesTestData {
+    public void sample() {
+        String lf = "a⏎b";
+        String crlf = "a⏎b";
+        String cr = "a␍b";
+        String tab = "a	b";
+        String space = "a b";
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/StringEscapeVisualizer.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/StringEscapeVisualizer.kt
@@ -1,0 +1,42 @@
+package com.intellij.advancedExpressionFolding.expression.literal
+
+object StringEscapeVisualizer {
+    fun render(value: String): String {
+        if (value.isEmpty()) {
+            return value
+        }
+        val asciiOnly = isAsciiOnly()
+        val builder = StringBuilder(value.length)
+        var index = 0
+        while (index < value.length) {
+            when (val character = value[index]) {
+                '\r' -> {
+                    if (index + 1 < value.length && value[index + 1] == '\n') {
+                        builder.append(if (asciiOnly) ASCII_NEWLINE else NEWLINE_TOKEN)
+                        index += 2
+                    } else {
+                        builder.append(if (asciiOnly) ASCII_CARRIAGE_RETURN else CARRIAGE_RETURN_TOKEN)
+                        index += 1
+                    }
+                }
+                '\n' -> {
+                    builder.append(if (asciiOnly) ASCII_NEWLINE else NEWLINE_TOKEN)
+                    index += 1
+                }
+                else -> {
+                    builder.append(character)
+                    index += 1
+                }
+            }
+        }
+        return builder.toString()
+    }
+
+    private fun isAsciiOnly(): Boolean = java.lang.Boolean.getBoolean(ASCII_ONLY_PROPERTY)
+
+    private const val ASCII_ONLY_PROPERTY = "advanced.expression.folding.stringEscapes.visualizeNewlines.asciiOnly"
+    private const val NEWLINE_TOKEN = "⏎"
+    private const val CARRIAGE_RETURN_TOKEN = "␍"
+    private const val ASCII_NEWLINE = "\\n"
+    private const val ASCII_CARRIAGE_RETURN = "\\r"
+}

--- a/src/com/intellij/advancedExpressionFolding/expression/literal/StringLiteral.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/literal/StringLiteral.kt
@@ -1,11 +1,13 @@
 package com.intellij.advancedExpressionFolding.expression.literal
 
 import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLiteralExpression
 
 class StringLiteral(
     element: PsiElement,
@@ -14,7 +16,11 @@ class StringLiteral(
 ) : Expression(element, textRange), CharSequenceLiteral {
 
     override fun supportsFoldRegions(document: Document, parent: Expression?): Boolean {
-        return document.getText(textRange) != "\"$string\""
+        val settings = AdvancedExpressionFoldingSettings.getInstance().state
+        if (!settings.stringEscapesVisualizeNewlines && !isTextBlockLiteral() && string.any { it == '\n' || it == '\r' }) {
+            return false
+        }
+        return document.getText(textRange) != placeholder(settings)
     }
 
     override fun buildFoldRegions(
@@ -24,8 +30,28 @@ class StringLiteral(
     ): Array<FoldingDescriptor> {
         val group = FoldingGroup.newGroup(StringLiteral::class.java.name)
         val descriptors = arrayOf(
-            FoldingDescriptor(element.node, element.textRange, group, "\"$string\"")
+            FoldingDescriptor(element.node, element.textRange, group, placeholder())
         )
         return descriptors
     }
+
+    private fun placeholder(settings: AdvancedExpressionFoldingSettings.State = AdvancedExpressionFoldingSettings.getInstance().state): String {
+        return if (shouldVisualize(settings)) {
+            "\"${StringEscapeVisualizer.render(string)}\""
+        } else {
+            "\"$string\""
+        }
+    }
+    private fun shouldVisualize(settings: AdvancedExpressionFoldingSettings.State): Boolean {
+        if (!settings.stringEscapesVisualizeNewlines) {
+            return false
+        }
+        return !isTextBlockLiteral()
+    }
+
+    private fun isTextBlockLiteral(): Boolean {
+        val literal = element
+        return literal is PsiLiteralExpression && literal.isTextBlock
+    }
+
 }

--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -93,7 +93,7 @@ class AdvancedExpressionFoldingSettings :
         override var overrideHide: Boolean = true,
         override var suppressWarningsHide: Boolean = true,
         override var pseudoAnnotations: Boolean = true,
-        // NEW OPTION VAR
+        override var stringEscapesVisualizeNewlines: Boolean = true,
 
         override var memoryImprovement: Boolean = true,
         override var experimental: Boolean = false,

--- a/src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt
@@ -2,10 +2,10 @@ package com.intellij.advancedExpressionFolding.settings
 
 interface IUnclassifiedFeatureState {
     val semicolonsCollapse: Boolean
-    // NEW OPTION VAR
+    val stringEscapesVisualizeNewlines: Boolean
 }
 
 data class UnclassifiedFeatureState(
     override val semicolonsCollapse: Boolean = false,
-    // NEW OPTION VAR
+    override val stringEscapesVisualizeNewlines: Boolean = true,
 ) : IUnclassifiedFeatureState

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -171,6 +171,13 @@ abstract class CheckboxesProvider {
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#controlflowmultistatementcodeblockcollapse")
         }
 
+        registerCheckbox(
+            state::stringEscapesVisualizeNewlines,
+            "String escapes: visualize newlines"
+        ) {
+            example(StringEscapesTestData::class)
+        }
+
         registerCheckbox(state::semicolonsCollapse, "Semicolons (read-only files)") {
             example(SemicolonTestData::class)
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#semicolonscollapse")

--- a/test/com/intellij/advancedExpressionFolding/expression/literal/StringEscapeVisualizerTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/expression/literal/StringEscapeVisualizerTest.kt
@@ -1,0 +1,31 @@
+package com.intellij.advancedExpressionFolding.expression.literal
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class StringEscapeVisualizerTest {
+    @Test
+    fun rendersVisibleTokens() {
+        assertEquals("a⏎b", StringEscapeVisualizer.render("a\nb"))
+        assertEquals("a⏎b", StringEscapeVisualizer.render("a\r\nb"))
+        assertEquals("a␍b", StringEscapeVisualizer.render("a\rb"))
+    }
+
+    @Test
+    fun rendersAsciiTokensWhenRequested() {
+        val property = "advanced.expression.folding.stringEscapes.visualizeNewlines.asciiOnly"
+        val original = System.getProperty(property)
+        try {
+            System.setProperty(property, "true")
+            assertEquals("a\\nb", StringEscapeVisualizer.render("a\nb"))
+            assertEquals("a\\nb", StringEscapeVisualizer.render("a\r\nb"))
+            assertEquals("a\\rb", StringEscapeVisualizer.render("a\rb"))
+        } finally {
+            if (original == null) {
+                System.clearProperty(property)
+            } else {
+                System.setProperty(property, original)
+            }
+        }
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/folding/base/folding/UnclassifiedFeatureFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/folding/base/folding/UnclassifiedFeatureFoldingTest.kt
@@ -5,6 +5,12 @@ import org.junit.jupiter.api.Test
 
 interface UnclassifiedFeatureFoldingTest : FoldingTestSection {
     @Test
+    fun stringEscapesTestData() = testCase.runFoldingTest(foldingState()::stringEscapesVisualizeNewlines)
+
+    @Test
+    fun stringEscapesDisabledTestData() = testCase.runFoldingTest()
+
+    @Test
     fun semicolonTestData() = testCase.runReadOnlyFoldingTest(foldingState()::semicolonsCollapse)
 }
 

--- a/testData/StringEscapesDisabledTestData-all.java
+++ b/testData/StringEscapesDisabledTestData-all.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesDisabledTestData {
+    public void sample() <fold text='{...}' expand='true'>{
+        <fold text='val' expand='false'>String</fold> lf = <fold text='"a⏎b"' expand='false'>"a\nb"</fold>;
+        <fold text='val' expand='false'>String</fold> crlf = <fold text='"a⏎b"' expand='false'>"a\r\nb"</fold>;
+        <fold text='val' expand='false'>String</fold> cr = <fold text='"a␍b"' expand='false'>"a\rb"</fold>;
+        <fold text='val' expand='false'>String</fold> tab = <fold text='"a	b"' expand='false'>"a\tb"</fold>;
+        <fold text='val' expand='false'>String</fold> space = "a b";
+    }</fold>
+}

--- a/testData/StringEscapesDisabledTestData.java
+++ b/testData/StringEscapesDisabledTestData.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesDisabledTestData {
+    public void sample() <fold text='{...}' expand='true'>{
+        String lf = "a\nb";
+        String crlf = "a\r\nb";
+        String cr = "a\rb";
+        String tab = <fold text='"a	b"' expand='false'>"a\tb"</fold>;
+        String space = "a b";
+    }</fold>
+}

--- a/testData/StringEscapesTestData-all.java
+++ b/testData/StringEscapesTestData-all.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesTestData {
+    public void sample() <fold text='{...}' expand='true'>{
+        <fold text='val' expand='false'>String</fold> lf = <fold text='"a⏎b"' expand='false'>"a\nb"</fold>;
+        <fold text='val' expand='false'>String</fold> crlf = <fold text='"a⏎b"' expand='false'>"a\r\nb"</fold>;
+        <fold text='val' expand='false'>String</fold> cr = <fold text='"a␍b"' expand='false'>"a\rb"</fold>;
+        <fold text='val' expand='false'>String</fold> tab = <fold text='"a	b"' expand='false'>"a\tb"</fold>;
+        <fold text='val' expand='false'>String</fold> space = "a b";
+    }</fold>
+}

--- a/testData/StringEscapesTestData.java
+++ b/testData/StringEscapesTestData.java
@@ -1,0 +1,11 @@
+package data;
+
+public class StringEscapesTestData {
+    public void sample() <fold text='{...}' expand='true'>{
+        String lf = <fold text='"a⏎b"' expand='false'>"a\nb"</fold>;
+        String crlf = <fold text='"a⏎b"' expand='false'>"a\r\nb"</fold>;
+        String cr = <fold text='"a␍b"' expand='false'>"a\rb"</fold>;
+        String tab = <fold text='"a	b"' expand='false'>"a\tb"</fold>;
+        String space = "a b";
+    }</fold>
+}


### PR DESCRIPTION
Fixes https://github.com/cheptsov/AdvancedExpressionFolding/issues/111


## Summary
- introduce StringEscapeVisualizer and render newline tokens in string placeholders while skipping text blocks when visualization is disabled
- add a settings toggle and UI checkbox to control newline visualization along with unit coverage
- supply examples, folded outputs, and folding tests for both enabled and disabled newline visualization states, including the disabled example data

## Testing
- ./gradlew clean build test --console=plain --no-daemon --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_69012c093760832eae1a0f1132bd3a5d