### PR TITLE
Expose experiment variants via tools menu actions

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
         <!-- Application-level service that persists plugin settings -->
         <applicationService
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.ab.AbTestingService"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->
@@ -85,6 +87,67 @@
         <!-- Hidden action invoked from settings to refresh folded text colors -->
         <action id="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"
                 class="com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction"/>
+
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.OnboardingFlow"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Onboarding Flow"
+                description="Show assigned variant for Onboarding Flow experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.QuickHints"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Quick Hints"
+                description="Show assigned variant for Quick Hints experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.AutoFoldIntro"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Auto Fold Intro"
+                description="Show assigned variant for Auto Fold Intro experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.AutoFormatPrimer"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Auto Format Primer"
+                description="Show assigned variant for Auto Format Primer experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.LiveTemplateCoach"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Live Template Coach"
+                description="Show assigned variant for Live Template Coach experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.DocumentationNudge"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Documentation Nudge"
+                description="Show assigned variant for Documentation Nudge experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.ShortcutTrainer"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Shortcut Trainer"
+                description="Show assigned variant for Shortcut Trainer experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.SettingsTour"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Settings Tour"
+                description="Show assigned variant for Settings Tour experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.EditorHighlights"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Editor Highlights"
+                description="Show assigned variant for Editor Highlights experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
+        <action id="AdvancedExpressionFolding.AbTesting.Experiment.ProductivityWizard"
+                class="com.intellij.advancedExpressionFolding.action.AbExperimentStatusAction"
+                text="AB: Productivity Wizard"
+                description="Show assigned variant for Productivity Wizard experiment">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+        </action>
     </actions>
 
     <extensionPoints>

