### PR TITLE
Add IntelliJ preview for observability dashboard variants

### DIFF
--- a/docs/observability_dashboard_plan.md
+++ b/docs/observability_dashboard_plan.md
@@ -1,0 +1,17 @@
+# Observability Dashboard Plan
+
+## Optimized Solution Overview
+- **Data Intake Layer**: Ship metrics, logs, and traces through language-specific SDKs and sidecars into a Kafka-backed ingestion bus with schema validation to prevent malformed payloads.
+- **Processing & Storage**: Use a streaming job (Apache Flink) to normalize events, write hot metrics to a time-series database (ClickHouse) and persisted logs/traces to S3-backed object storage indexed by OpenSearch.
+- **Visualization UI**: React-based frontend backed by GraphQL gateway that federates metrics, logs, and trace queries; supports templated dashboards, drilldowns, and correlation widgets.
+- **Alerting & Automation**: Rules-as-code repository compiled into Prometheus-compatible alert rules and routed through Alertmanager with ChatOps + ticketing hooks.
+- **Governance & Reliability**: Terraform-managed infrastructure, feature flags for gradual rollout, audit logging, and golden-path runbooks stored with the dashboards.
+
+## Confidence Ratings
+| Section | Confidence |
+| --- | --- |
+| Data Intake Layer | 0.8 |
+| Processing & Storage | 0.75 |
+| Visualization UI | 0.7 |
+| Alerting & Automation | 0.8 |
+| Governance & Reliability | 0.65 |

