### PR TITLE
Document all Lombok optional/dirty combinations

### DIFF
--- a/examples/data/LombokOptionalDirtyNoReferenceTestData.java
+++ b/examples/data/LombokOptionalDirtyNoReferenceTestData.java
@@ -1,0 +1,29 @@
+package data;
+
+import java.util.Optional;
+
+public class LombokOptionalDirtyNoReferenceTestData {
+
+    public static class OptionalTrueCases {
+        // 4. optional = true, dirty = none (dirty heuristic fires but optional wins)
+        private String optionalPlain;
+
+        public Optional<String> getOptionalPlain() {
+            return Optional.ofNullable(optionalPlain);
+        }
+
+        // 5. optional = true, dirty = dirty (optional still wins)
+        private String optionalAliased;
+
+        public Optional<String> getOptionalAliased() {
+            return Optional.ofNullable(optionalAliased);
+        }
+
+        // 6. optional = true, dirty = dirtyNoReference (optional flag disappears without a field reference)
+        private String optionalDetached;
+
+        public Optional<String> getOptionalDetached() {
+            return Optional.ofNullable("fallback");
+        }
+    }
+}

--- a/examples/data/LombokOptionalDirtyTestData.java
+++ b/examples/data/LombokOptionalDirtyTestData.java
@@ -1,0 +1,28 @@
+package data;
+
+public class LombokOptionalDirtyTestData {
+
+    public static class OptionalFalseCases {
+        // 1. optional = false, dirty = none
+        private String plain;
+
+        public String getPlain() {
+            return plain;
+        }
+
+        // 2. optional = false, dirty = dirty
+        private String alias;
+        private String fallback;
+
+        public String getAlias() {
+            return alias != null ? alias : fallback;
+        }
+
+        // 3. optional = false, dirty = dirtyNoReference
+        private String detached;
+
+        public String getDetached() {
+            return "fallback";
+        }
+    }
+}

--- a/folded/LombokOptionalDirtyNoReferenceTestData-folded.java
+++ b/folded/LombokOptionalDirtyNoReferenceTestData-folded.java
@@ -1,0 +1,17 @@
+package data;
+
+import java.util.Optional;
+
+public class LombokOptionalDirtyNoReferenceTestData {
+
+    public static class OptionalTrueCases {
+        // 4. optional = true, dirty = none (dirty heuristic fires but optional wins)
+        @Getter(optional = true) private String optionalPlain;
+
+        // 5. optional = true, dirty = dirty (optional still wins)
+        @Getter(optional = true) private String optionalAliased;
+
+        // 6. optional = true, dirty = dirtyNoReference (optional flag disappears without a field reference)
+        @Getter(dirtyNoReference) private String optionalDetached;
+    }
+}