--- a/src/com/intellij/advancedExpressionFolding/ab/AbTestingService.kt
+++ b/src/com/intellij/advancedExpressionFolding/ab/AbTestingService.kt
@@ -1,0 +1,106 @@
+package com.intellij.advancedExpressionFolding.ab
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import org.jetbrains.annotations.TestOnly
+import java.util.concurrent.ThreadLocalRandom
+import kotlin.math.abs
+
+private const val UNINITIALIZED_SEED: Long = Long.MIN_VALUE
+
+@State(name = "AdvancedExpressionFoldingAbTesting", storages = [Storage("advancedExpressionFoldingAbTesting.xml")])
+class AbTestingService(private val seedProvider: () -> Long = defaultSeedProvider) :
+    PersistentStateComponent<AbTestingService.State> {
+
+    data class State(
+        var seed: Long = UNINITIALIZED_SEED,
+        var assignments: MutableMap<String, String> = mutableMapOf()
+    )
+
+    private var state: State = State()
+        set(value) {
+            field = value
+            ensureSeedInitialized()
+        }
+
+    init {
+        ensureSeedInitialized()
+    }
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = State(
+            seed = state.seed,
+            assignments = state.assignments.toMutableMap()
+        )
+    }
+
+    @Synchronized
+    fun variant(experiment: String, variants: List<String> = DEFAULT_VARIANTS): String {
+        require(experiment.isNotBlank()) { "Experiment key must not be blank" }
+        require(variants.isNotEmpty()) { "At least one variant is required" }
+
+        state.assignments[experiment]?.let { stored ->
+            if (variants.contains(stored)) {
+                return stored
+            }
+        }
+
+        val variant = selectVariant(experiment, variants)
+        state.assignments[experiment] = variant
+        return variant
+    }
+
+    @Synchronized
+    fun isInVariant(
+        experiment: String,
+        variant: String,
+        variants: List<String> = DEFAULT_VARIANTS
+    ): Boolean = variant(experiment, variants) == variant
+
+    @TestOnly
+    @Synchronized
+    fun clearAssignments() {
+        state.assignments.clear()
+    }
+
+    @TestOnly
+    fun snapshotState(): State {
+        return State(
+            seed = state.seed,
+            assignments = state.assignments.toMutableMap()
+        )
+    }
+
+    private fun ensureSeedInitialized() {
+        if (state.seed == UNINITIALIZED_SEED) {
+            state.seed = sanitizeSeed(seedProvider())
+        }
+    }
+
+    private fun selectVariant(experiment: String, variants: List<String>): String {
+        val mix = sanitizeSeed(state.seed xor experiment.hashCode().toLong())
+        val index = (mix % variants.size).toInt()
+        return variants[index]
+    }
+
+    companion object {
+        private val DEFAULT_VARIANTS = listOf("control", "treatment")
+
+        private val defaultSeedProvider: () -> Long = {
+            ThreadLocalRandom.current().nextLong()
+        }
+
+        private fun sanitizeSeed(value: Long): Long {
+            return if (value == Long.MIN_VALUE) 0 else abs(value)
+        }
+
+        @JvmStatic
+        fun getInstance(): AbTestingService {
+            return ApplicationManager.getApplication().getService(AbTestingService::class.java)
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/action/AbExperimentStatusAction.kt
+++ b/src/com/intellij/advancedExpressionFolding/action/AbExperimentStatusAction.kt
@@ -1,0 +1,23 @@
+package com.intellij.advancedExpressionFolding.action
+
+import com.intellij.advancedExpressionFolding.ab.AbTestingService
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.ui.Messages
+
+class AbExperimentStatusAction : DumbAwareAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val actionId = ActionManager.getInstance().getId(this) ?: return
+        val experiment = actionId.removePrefix(ACTION_ID_PREFIX)
+        val variant = AbTestingService.getInstance().variant(experiment)
+        val message = "Experiment \"$experiment\" assigned variant \"$variant\"."
+        Messages.showInfoMessage(e.project, message, DIALOG_TITLE)
+    }
+
+    companion object {
+        private const val ACTION_ID_PREFIX = "AdvancedExpressionFolding.AbTesting.Experiment."
+        private const val DIALOG_TITLE = "A/B Testing"
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/unit/AbTestingServiceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/unit/AbTestingServiceTest.kt
@@ -1,0 +1,57 @@
+package com.intellij.advancedExpressionFolding.unit
+
+import com.intellij.advancedExpressionFolding.ab.AbTestingService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class AbTestingServiceTest {
+
+    @Test
+    fun `variant is stable for the same experiment`() {
+        val seed = 42L
+        val service = AbTestingService { seed }
+
+        val first = service.variant("folding-speed")
+        val second = service.variant("folding-speed")
+
+        assertEquals(first, second)
+        assertEquals(expectedVariant(seed, "folding-speed", listOf("control", "treatment")), first)
+    }
+
+    @Test
+    fun `assignments survive serialization`() {
+        val initialService = AbTestingService { 7L }
+        val assigned = initialService.variant("folding-speed")
+
+        val storedState = initialService.snapshotState()
+
+        val restoredService = AbTestingService { 99L }
+        restoredService.loadState(storedState)
+
+        val restored = restoredService.variant("folding-speed")
+        assertEquals(assigned, restored)
+    }
+
+    @Test
+    fun `variant recalculates when requested variant list changes`() {
+        val service = AbTestingService { 1L }
+        val original = service.variant("folding-speed", listOf("control", "treatment"))
+
+        val alternatives = listOf("baseline", "enhanced", "aggressive")
+        val reassigned = service.variant("folding-speed", alternatives)
+
+        assertNotEquals(original, reassigned)
+        assertEquals(expectedVariant(1L, "folding-speed", alternatives), reassigned)
+    }
+
+    private fun expectedVariant(seed: Long, experiment: String, variants: List<String>): String {
+        val mix = sanitize(seed xor experiment.hashCode().toLong())
+        val index = (mix % variants.size).toInt()
+        return variants[index]
+    }
+
+    private fun sanitize(value: Long): Long {
+        return if (value == Long.MIN_VALUE) 0 else kotlin.math.abs(value)
+    }
+}


### PR DESCRIPTION
## Summary
- add a snapshotState helper to AbTestingService so tests can round-trip persisted assignments safely
- introduce an AbExperimentStatusAction that reports the current variant for the invoking experiment
- register ten Tools menu actions to surface experiment variants and update the existing unit test to use the helper

## Testing
- ./gradlew test --console=plain *(fails: command interrupted after extended toolchain download; Gradle could not complete in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6904dec635c8832e879f919787070eb6