### PR TITLE
Add onboarding tool window

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -36,6 +36,12 @@
                 key="editor.folding.advanced.expression.displayName"
                 bundle="Bundle"/>
 
+        <toolWindow id="Advanced Expression Folding Onboarding"
+                    anchor="right"
+                    secondary="true"
+                    stripeTitle="Onboarding"
+                    factoryClass="com.intellij.advancedExpressionFolding.onboarding.OnboardingToolWindowFactory"/>
+
         <notificationGroup id="Advanced Expression Folding"
                            displayType="BALLOON"
                            isLogByDefault="true"/>

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuest.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuest.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+/**
+ * Minimal representation of a quest surfaced in the onboarding flow.
+ */
+data class OnboardingQuest(
+    val id: String,
+    val title: String,
+    val description: String
+)

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestProgressService.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestProgressService.kt
@@ -1,0 +1,45 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+
+/**
+ * Persists quest completion flags so onboarding progress survives IDE restarts.
+ */
+@Service
+@State(
+    name = "AdvancedExpressionFoldingOnboarding",
+    storages = [Storage("advancedExpressionFoldingOnboarding.xml")]
+)
+class OnboardingQuestProgressService : PersistentStateComponent<OnboardingQuestProgressService.State> {
+    data class State(
+        var completedQuestIds: MutableSet<String> = mutableSetOf()
+    )
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = State(state.completedQuestIds.toMutableSet())
+    }
+
+    fun isCompleted(id: String): Boolean = state.completedQuestIds.contains(id)
+
+    fun setCompleted(id: String, completed: Boolean) {
+        if (completed) {
+            state.completedQuestIds.add(id)
+        } else {
+            state.completedQuestIds.remove(id)
+        }
+    }
+
+    fun completedQuests(): Set<String> = state.completedQuestIds
+
+    companion object {
+        fun getInstance(): OnboardingQuestProgressService = service()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestRegistry.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestRegistry.kt
@@ -1,0 +1,26 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+/**
+ * Static catalogue of onboarding quests shown to newcomers.
+ */
+object OnboardingQuestRegistry {
+    val quests: List<OnboardingQuest> = listOf(
+        OnboardingQuest(
+            id = "discover-foldings",
+            title = "Discover folding switches",
+            description = "Toggle a few folding checkboxes to learn what the plugin can collapse."
+        ),
+        OnboardingQuest(
+            id = "checkout-examples",
+            title = "Check out example files",
+            description = "Use the checkout buttons below to pull sample files into your project."
+        ),
+        OnboardingQuest(
+            id = "personalize-dynamic",
+            title = "Personalize dynamic names",
+            description = "Enable dynamic names so folded members adopt labels from your dynamic-ajf2.toml."
+        )
+    )
+
+    fun findById(id: String): OnboardingQuest? = quests.firstOrNull { it.id == id }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingToolWindowFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingToolWindowFactory.kt
@@ -1,0 +1,62 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.ScrollPaneFactory
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.content.ContentFactory
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+class OnboardingToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val content = ContentFactory.getInstance().createContent(createContent(), null, false)
+        toolWindow.contentManager.addContent(content)
+    }
+
+    private fun createContent(): JComponent {
+        val questsPanel = JPanel()
+        questsPanel.layout = BoxLayout(questsPanel, BoxLayout.Y_AXIS)
+        questsPanel.border = JBUI.Borders.empty(12)
+        questsPanel.isOpaque = false
+
+        val progress = OnboardingQuestProgressService.getInstance()
+
+        OnboardingQuestRegistry.quests.forEachIndexed { index, quest ->
+            val checkbox = JBCheckBox(quest.title)
+            checkbox.alignmentX = Component.LEFT_ALIGNMENT
+            checkbox.isSelected = progress.isCompleted(quest.id)
+            checkbox.addActionListener {
+                progress.setCompleted(quest.id, checkbox.isSelected)
+            }
+            questsPanel.add(checkbox)
+
+            if (quest.description.isNotBlank()) {
+                val description = JBLabel(quest.description)
+                description.alignmentX = Component.LEFT_ALIGNMENT
+                description.foreground = JBUI.CurrentTheme.Label.disabledForeground()
+                description.border = JBUI.Borders.emptyLeft(24)
+                questsPanel.add(description)
+            }
+
+            if (index != OnboardingQuestRegistry.quests.lastIndex) {
+                questsPanel.add(Box.createVerticalStrut(12))
+            }
+        }
+
+        val scrollPane = ScrollPaneFactory.createScrollPane(questsPanel, true)
+        scrollPane.border = JBUI.Borders.empty()
+
+        val wrapper = JPanel(BorderLayout())
+        wrapper.add(scrollPane, BorderLayout.CENTER)
+        return wrapper
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestProgressServiceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestProgressServiceTest.kt
@@ -1,0 +1,32 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OnboardingQuestProgressServiceTest {
+
+    @Test
+    fun `new service starts with empty progress`() {
+        val service = OnboardingQuestProgressService()
+
+        assertTrue(service.completedQuests().isEmpty())
+        OnboardingQuestRegistry.quests.forEach { quest ->
+            assertFalse(service.isCompleted(quest.id))
+        }
+    }
+
+    @Test
+    fun `quest completion can be toggled`() {
+        val service = OnboardingQuestProgressService()
+        val quest = OnboardingQuestRegistry.quests.first()
+
+        service.setCompleted(quest.id, true)
+        assertTrue(service.isCompleted(quest.id))
+        assertTrue(service.completedQuests().contains(quest.id))
+
+        service.setCompleted(quest.id, false)
+        assertFalse(service.isCompleted(quest.id))
+        assertFalse(service.completedQuests().contains(quest.id))
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurableTest.kt
@@ -1,7 +1,9 @@
 package com.intellij.advancedExpressionFolding.settings.view
 
 import com.intellij.ui.components.ActionLink
+import com.intellij.ui.components.JBCheckBox
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import java.awt.event.ActionEvent
 import java.awt.event.ActionListener
@@ -27,6 +29,21 @@ class SettingsConfigurableTest {
 
         assertDoesNotThrow {
             triggerAction(exampleLink)
+        }
+    }
+
+    @Test
+    fun onboardingQuestToggleDoesNotThrow() {
+        val configurable = SettingsConfigurable()
+        val questsPanel = configurable.createOnboardingPanel()
+        val questCheckbox = questsPanel.components.filterIsInstance<JBCheckBox>().firstOrNull()
+
+        assertNotNull(questCheckbox, "Expected at least one onboarding quest checkbox")
+
+        questCheckbox ?: return
+
+        assertDoesNotThrow {
+            questCheckbox.doClick()
         }
     }
 


### PR DESCRIPTION

<img width="771" height="380" alt="Screenshot 2025-11-01 at 20 02 38" src="https://github.com/user-attachments/assets/f34cd551-42eb-41d5-bce5-710fb2530b96" />

## Summary
- register an onboarding tool window in the plugin manifest
- render the gamified onboarding quests inside the tool window with persistent completion toggles

## Testing
- ./gradlew --no-daemon clean build test --console=plain -Pkotlin.incremental=false

------
https://chatgpt.com/codex/tasks/task_e_6904dea568d8832e94a35058ba292710