--- a/docs/observability_dashboard_ui.html
+++ b/docs/observability_dashboard_ui.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Observability Control Room</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --accent: #38bdf8;
+      --accent-muted: rgba(56, 189, 248, 0.15);
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.15), transparent 55%),
+                  radial-gradient(circle at bottom right, rgba(94, 234, 212, 0.12), transparent 45%),
+                  var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: stretch;
+    }
+
+    .sidebar {
+      width: 260px;
+      background: rgba(15, 23, 42, 0.8);
+      border-right: 1px solid rgba(148, 163, 184, 0.2);
+      padding: 24px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .sidebar h1 {
+      margin: 0;
+      font-size: 20px;
+      letter-spacing: 0.02em;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .sidebar h1::before {
+      content: "";
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 12px rgba(56, 189, 248, 0.6);
+    }
+
+    .sidebar nav {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .sidebar button {
+      background: transparent;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 10px;
+      color: var(--text);
+      padding: 10px 12px;
+      text-align: left;
+      font-size: 14px;
+      cursor: pointer;
+      transition: border-color 0.2s ease, background 0.2s ease;
+    }
+
+    .sidebar button:hover,
+    .sidebar button.active {
+      border-color: var(--accent);
+      background: var(--accent-muted);
+    }
+
+    .main {
+      flex: 1;
+      padding: 32px 40px;
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+    }
+
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 20px;
+    }
+
+    .card {
+      background: rgba(30, 41, 59, 0.85);
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      border-radius: 16px;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+    }
+
+    .card h2 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 600;
+    }
+
+    .card p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 14px;
+      color: var(--muted);
+    }
+
+    .status-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: rgba(148, 163, 184, 0.4);
+      box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.08);
+    }
+
+    .status-dot.healthy {
+      background: #4ade80;
+      box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.18);
+    }
+
+    .status-dot.warning {
+      background: #facc15;
+      box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.22);
+    }
+
+    .status-dot.risk {
+      background: #fb7185;
+      box-shadow: 0 0 0 3px rgba(251, 113, 133, 0.22);
+    }
+
+    .confidence {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border-radius: 999px;
+      background: rgba(148, 163, 184, 0.12);
+      font-size: 13px;
+      color: var(--text);
+      width: fit-content;
+    }
+
+    .confidence span {
+      font-variant-numeric: tabular-nums;
+    }
+
+    .timeline {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 24px;
+    }
+
+    .timeline-step {
+      border-left: 2px solid rgba(56, 189, 248, 0.35);
+      padding-left: 16px;
+      position: relative;
+    }
+
+    .timeline-step::before {
+      content: "";
+      position: absolute;
+      left: -11px;
+      top: 6px;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.18);
+    }
+
+    .timeline-step h3 {
+      margin: 0;
+      font-size: 15px;
+    }
+
+    .timeline-step ul {
+      margin: 8px 0 0;
+      padding-left: 18px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .footer-note {
+      font-size: 13px;
+      color: var(--muted);
+      text-align: right;
+    }
+
+    @media (max-width: 900px) {
+      body {
+        flex-direction: column;
+      }
+
+      .sidebar {
+        width: auto;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 20px;
+      }
+
+      .sidebar nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+      }
+
+      .sidebar button {
+        flex: 1;
+        min-width: 140px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <aside class="sidebar">
+    <h1>Observability Control</h1>
+    <nav>
+      <button class="active">Intake</button>
+      <button>Processing</button>
+      <button>Visualization</button>
+      <button>Alerts</button>
+      <button>Governance</button>
+    </nav>
+    <section>
+      <p class="footer-note">Blueprint v1.0 · Confidence snapshot updated hourly.</p>
+    </section>
+  </aside>
+
+  <main class="main">
+    <section>
+      <h2>System Status Overview</h2>
+      <div class="summary-grid">
+        <article class="card">
+          <h2>Data Intake Layer</h2>
+          <p>SDKs and sidecars stream telemetry into schema-validated Kafka topics with autoscaled collectors.</p>
+          <div class="status-row">
+            <span class="status-dot healthy"></span>
+            <span>Throughput 92%, schema errors &lt; 0.2%</span>
+          </div>
+          <div class="confidence">
+            Confidence <span>0.80</span>
+          </div>
+        </article>
+        <article class="card">
+          <h2>Processing &amp; Storage</h2>
+          <p>Flink normalizes events before routing to ClickHouse for hot queries and S3 + OpenSearch for deep history.</p>
+          <div class="status-row">
+            <span class="status-dot warning"></span>
+            <span>Storage burn rate 67%, tiering review pending</span>
+          </div>
+          <div class="confidence">
+            Confidence <span>0.75</span>
+          </div>
+        </article>
+        <article class="card">
+          <h2>Visualization UI</h2>
+          <p>React dashboards backed by GraphQL federation provide templated views, drilldowns, and correlations.</p>
+          <div class="status-row">
+            <span class="status-dot warning"></span>
+            <span>Widget latency P95 420ms · improving</span>
+          </div>
+          <div class="confidence">
+            Confidence <span>0.70</span>
+          </div>
+        </article>
+        <article class="card">
+          <h2>Alerting &amp; Automation</h2>
+          <p>Rules-as-code compile into Alertmanager, syncing ChatOps rooms and ticketing workflows.</p>
+          <div class="status-row">
+            <span class="status-dot healthy"></span>
+            <span>Escalation SLO 99.5% · fatigue guardrails active</span>
+          </div>
+          <div class="confidence">
+            Confidence <span>0.80</span>
+          </div>
+        </article>
+        <article class="card">
+          <h2>Governance &amp; Reliability</h2>
+          <p>Terraform-managed infrastructure with feature flags, audit trails, and chaos drill runbooks.</p>
+          <div class="status-row">
+            <span class="status-dot risk"></span>
+            <span>Cross-region failover drill overdue</span>
+          </div>
+          <div class="confidence">
+            Confidence <span>0.65</span>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Operational Flow</h2>
+      <div class="timeline">
+        <div class="card timeline-step">
+          <h3>1. Instrument</h3>
+          <ul>
+            <li>Service SDK rollout checklist</li>
+            <li>Schema registry validation</li>
+            <li>Collector autoscale policy</li>
+          </ul>
+        </div>
+        <div class="card timeline-step">
+          <h3>2. Normalize</h3>
+          <ul>
+            <li>Streaming enrichment via Flink</li>
+            <li>Data quality scorecards</li>
+            <li>Retry &amp; quarantine lanes</li>
+          </ul>
+        </div>
+        <div class="card timeline-step">
+          <h3>3. Observe</h3>
+          <ul>
+            <li>Unified metrics/logs/traces search</li>
+            <li>Scenario templates for incidents</li>
+            <li>Drilldown to RCA wikis</li>
+          </ul>
+        </div>
+        <div class="card timeline-step">
+          <h3>4. Act</h3>
+          <ul>
+            <li>Alertmanager routing ladders</li>
+            <li>ChatOps + ticket sync</li>
+            <li>Runbook-driven automation</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -85,6 +85,12 @@
         <!-- Hidden action invoked from settings to refresh folded text colors -->
         <action id="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"
                 class="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"/>
+
+        <action id="com.intellij.advancedExpressionFolding.action.ShowObservabilityDashboardPreviewAction"
+                class="com.intellij.advancedExpressionFolding.action.ShowObservabilityDashboardPreviewAction"
+                text="Show Observability Dashboard Variants">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
     </actions>
 
     <extensionPoints>

--- a/src/com/intellij/advancedExpressionFolding/action/ShowObservabilityDashboardPreviewAction.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/ShowObservabilityDashboardPreviewAction.kt
@@ -1,0 +1,17 @@
+package com.intellij.advancedExpressionFolding.action
+
+import com.intellij.advancedExpressionFolding.view.observability.ObservabilityDashboardPreviewDialog
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
+
+class ShowObservabilityDashboardPreviewAction : AnAction(), DumbAware {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        ObservabilityDashboardPreviewDialog(project).show()
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabledAndVisible = e.project != null
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/observability/ObservabilityDashboardPreviewDialog.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/observability/ObservabilityDashboardPreviewDialog.kt
@@ -1,0 +1,59 @@
+package com.intellij.advancedExpressionFolding.view.observability
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Dimension
+import javax.swing.JComboBox
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Dialog that lets developers preview five IntelliJ UI variants for the observability dashboard.
+ */
+class ObservabilityDashboardPreviewDialog(project: Project) : DialogWrapper(project, true) {
+    private val cards = JPanel(CardLayout())
+    private val comboBox = JComboBox(ObservabilityDashboardVariant.entries.toTypedArray())
+
+    init {
+        title = "Observability Dashboard Variants"
+        cards.preferredSize = Dimension(600, 360)
+        initCards()
+        initComboBox()
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        return JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.empty(8)
+            add(buildHeader(), BorderLayout.NORTH)
+            add(cards, BorderLayout.CENTER)
+        }
+    }
+
+    private fun buildHeader(): JPanel {
+        return JPanel(BorderLayout()).apply {
+            border = JBUI.Borders.emptyBottom(8)
+            add(JBLabel("Variant"), BorderLayout.WEST)
+            add(comboBox, BorderLayout.CENTER)
+        }
+    }
+
+    private fun initCards() {
+        ObservabilityDashboardVariant.entries.forEach { variant ->
+            cards.add(variant.createComponent(), variant.name)
+        }
+        (cards.layout as CardLayout).show(cards, ObservabilityDashboardVariant.STATUS_CARDS.name)
+    }
+
+    private fun initComboBox() {
+        comboBox.selectedItem = ObservabilityDashboardVariant.STATUS_CARDS
+        comboBox.addActionListener {
+            val selected = comboBox.selectedItem as? ObservabilityDashboardVariant ?: return@addActionListener
+            (cards.layout as CardLayout).show(cards, selected.name)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/observability/ObservabilityDashboardVariant.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/observability/ObservabilityDashboardVariant.kt
@@ -1,0 +1,175 @@
+package com.intellij.advancedExpressionFolding.view.observability
+
+import com.intellij.ui.OnePixelSplitter
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTabbedPane
+import com.intellij.ui.table.JBTable
+import com.intellij.ui.treeStructure.SimpleTree
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.GridLayout
+import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.table.DefaultTableModel
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.DefaultTreeModel
+
+/**
+ * Provides five lightweight Swing-based variants for previewing the observability dashboard.
+ */
+enum class ObservabilityDashboardVariant(val displayName: String) {
+    STATUS_CARDS("Status cards"),
+    TAB_OVERVIEW("Tab overview"),
+    SPLIT_SUMMARY("Split summary"),
+    TABLE_MATRIX("Table matrix"),
+    TREE_TIMELINE("Tree timeline");
+
+    fun createComponent(): JPanel = when (this) {
+        STATUS_CARDS -> buildStatusCards()
+        TAB_OVERVIEW -> buildTabOverview()
+        SPLIT_SUMMARY -> buildSplitSummary()
+        TABLE_MATRIX -> buildTableMatrix()
+        TREE_TIMELINE -> buildTreeTimeline()
+    }
+
+    private fun buildStatusCards(): JPanel {
+        val container = JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(16, 16, 16, 16)
+        }
+        val cardsPanel = JPanel(GridLayout(2, 2, 12, 12))
+        cardsPanel.add(createCard("Ingestion", "Healthy", Color(0x2E7D32)))
+        cardsPanel.add(createCard("Processing", "Stable", Color(0x1565C0)))
+        cardsPanel.add(createCard("Storage", "Lagging", Color(0xEF6C00)))
+        cardsPanel.add(createCard("Alerts", "Noisy", Color(0xC62828)))
+        container.add(cardsPanel, BorderLayout.CENTER)
+        return container
+    }
+
+    private fun buildTabOverview(): JPanel {
+        val tabs = JBTabbedPane()
+        tabs.addTab("Overview", JBScrollPane(buildStatusList()))
+        tabs.addTab("Incidents", JBScrollPane(buildIncidentList()))
+        tabs.addTab("Reliability", JBScrollPane(buildReliabilityList()))
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+            add(tabs, BorderLayout.CENTER)
+        }
+    }
+
+    private fun buildSplitSummary(): JPanel {
+        val splitter = OnePixelSplitter(false, 0.35f)
+        splitter.firstComponent = JBScrollPane(buildStatusList())
+        splitter.secondComponent = JBScrollPane(buildIncidentDetails())
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+            add(splitter, BorderLayout.CENTER)
+        }
+    }
+
+    private fun buildTableMatrix(): JPanel {
+        val headers = arrayOf("Subsystem", "Signal", "State", "Confidence")
+        val rows = arrayOf(
+            arrayOf("Ingestion", "Requests/min", "12.3k", "0.82"),
+            arrayOf("Processing", "Lag time", "210 ms", "0.74"),
+            arrayOf("Storage", "Hot retention", "48 h", "0.68"),
+            arrayOf("Alerts", "Open incidents", "3", "0.61")
+        )
+        val model = DefaultTableModel(rows, headers)
+        val table = JBTable(model).apply {
+            tableHeader.reorderingAllowed = false
+            preferredScrollableViewportSize = Dimension(420, 160)
+        }
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(12, 12, 12, 12)
+            add(JBScrollPane(table), BorderLayout.CENTER)
+        }
+    }
+
+    private fun buildTreeTimeline(): JPanel {
+        val root = DefaultMutableTreeNode("Last 24h")
+        val ingestion = DefaultMutableTreeNode("Ingestion stable")
+        val processing = DefaultMutableTreeNode("Processing spikes")
+        processing.add(DefaultMutableTreeNode("08:15 UTC – Backlog cleared"))
+        processing.add(DefaultMutableTreeNode("11:42 UTC – Alert acknowledged"))
+        val storage = DefaultMutableTreeNode("Storage degradation")
+        storage.add(DefaultMutableTreeNode("S3 retry increase"))
+        val alerts = DefaultMutableTreeNode("Alert review")
+        alerts.add(DefaultMutableTreeNode("Noise budget exceeded"))
+        alerts.add(DefaultMutableTreeNode("Follow-up runbook"))
+        root.add(ingestion)
+        root.add(processing)
+        root.add(storage)
+        root.add(alerts)
+        val tree = SimpleTree(DefaultTreeModel(root))
+        tree.isRootVisible = true
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+            add(JBScrollPane(tree), BorderLayout.CENTER)
+        }
+    }
+
+    private fun createCard(title: String, state: String, color: Color): JPanel {
+        return JPanel(BorderLayout()).apply {
+            border = BorderFactory.createCompoundBorder(
+                BorderFactory.createLineBorder(color, 1, true),
+                BorderFactory.createEmptyBorder(12, 12, 12, 12)
+            )
+            val titleLabel = JBLabel(title, SwingConstants.LEFT).apply {
+                foreground = color
+            }
+            val stateLabel = JBLabel(state, SwingConstants.RIGHT).apply {
+                font = font.deriveFont(font.size2D + 2f)
+            }
+            add(titleLabel, BorderLayout.NORTH)
+            add(stateLabel, BorderLayout.SOUTH)
+        }
+    }
+
+    private fun buildStatusList(): JBList<String> = JBList(
+        listOf(
+            "Collectors healthy",
+            "5xx rate steady",
+            "Stream lag 210 ms",
+            "ClickHouse at 68% capacity"
+        )
+    )
+
+    private fun buildIncidentList(): JBList<String> = JBList(
+        listOf(
+            "SLO breach – API latency",
+            "Escalation pending – Alerts",
+            "Resolved – Billing ingestion"
+        )
+    )
+
+    private fun buildReliabilityList(): JBList<String> = JBList(
+        listOf(
+            "Confidence Intake 0.8",
+            "Confidence Processing 0.75",
+            "Confidence Visualization 0.7"
+        )
+    )
+
+    private fun buildIncidentDetails(): JPanel {
+        val panel = JPanel(BorderLayout())
+        val header = JBLabel("Selected incident", SwingConstants.LEFT)
+        val body = JPanel().apply {
+            border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(JBLabel("08:15 UTC – Spike in processing backlog"))
+            add(Box.createVerticalStrut(4))
+            add(JBLabel("Action: scaled Flink workers"))
+            add(Box.createVerticalStrut(4))
+            add(JBLabel("Confidence restored to 0.74"))
+        }
+        panel.add(header, BorderLayout.NORTH)
+        panel.add(body, BorderLayout.CENTER)
+        return panel
+    }
+}


### PR DESCRIPTION
## Summary
- add a Tools menu action that opens an observability dashboard preview dialog
- implement five lightweight dashboard layouts (cards, tabs, split summary, table, tree) selectable inside the dialog
- register the new preview action so the variants can be explored inside the IDE

## Testing
- ./gradlew --no-configuration-cache --console=plain clean build test

------
https://chatgpt.com/codex/tasks/task_e_6904defb1658832ea096d38ca96b4caf