### PR TITLE
Add onboarding quest UI surfaces

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,15 @@
         <!-- Application-level service that persists plugin settings -->
         <applicationService
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.onboarding.GamifiedOnboardingQuestService"/>
+        <toolWindow id="Onboarding Quests"
+                    anchor="right"
+                    factoryClass="com.intellij.advancedExpressionFolding.onboarding.GamifiedOnboardingToolWindowFactory"/>
+        <statusBarWidgetFactory
+                implementation="com.intellij.advancedExpressionFolding.onboarding.OnboardingQuestStatusBarWidgetFactory"/>
+        <editorNotificationProvider
+                implementation="com.intellij.advancedExpressionFolding.onboarding.OnboardingQuestEditorNotificationProvider"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->

--- a/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestListener.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestListener.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.util.messages.Topic
+
+/**
+ * Broadcasts when quest progress or selection changes so UI surfaces can update.
+ */
+fun interface GamifiedOnboardingQuestListener {
+    fun questStateChanged()
+
+    companion object {
+        val TOPIC: Topic<GamifiedOnboardingQuestListener> = Topic.create(
+            "advanced.expression.folding.onboardingQuest",
+            GamifiedOnboardingQuestListener::class.java,
+        )
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestService.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestService.kt
@@ -1,0 +1,167 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.EditorNotifications
+import com.intellij.util.xmlb.annotations.Property
+import com.intellij.util.xmlb.annotations.Tag
+import java.util.LinkedHashSet
+
+/**
+ * Tracks the player's progress through onboarding quests and persists state across IDE restarts.
+ */
+@Service(Service.Level.APP)
+@State(name = "AdvancedExpressionFoldingGamifiedOnboarding", storages = [Storage("advancedExpressionFoldingOnboarding.xml")])
+class GamifiedOnboardingQuestService : PersistentStateComponent<GamifiedOnboardingQuestService.State> {
+
+    private var state = State()
+
+    private val quests = GamifiedOnboardingQuests.defaults().associateBy(OnboardingQuest::id)
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state.normalize()
+        ensureActiveQuestPresent()
+        notifyStateChanged()
+    }
+
+    fun availableQuests(): List<OnboardingQuest> = quests.values.toList()
+
+    fun getActiveQuest(): OnboardingQuest? {
+        ensureActiveQuestPresent()
+        return state.activeQuestId?.let(quests::get)
+    }
+
+    fun setActiveQuest(questId: String) {
+        require(quests.containsKey(questId)) { "Unknown quest id: $questId" }
+        state.activeQuestId = questId
+        notifyStateChanged()
+    }
+
+    fun completeStep(stepId: String): Boolean {
+        val quest = getActiveQuest() ?: return false
+        if (quest.steps.none { it.id == stepId }) {
+            return false
+        }
+        val progress = state.progressStateFor(quest.id)
+        if (progress.completedStepIds.contains(stepId)) {
+            return false
+        }
+        progress.completedStepIds.add(stepId)
+        notifyStateChanged()
+        return true
+    }
+
+    fun isQuestCompleted(questId: String): Boolean {
+        val quest = quests[questId] ?: return false
+        val progress = state.progress.firstOrNull { it.questId == questId } ?: return false
+        return progress.completedStepIds.containsAll(quest.steps.map(QuestStep::id))
+    }
+
+    fun claimReward(questId: String): Boolean {
+        val quest = quests[questId] ?: return false
+        if (!isQuestCompleted(questId)) {
+            return false
+        }
+        val progress = state.progressStateFor(quest.id)
+        if (progress.rewardClaimed) {
+            return false
+        }
+        progress.rewardClaimed = true
+        notifyStateChanged()
+        return true
+    }
+
+    fun getProgress(questId: String): QuestProgress {
+        val quest = quests[questId]
+            ?: error("Unknown quest id: $questId")
+        val progress = state.progressStateFor(quest.id)
+        return QuestProgress(
+            questId = quest.id,
+            completedStepIds = progress.completedStepIds.toSet(),
+            totalSteps = quest.steps.size,
+            rewardClaimed = progress.rewardClaimed,
+        )
+    }
+
+    fun resetQuest(questId: String) {
+        val iterator = state.progress.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().questId == questId) {
+                iterator.remove()
+                break
+            }
+        }
+        if (state.activeQuestId == questId) {
+            state.activeQuestId = null
+            ensureActiveQuestPresent()
+        }
+        notifyStateChanged()
+    }
+
+    private fun ensureActiveQuestPresent() {
+        if (state.activeQuestId != null && quests.containsKey(state.activeQuestId)) {
+            return
+        }
+        state.activeQuestId = quests.keys.firstOrNull()
+    }
+
+    private fun State.progressStateFor(questId: String): QuestProgressState {
+        var questProgress = progress.firstOrNull { it.questId == questId }
+        if (questProgress == null) {
+            questProgress = QuestProgressState(questId)
+            this.progress.add(questProgress)
+        }
+        questProgress.trimToQuest(quests[questId])
+        return questProgress
+    }
+
+    private fun QuestProgressState.trimToQuest(quest: OnboardingQuest?) {
+        if (quest == null) {
+            completedStepIds.clear()
+            rewardClaimed = false
+            return
+        }
+        val allowedSteps = quest.steps.map(QuestStep::id).toSet()
+        completedStepIds.retainAll(allowedSteps)
+        if (!completedStepIds.containsAll(allowedSteps)) {
+            rewardClaimed = false
+        }
+    }
+
+    data class State(
+        var activeQuestId: String? = null,
+        @get:Property(surroundWithTag = false)
+        var progress: MutableList<QuestProgressState> = mutableListOf(),
+    ) {
+        fun normalize(): State {
+            val normalizedProgress = progress
+                .map { it.copy(completedStepIds = LinkedHashSet(it.completedStepIds)) }
+                .distinctBy(QuestProgressState::questId)
+                .toMutableList()
+            return copy(progress = normalizedProgress)
+        }
+    }
+
+    @Tag("quest")
+    data class QuestProgressState(
+        var questId: String = "",
+        var completedStepIds: MutableSet<String> = LinkedHashSet(),
+        var rewardClaimed: Boolean = false,
+    )
+
+    private fun notifyStateChanged() {
+        val application = ApplicationManager.getApplication() ?: return
+        application.messageBus.syncPublisher(GamifiedOnboardingQuestListener.TOPIC).questStateChanged()
+        application.invokeLater {
+            ProjectManager.getInstance().openProjects.forEach { project ->
+                EditorNotifications.getInstance(project).updateAllNotifications()
+            }
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuests.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuests.kt
@@ -1,0 +1,55 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+/**
+ * Provides the curated set of onboarding quests used by the plugin.
+ */
+object GamifiedOnboardingQuests {
+    fun defaults(): List<OnboardingQuest> = listOf(
+        OnboardingQuest(
+            id = "get-started",
+            title = "Get started with folding",
+            description = "Introduce the most common folding controls in three short actions.",
+            steps = listOf(
+                QuestStep(
+                    id = "enable-global-folding",
+                    title = "Enable folding globally",
+                    description = "Toggle Advanced Folding on to see expressions collapse automatically.",
+                ),
+                QuestStep(
+                    id = "inspect-folded-region",
+                    title = "Inspect a folded region",
+                    description = "Hover a folded expression and read the inline summary tooltip.",
+                ),
+                QuestStep(
+                    id = "toggle-single-fold",
+                    title = "Manually toggle a fold",
+                    description = "Use the gutter icon to temporarily expand a single folded section.",
+                ),
+            ),
+            rewardPoints = 50,
+        ),
+        OnboardingQuest(
+            id = "level-up",
+            title = "Level up your shortcuts",
+            description = "Learn the fastest shortcuts for enabling, disabling and refreshing folds.",
+            steps = listOf(
+                QuestStep(
+                    id = "use-enable-shortcut",
+                    title = "Use the enable shortcut",
+                    description = "Press Alt+Shift+F (or Alt+T on macOS) to enable folding.",
+                ),
+                QuestStep(
+                    id = "use-disable-shortcut",
+                    title = "Use the disable shortcut",
+                    description = "Press Alt+Shift+D (or Alt+Y on macOS) to disable folding.",
+                ),
+                QuestStep(
+                    id = "refresh-folding",
+                    title = "Refresh folding colors",
+                    description = "Trigger the hidden refresh action from the settings view.",
+                ),
+            ),
+            rewardPoints = 80,
+        ),
+    )
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingToolWindowFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingToolWindowFactory.kt
@@ -1,0 +1,216 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.CollectionListModel
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.content.ContentFactory
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+import javax.swing.ListSelectionModel
+
+/**
+ * Tool window that showcases onboarding quests with their current progress.
+ */
+class GamifiedOnboardingToolWindowFactory : ToolWindowFactory, DumbAware {
+
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = GamifiedOnboardingPanel()
+        val content = ContentFactory.getInstance().createContent(panel, null, false)
+        toolWindow.contentManager.addContent(content)
+        Disposer.register(toolWindow.disposable, panel)
+    }
+
+    private class GamifiedOnboardingPanel : JPanel(BorderLayout()), Disposable {
+        private val questService = service<GamifiedOnboardingQuestService>()
+        private val questsModel = CollectionListModel(questService.availableQuests())
+        private val questList = JBList(questsModel)
+        private val questDetails = JPanel(BorderLayout())
+        private val connection = ApplicationManager.getApplication().messageBus.connect(this)
+
+        init {
+            border = JBUI.Borders.empty()
+            questList.cellRenderer = QuestCellRenderer()
+            questList.visibleRowCount = 8
+            questList.selectionMode = ListSelectionModel.SINGLE_SELECTION
+            questList.addListSelectionListener { updateDetails(questList.selectedValue) }
+
+            val listContainer = JPanel(BorderLayout())
+            listContainer.border = JBUI.Borders.compound(
+                JBUI.Borders.empty(8, 8, 8, 4),
+                JBUI.Borders.customLine(UIUtil.getPanelBackground().darker(), 0, 0, 0, 1),
+            )
+            listContainer.add(JBLabel("Quests"), BorderLayout.NORTH)
+            listContainer.add(JBScrollPane(questList), BorderLayout.CENTER)
+
+            val detailContainer = JPanel(BorderLayout())
+            detailContainer.border = JBUI.Borders.empty(8)
+            detailContainer.add(questDetails, BorderLayout.CENTER)
+
+            add(listContainer, BorderLayout.WEST)
+            add(detailContainer, BorderLayout.CENTER)
+
+            connection.subscribe(GamifiedOnboardingQuestListener.TOPIC, GamifiedOnboardingQuestListener { refreshSelection() })
+
+            refreshSelection()
+        }
+
+        override fun dispose() {
+            connection.disconnect()
+        }
+
+        private fun refreshSelection() {
+            val activeQuest = questService.getActiveQuest()
+            if (activeQuest != null) {
+                questList.setSelectedValue(activeQuest, true)
+            } else if (!questsModel.isEmpty) {
+                questList.selectedIndex = 0
+            }
+            questList.repaint()
+            updateDetails(questList.selectedValue)
+        }
+
+        private fun updateDetails(quest: OnboardingQuest?) {
+            questDetails.removeAll()
+            if (quest == null) {
+                questDetails.add(createInfoLabel("No quests available."), BorderLayout.CENTER)
+            } else {
+                questDetails.add(createQuestDetail(quest), BorderLayout.CENTER)
+            }
+            questDetails.revalidate()
+            questDetails.repaint()
+        }
+
+        private fun createQuestDetail(quest: OnboardingQuest): JComponent {
+            val wrapper = JPanel(BorderLayout())
+            wrapper.border = JBUI.Borders.empty()
+
+            val header = JPanel(BorderLayout())
+            header.border = JBUI.Borders.empty(0, 0, 8, 0)
+            header.add(JBLabel(quest.title).apply { font = UIUtil.getLabelFont().deriveFont(UIUtil.getLabelFont().size2D + 1) }, BorderLayout.NORTH)
+            header.add(JBLabel(quest.description).apply { foreground = UIUtil.getLabelDisabledForeground() }, BorderLayout.SOUTH)
+
+            val progress = questService.getProgress(quest.id)
+            val progressPanel = JPanel(BorderLayout())
+            progressPanel.border = JBUI.Borders.empty(0, 0, 8, 0)
+            val progressBar = JProgressBar(0, progress.totalSteps.coerceAtLeast(1))
+            progressBar.value = progress.completedStepIds.size
+            progressBar.isStringPainted = true
+            progressBar.string = "${progress.completedStepIds.size}/${progress.totalSteps} steps"
+            progressPanel.add(progressBar, BorderLayout.CENTER)
+
+            val buttonPanel = JPanel(FlowLayout(FlowLayout.LEFT, 8, 0))
+            val setActiveButton = JButton("Set active").apply {
+                isEnabled = questService.getActiveQuest()?.id != quest.id
+                addActionListener {
+                    questService.setActiveQuest(quest.id)
+                }
+            }
+            val resetButton = JButton("Reset").apply {
+                addActionListener {
+                    questService.resetQuest(quest.id)
+                }
+            }
+            val claimButton = JButton("Claim reward").apply {
+                isEnabled = progress.isQuestCompleted && !progress.rewardClaimed
+                addActionListener {
+                    questService.claimReward(quest.id)
+                }
+            }
+            val refreshButton = JButton("Refresh").apply {
+                addActionListener { refreshSelection() }
+            }
+            buttonPanel.add(setActiveButton)
+            buttonPanel.add(resetButton)
+            buttonPanel.add(claimButton)
+            buttonPanel.add(refreshButton)
+
+            val stepPanel = JPanel()
+            stepPanel.layout = BoxLayout(stepPanel, BoxLayout.Y_AXIS)
+            quest.steps.forEach { step ->
+                val checkBox = JBCheckBox(step.title, progress.completedStepIds.contains(step.id))
+                checkBox.toolTipText = step.description
+                checkBox.isEnabled = false
+                stepPanel.add(checkBox)
+            }
+            if (quest.steps.isEmpty()) {
+                stepPanel.add(createInfoLabel("No steps required."))
+            }
+
+            val rewardLabel = JBLabel(
+                when {
+                    progress.rewardClaimed -> "Reward claimed: ${quest.rewardPoints} XP"
+                    progress.isQuestCompleted -> "Reward ready: ${quest.rewardPoints} XP"
+                    else -> "Reward: ${quest.rewardPoints} XP"
+                },
+            )
+            rewardLabel.border = JBUI.Borders.empty(8, 0, 0, 0)
+
+            wrapper.add(header, BorderLayout.NORTH)
+            wrapper.add(progressPanel, BorderLayout.CENTER)
+            wrapper.add(stepPanel, BorderLayout.SOUTH)
+
+            val bottomBox = Box.createVerticalBox()
+            bottomBox.add(rewardLabel)
+            bottomBox.add(Box.createVerticalStrut(8))
+            bottomBox.add(buttonPanel)
+
+            val container = JPanel(BorderLayout())
+            container.add(wrapper, BorderLayout.NORTH)
+            container.add(bottomBox, BorderLayout.SOUTH)
+            container.preferredSize = Dimension(0, 0)
+
+            return container
+        }
+
+        private fun createInfoLabel(text: String): JBLabel = JBLabel(text).apply {
+            foreground = UIUtil.getLabelDisabledForeground()
+        }
+
+        private inner class QuestCellRenderer : ColoredListCellRenderer<OnboardingQuest>() {
+            override fun customizeCellRenderer(
+                list: JList<out OnboardingQuest>,
+                value: OnboardingQuest?,
+                index: Int,
+                selected: Boolean,
+                hasFocus: Boolean,
+            ) {
+                if (value == null) {
+                    append("", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                    return
+                }
+                append(value.title, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                val progress = questService.getProgress(value.id)
+                val suffix = " ${progress.completedStepIds.size}/${progress.totalSteps}"
+                append(suffix, SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                if (questService.getActiveQuest()?.id == value.id) {
+                    append("  (active)", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
+                }
+                if (progress.rewardClaimed) {
+                    append("  ✓", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES)
+                }
+            }
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuest.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuest.kt
@@ -1,0 +1,21 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+/**
+ * Describes a quest that introduces a feature during the onboarding experience.
+ */
+data class OnboardingQuest(
+    val id: String,
+    val title: String,
+    val description: String,
+    val steps: List<QuestStep>,
+    val rewardPoints: Int,
+)
+
+/**
+ * Represents a single actionable step in a quest.
+ */
+data class QuestStep(
+    val id: String,
+    val title: String,
+    val description: String,
+)

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestEditorNotificationProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestEditorNotificationProvider.kt
@@ -1,0 +1,60 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotificationProvider
+import java.util.function.Function
+
+/**
+ * Editor banner that highlights the current onboarding quest and remaining work.
+ */
+class OnboardingQuestEditorNotificationProvider : EditorNotificationProvider, DumbAware {
+
+    override fun collectNotificationData(project: Project, file: VirtualFile): Function<in FileEditor, out EditorNotificationPanel?>? {
+        val questService = service<GamifiedOnboardingQuestService>()
+        val activeQuest = questService.getActiveQuest() ?: return null
+        val progress = questService.getProgress(activeQuest.id)
+
+        val message = buildString {
+            append(activeQuest.title)
+            append(" — ")
+            if (progress.isQuestCompleted) {
+                append("All steps complete")
+            } else {
+                val remaining = progress.remainingSteps
+                append("$remaining step${if (remaining == 1) "" else "s"} remaining")
+            }
+        }
+
+        return Function { _: FileEditor ->
+            EditorNotificationPanel().apply {
+                text = message
+                toolTipText = activeQuest.description
+                createActionLabel("View quests") {
+                    ToolWindowManager.getInstance(project)
+                        .getToolWindow(TOOLWINDOW_ID)
+                        ?.activate(null, true)
+                }
+                if (progress.isQuestCompleted && !progress.rewardClaimed) {
+                    createActionLabel("Claim reward") {
+                        questService.claimReward(activeQuest.id)
+                    }
+                }
+                if (!progress.isQuestCompleted) {
+                    createActionLabel("Reset progress") {
+                        questService.resetQuest(activeQuest.id)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val TOOLWINDOW_ID = "Onboarding Quests"
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestStatusBarWidgetFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/OnboardingQuestStatusBarWidgetFactory.kt
@@ -1,0 +1,91 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.intellij.util.Consumer
+import javax.swing.JComponent
+import java.awt.Component
+import java.awt.event.MouseEvent
+
+/**
+ * Status bar widget showing the active onboarding quest progress.
+ */
+class OnboardingQuestStatusBarWidgetFactory : StatusBarWidgetFactory, DumbAware {
+    override fun getId(): String = WIDGET_ID
+
+    override fun getDisplayName(): String = "Onboarding quest progress"
+
+    override fun isAvailable(project: Project): Boolean = true
+
+    override fun createWidget(project: Project): StatusBarWidget = OnboardingQuestStatusBarWidget(project)
+
+    override fun disposeWidget(widget: StatusBarWidget) {
+        widget.dispose()
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
+
+    private class OnboardingQuestStatusBarWidget(private val project: Project) : StatusBarWidget, StatusBarWidget.Multiframe {
+        private val questService = service<GamifiedOnboardingQuestService>()
+        private var statusBar: StatusBar? = null
+        private var cachedText: String = ""
+        private var tooltip: String? = null
+        private val connection = ApplicationManager.getApplication().messageBus.connect()
+        private val presentation = object : StatusBarWidget.TextPresentation {
+            override fun getText(): String = cachedText
+            override fun getTooltipText(): String? = tooltip
+            override fun getClickConsumer(): Consumer<MouseEvent>? = null
+            override fun getAlignment(): Float = Component.CENTER_ALIGNMENT
+        }
+
+        init {
+            connection.subscribe(GamifiedOnboardingQuestListener.TOPIC, GamifiedOnboardingQuestListener { updateText() })
+            updateText()
+        }
+
+        override fun ID(): String = WIDGET_ID
+
+        override fun install(statusBar: StatusBar) {
+            this.statusBar = statusBar
+        }
+
+        override fun dispose() {
+            connection.disconnect()
+        }
+
+        override fun getComponent(): JComponent? = null
+
+        override fun getPresentation(): StatusBarWidget.WidgetPresentation = presentation
+
+        override fun copy(): StatusBarWidget = OnboardingQuestStatusBarWidget(project)
+
+        private fun updateText() {
+            val activeQuest = questService.getActiveQuest()
+            if (activeQuest == null) {
+                cachedText = "No onboarding quest"
+                tooltip = null
+            } else {
+                val progress = questService.getProgress(activeQuest.id)
+                val completed = progress.completedStepIds.size
+                val total = progress.totalSteps
+                val rewardSuffix = when {
+                    progress.rewardClaimed -> " • reward claimed"
+                    progress.isQuestCompleted -> " • reward ready"
+                    else -> ""
+                }
+                cachedText = "${activeQuest.title}: $completed/$total$rewardSuffix"
+                tooltip = activeQuest.description
+            }
+            statusBar?.updateWidget(ID())
+        }
+    }
+
+    companion object {
+        private const val WIDGET_ID = "advanced.expression.folding.onboardingQuestStatus"
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/onboarding/QuestProgress.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/QuestProgress.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+/**
+ * Immutable snapshot of a quest progress used by the UI layer.
+ */
+data class QuestProgress(
+    val questId: String,
+    val completedStepIds: Set<String>,
+    val totalSteps: Int,
+    val rewardClaimed: Boolean,
+) {
+    val isQuestCompleted: Boolean
+        get() = totalSteps == 0 || completedStepIds.size >= totalSteps
+
+    val remainingSteps: Int
+        get() = (totalSteps - completedStepIds.size).coerceAtLeast(0)
+}

--- a/test/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestServiceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/onboarding/GamifiedOnboardingQuestServiceTest.kt
@@ -1,0 +1,55 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GamifiedOnboardingQuestServiceTest {
+
+    private val service = GamifiedOnboardingQuestService()
+
+    @Test
+    fun `defaults to first quest`() {
+        val defaultQuest = GamifiedOnboardingQuests.defaults().first()
+
+        val activeQuest = service.getActiveQuest()
+
+        assertNotNull(activeQuest)
+        assertEquals(defaultQuest.id, activeQuest!!.id)
+    }
+
+    @Test
+    fun `completing step is idempotent`() {
+        val quest = service.getActiveQuest() ?: error("Active quest expected")
+        val firstStep = quest.steps.first()
+
+        val firstCompletion = service.completeStep(firstStep.id)
+        val secondCompletion = service.completeStep(firstStep.id)
+        val progress = service.getProgress(quest.id)
+
+        assertTrue(firstCompletion)
+        assertFalse(secondCompletion)
+        assertEquals(setOf(firstStep.id), progress.completedStepIds)
+        assertFalse(progress.rewardClaimed)
+    }
+
+    @Test
+    fun `reward can be claimed exactly once`() {
+        val quest = service.availableQuests().first()
+        quest.steps.forEach { step ->
+            assertTrue(service.completeStep(step.id))
+        }
+        val beforeClaimProgress = service.getProgress(quest.id)
+        assertTrue(beforeClaimProgress.isQuestCompleted)
+
+        val firstClaim = service.claimReward(quest.id)
+        val secondClaim = service.claimReward(quest.id)
+        val afterClaimProgress = service.getProgress(quest.id)
+
+        assertTrue(firstClaim)
+        assertFalse(secondClaim)
+        assertTrue(afterClaimProgress.rewardClaimed)
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated onboarding quests tool window with progress controls and rewards
- broadcast quest progress changes so status bar and editor notifications stay current
- register new status bar, notification, and tool window extensions for the onboarding experience

## Testing
- ./gradlew clean build test --no-configuration-cache --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_6904dea85b94832e98fc1b18bf05ca97