--- a/folded/LombokOptionalDirtyTestData-folded.java
+++ b/folded/LombokOptionalDirtyTestData-folded.java
@@ -1,0 +1,16 @@
+package data;
+
+public class LombokOptionalDirtyTestData {
+
+    public static class OptionalFalseCases {
+        // 1. optional = false, dirty = none
+        @Getter private String plain;
+
+        // 2. optional = false, dirty = dirty
+        @Getter(dirty) private String alias;
+        private String fallback;
+
+        // 3. optional = false, dirty = dirtyNoReference
+        @Getter(dirtyNoReference) private String detached;
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt
@@ -20,6 +20,12 @@ interface LombokFoldingTest : FoldingTestSection {
     )
 
     @Test
+    fun lombokOptionalDirtyTestData() = testCase.runFoldingTest(foldingState()::lombok)
+
+    @Test
+    fun lombokOptionalDirtyNoReferenceTestData() = testCase.runFoldingTest(foldingState()::lombok)
+
+    @Test
     fun interfaceExtensionPropertiesTestData() = testCase.runFoldingTest(
         foldingState()::interfaceExtensionProperties,
         foldingState()::lombok,

--- a/test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt
+++ b/test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt
@@ -46,6 +46,8 @@ object PerformanceResult : FoldingTest() {
         ::localDateTestData to 7
         ::logBrackets to 6
         ::lombokDirtyOffTestData to 6
+        ::lombokOptionalDirtyNoReferenceTestData to 6
+        ::lombokOptionalDirtyTestData to 6
         ::lombokPatternOffNegativeTestData to 23
         ::lombokPatternOffTestData to 19
         ::lombokTestData to 24

--- a/testData/LombokOptionalDirtyNoReferenceTestData-all.java
+++ b/testData/LombokOptionalDirtyNoReferenceTestData-all.java
@@ -1,0 +1,26 @@
+package data;
+
+import java.util.Optional;
+
+public class LombokOptionalDirtyNoReferenceTestData {
+
+    public static class OptionalTrueCases <fold text='{...}' expand='true'>{
+        // 4. optional = true, dirty = none (dirty heuristic fires but optional wins)
+        private String optionalPlain;
+        public Optional<String> getOptionalPlain()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold><fold text='' expand='false'>Optional.ofNullable(</fold>optionalPlain<fold text='' expand='false'>)</fold><fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+
+        // 5. optional = true, dirty = dirty (optional still wins)
+        private String optionalAliased;
+        public Optional<String> getOptionalAliased()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> <fold text='' expand='false'></fold>Optional.ofNullable(</fold>optionalAliased<fold text='' expand='false'>)</fold><fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+
+        // 6. optional = true, dirty = dirtyNoReference (optional flag disappears without a field reference)
+        private String optionalDetached;
+        public Optional<String> getOptionalDetached()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold><fold text='' expand='false'>Optional.ofNullable(</fold>"fallback"<fold text='' expand='false'>)</fold><fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+    }</fold>
+}

--- a/testData/LombokOptionalDirtyNoReferenceTestData.java
+++ b/testData/LombokOptionalDirtyNoReferenceTestData.java
@@ -1,0 +1,26 @@
+package data;
+
+import java.util.Optional;
+
+public class LombokOptionalDirtyNoReferenceTestData {
+
+    public static class OptionalTrueCases <fold text='{...}' expand='true'>{
+        // 4. optional = true, dirty = none (dirty heuristic fires but optional wins)
+        <fold text='@Getter(optional = true) p' expand='false'>p</fold>rivate String optionalPlain;<fold text='' expand='false'>
+        </fold><fold text='' expand='false'>public Optional<String> getOptionalPlain()<fold text=' { ' expand='false'> {
+            </fold>return Optional.ofNullable(optionalPlain);<fold text=' }' expand='false'>
+        }</fold></fold>
+
+        // 5. optional = true, dirty = dirty (optional still wins)
+        <fold text='@Getter(optional = true) p' expand='false'>p</fold>rivate String optionalAliased;<fold text='' expand='false'>
+        <fold text='' expand='false'></fold>public Optional<String> getOptionalAliased()<fold text=' { ' expand='false'> {
+            </fold>return Optional.ofNullable(optionalAliased);<fold text=' }' expand='false'>
+        }</fold></fold>
+
+        // 6. optional = true, dirty = dirtyNoReference (optional flag disappears without a field reference)
+        <fold text='@Getter(dirtyNoReference) p' expand='false'>p</fold>rivate String optionalDetached;<fold text='' expand='false'>
+        </fold><fold text='' expand='false'>public Optional<String> getOptionalDetached()<fold text=' { ' expand='false'> {
+            </fold>return Optional.ofNullable("fallback");<fold text=' }' expand='false'>
+        }</fold></fold>
+    }</fold>
+}

--- a/testData/LombokOptionalDirtyTestData-all.java
+++ b/testData/LombokOptionalDirtyTestData-all.java
@@ -1,0 +1,25 @@
+package data;
+
+public class LombokOptionalDirtyTestData {
+
+    public static class OptionalFalseCases <fold text='{...}' expand='true'>{
+        // 1. optional = false, dirty = none
+        <fold text='@Getter p' expand='false'>p</fold>rivate String plain;<fold text='' expand='false'>
+        </fold><fold text='' expand='false'>public String getPlain()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold>plain<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold></fold>
+
+        // 2. optional = false, dirty = dirty
+        private String alias;
+        private String fallback;
+        public String getAlias()<fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold><fold text='' expand='false'>alias != null ? </fold>alias<fold text=' ?: ' expand='false'> : </fold>fallback<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+
+        // 3. optional = false, dirty = dirtyNoReference
+        private String detached;
+        <fold text='' expand='true'>public</fold><fold text='' expand='true'> </fold><fold text='' expand='true'>String</fold><fold text='' expand='true'> </fold>getDetached<fold text='' expand='true'>()</fold><fold text=' { ' expand='false'> {<fold text=' ' expand='true'>
+            </fold></fold><fold text='' expand='true'>return</fold><fold text='' expand='true'> </fold>"fallback"<fold text='' expand='true'>;</fold><fold text=' ' expand='true'><fold text=' }' expand='false'>
+        </fold>}</fold>
+    }</fold>
+}

--- a/testData/LombokOptionalDirtyTestData.java
+++ b/testData/LombokOptionalDirtyTestData.java
@@ -1,0 +1,25 @@
+package data;
+
+public class LombokOptionalDirtyTestData {
+
+    public static class OptionalFalseCases <fold text='{...}' expand='true'>{
+        // 1. optional = false, dirty = none
+        <fold text='@Getter p' expand='false'>p</fold>rivate String plain;<fold text='' expand='false'>
+        </fold><fold text='' expand='false'>public String getPlain()<fold text=' { ' expand='false'> {
+            </fold>return plain;<fold text=' }' expand='false'>
+        }</fold></fold>
+
+        // 2. optional = false, dirty = dirty
+        <fold text='@Getter(dirty) p' expand='false'>p</fold>rivate String alias;
+        private String fallback;<fold text='' expand='false'>
+        <fold text='' expand='false'></fold>public String getAlias()<fold text=' { ' expand='false'> {
+            </fold>return alias != null ? alias : fallback;<fold text=' }' expand='false'>
+        }</fold></fold>
+
+        // 3. optional = false, dirty = dirtyNoReference
+        <fold text='@Getter(dirtyNoReference) p' expand='false'>p</fold>rivate String detached;<fold text='' expand='false'>
+        </fold><fold text='' expand='false'>public String getDetached()<fold text=' { ' expand='false'> {
+            </fold>return "fallback";<fold text=' }' expand='false'>
+        }</fold></fold>
+    }</fold>
+}

--- a/wiki-clone/docs/features/lombok.md
+++ b/wiki-clone/docs/features/lombok.md
@@ -86,6 +86,88 @@ folded/LombokDirtyOffTestData-folded.java:
 Highlights LombokDirtyOffTestData with lombok.
 Removes boilerplate while preserving behavior.
 
+#### Example: LombokOptionalDirtyTestData
+
+examples/data/LombokOptionalDirtyTestData.java:
+```java
+    public static class OptionalFalseCases {
+        // 1. optional = false, dirty = none
+        private String plain;
+
+        public String getPlain() {
+            return plain;
+        }
+
+        // 2. optional = false, dirty = dirty
+        private String alias;
+        private String fallback;
+
+        public String getAlias() {
+            return alias != null ? alias : fallback;
+        }
+
+        // 3. optional = false, dirty = dirtyNoReference
+        private String detached;
+
+        public String getDetached() {
+            return "fallback";
+        }
+    }
+```
+
+folded/LombokOptionalDirtyTestData-folded.java:
+```java
+    public static class OptionalFalseCases {
+        @Getter private String plain;
+
+        @Getter(dirty) private String alias;
+        private String fallback;
+
+        @Getter(dirtyNoReference) private String detached;
+    }
+```
+
+#### Example: LombokOptionalDirtyNoReferenceTestData
+
+examples/data/LombokOptionalDirtyNoReferenceTestData.java:
+```java
+    public static class OptionalTrueCases {
+        // 4. optional = true, dirty = none (dirty heuristic fires but optional wins)
+        private String optionalPlain;
+
+        public Optional<String> getOptionalPlain() {
+            return Optional.ofNullable(optionalPlain);
+        }
+
+        // 5. optional = true, dirty = dirty (optional still wins)
+        private String optionalAliased;
+
+        public Optional<String> getOptionalAliased() {
+            return Optional.ofNullable(optionalAliased);
+        }
+
+        // 6. optional = true, dirty = dirtyNoReference (optional flag disappears without a field reference)
+        private String optionalDetached;
+
+        public Optional<String> getOptionalDetached() {
+            return Optional.ofNullable("fallback");
+        }
+    }
+```
+
+folded/LombokOptionalDirtyNoReferenceTestData-folded.java:
+```java
+    public static class OptionalTrueCases {
+        @Getter(optional = true) private String optionalPlain;
+
+        @Getter(optional = true) private String optionalAliased;
+
+        @Getter(dirtyNoReference) private String optionalDetached;
+    }
+```
+
+These two examples enumerate the optional/dirty combinations so you can see which heuristics win for every case.
+
 #### Example: InterfaceExtensionPropertiesTestData
 
 examples/data/InterfaceExtensionPropertiesTestData.java:
@@ -1020,6 +1102,7 @@ public class LombokTestData {
         private List<String> lazyLoadedList;
         private List<String> oneLineLazyLoadedList;
         private List<String> defensiveCopyList;
+        private String optionalField;
 
         public List<String> getWrapper() {
             return Collections.unmodifiableList(wrapper);
@@ -1063,6 +1146,10 @@ public class LombokTestData {
             if (oneLineLazyLoadedList == null) oneLineLazyLoadedList = new ArrayList<>();
             return oneLineLazyLoadedList;
         }
+
+        public Optional<String> getOptionalField() {
+            return Optional.ofNullable(optionalField);
+        }
 ```
 
 **After**
@@ -1076,6 +1163,7 @@ public class LombokTestData {
         @Getter(lazy = ArrayList::new) private List<String> lazyLoadedList;
         @Getter(lazy = ArrayList::new) private List<String> oneLineLazyLoadedList;
         @Getter(wrapper = ArrayList::new) private List<String> defensiveCopyList;
+        @Getter(optional = true) private String optionalField;
 ```
 
 


### PR DESCRIPTION
## Summary
- add the optional=false matrix to the Lombok optional dirty example and align folded output
- extend the optional=true example with the dirty/dirtyNoReference heuristics and refresh folded + test fixtures
- document the six optional/dirty combinations in the Lombok feature guide

## Testing
- ./gradlew clean build test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_6901a5b10f8c832e8309e5795a5354db