### PR TITLE
Add DSL sandbox tool window

### DIFF
--- a/docs/dsl_sandbox_plan.md
+++ b/docs/dsl_sandbox_plan.md
@@ -1,0 +1,78 @@
+# Prototype DSL Sandbox with Rollback Simulator Plan
+
+## Stage 0 — Warm-Up
+- The seed demands a prototype sandbox where a domain-specific language can be tested safely with rollback capabilities. We need both an execution harness and a simulator that reverts states.
+
+## Stage 1 — Ideation Loop
+
+### Cycle 1
+**Visionary Futurist (functional paradigm, biology analogy):** Envision a pure function pipeline where every DSL command is like a cell signaling pathway, with immutable snapshots enabling deterministic rewinds; tension point: prove functional purity won’t strangle I/O-heavy tooling.
+**Seasoned Architect (object-oriented paradigm, urban planning analogy):** Layer sandbox modules like zoning districts—parsers, interpreter, state ledger—encapsulated in classes that negotiate interfaces; tension point: ensure we can enforce encapsulation without drowning in boilerplate.
+**Improvisational Artist (reactive paradigm, pop fiction analogy):** Picture observable streams similar to the time-loop narrative in *Edge of Tomorrow*, where rollbacks replay emissions to inspect divergent futures; tension point: decide how granular reactive updates should be before it becomes noise.
+**Skeptical Critic (logic programming paradigm, biology analogy):** Challenge assumptions by introducing rule-based constraints that validate DSL mutations like immune responses rejecting pathogens; tension point: identify how to reconcile rule conflicts with deterministic rollbacks.
+**Curious Beginner (procedural paradigm, urban planning analogy):** Ask for a simple step-by-step sandbox tour like following city transit lines so every rollback station is clearly labeled; tension point: clarify which steps must be exposed to the learner versus hidden behind automation.
+
+### Cycle 2
+**Visionary Futurist (actor model, pop fiction analogy):** Model each execution context as actors akin to starship crews coordinating via message passing to synchronize rollbacks; tension point: validate actor isolation when shared resources appear.
+**Seasoned Architect (component-based paradigm, biology analogy):** Assemble sandbox components like modular organs that plug into a circulatory backbone handling state diffs; tension point: specify the contract for swapping organs without triggering rejection.
+**Improvisational Artist (dataflow paradigm, urban planning analogy):** Imagine rollback timelines as traffic roundabouts rerouting cars along dataflow edges; tension point: map how data tokens carry metadata for auditing.
+**Skeptical Critic (constraint-oriented paradigm, pop fiction analogy):** Impose temporal paradox checks like in *Back to the Future* so conflicting rollbacks raise immediate alerts; tension point: prove the paradox detector isn’t overfitted to trivial cases.
+**Curious Beginner (service-oriented paradigm, biology analogy):** Request friendly services that behave like cooperative microbiomes offering rollback-as-a-service endpoints; tension point: list which services a newcomer must call directly.
+
+### Cycle 3
+**Visionary Futurist (event-sourcing paradigm, urban planning analogy):** Treat every DSL action as zoning permits stored in an event log, enabling reconstruction of any neighborhood; tension point: ensure event compaction keeps archives manageable.
+**Seasoned Architect (layered architecture paradigm, pop fiction analogy):** Stack parsing, execution, rollback, and UI layers like the levels of *Inception*, each with strict contracts; tension point: prevent dream-layer leakage—cross-layer coupling.
+**Improvisational Artist (metaprogramming paradigm, biology analogy):** Sculpt DSL macros as gene editors rewriting behavior safely inside the sandbox; tension point: decide how to sandbox meta-level edits without self-harm.
+**Skeptical Critic (deterministic finite automata paradigm, urban planning analogy):** Argue for finite state modeling like turnstiles at subway stations to guarantee predictable rollbacks; tension point: reconcile finite models with potentially infinite DSL constructs.
+**Curious Beginner (test-driven development paradigm, pop fiction analogy):** Beg for story-driven acceptance tests inspired by superhero training montages to validate rollback scenarios; tension point: figure out how to surface failing stories in plain language.
+
+## Stage 2 — Self-Critique Loop
+
+### Round 1: Composite Solution (Architect leads)
+- Define modular layers: Parser, Analyzer, Executor, State Ledger, Rollback Orchestrator, UI hooks.
+- Use event-sourced ledger storing immutable state diffs with compaction strategy.
+- Provide reactive observability channels for timeline inspection, backed by actor-isolated execution contexts.
+- Enforce constraint rules pre/post execution with deterministic automata checks.
+- Document beginner-friendly service endpoints and story-driven tests.
+
+### Round 2: Weaknesses & Assumptions (Critic leads)
+- Event log growth may still overwhelm storage without adaptive pruning.
+- Actor isolation could break when DSL operations require shared state locks.
+- Constraint engine might become brittle if rules lag behind DSL evolution.
+- Beginner services risk oversimplifying critical rollback configuration.
+- Testing strategy depends on narratives that may not cover edge semantics.
+
+### Round 3: Refinements (Architect + Artist)
+- Introduce tiered compaction: periodic snapshots plus diff bucketing with configurable retention.
+- Define shared resource broker mediating actor access via transactional boundaries.
+- Build rule authoring DSL with safety nets to update constraints alongside language changes.
+- Craft progressive disclosure UI where advanced rollback options unlock after tutorials.
+- Combine story tests with property-based generators to expand semantic coverage.
+
+### Round 4: Stress Tests (Futurist + Critic)
+- High load: simulate thousands of concurrent DSL sessions to measure actor broker contention.
+- Hostile input: fuzz parser and constraint DSL to ensure graceful degradation and rollbacks.
+- Missing dependencies: run sandbox in degraded mode where optional plugins are stubbed yet rollbacks still succeed.
+- Long-running sessions: validate compaction doesn’t corrupt reconstruction over millions of events.
+
+### Round 5: Optimized Solution & Confidence
+- Modular layering with event ledger and compaction [confidence 0.7].
+- Actor execution with transactional broker [confidence 0.6].
+- Constraint DSL with safety nets [confidence 0.65].
+- Progressive disclosure services/UI [confidence 0.55].
+- Hybrid narrative + property tests [confidence 0.6].
+
+## Final Package
+- **Architect’s Synthesized Plan:**
+  - Implement parser/analyzer with hooks for constraint DSL integration.
+  - Build executor atop actor contexts mediated by transactional broker.
+  - Persist event ledger with snapshot/compaction pipeline and audit tooling.
+  - Develop reactive timeline inspector UI with progressive disclosure controls.
+  - Deliver dual-layer testing: story acceptance suite plus property generators.
+- **North-Star Slogan:** "Sandbox boldly, rewind wisely: every DSL experiment remembered, none regretted."
+- **Next Experiments (Novelty × Effort):**
+  | Rank | Experiment | Novelty | Effort |
+  | --- | --- | --- | --- |
+  | 1 | Self-healing constraint recommender | High | High |
+  | 2 | Visual timeline diff animator | High | Medium |
+  | 3 | Lightweight CLI snapshot explorer | Medium | Low |

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,6 +50,11 @@
         <completion.contributor
                 language="JAVA"
                 implementationClass="com.intellij.advancedExpressionFolding.pseudo.TracingLoggableAnnotationCompletionContributor"/>
+
+        <toolWindow id="DSL Sandbox"
+                    anchor="right"
+                    factoryClass="com.intellij.advancedExpressionFolding.view.sandbox.DslSandboxToolWindowFactory"
+                    icon="AllIcons.Actions.PreviewDetails"/>
     </extensions>
 
     <actions>

--- a/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxEngine.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxEngine.kt
@@ -1,0 +1,150 @@
+package com.intellij.advancedExpressionFolding.view.sandbox
+
+import java.util.LinkedHashMap
+
+internal class DslSandboxEngine {
+    data class StateFrame(
+        val index: Int,
+        val command: String,
+        val snapshot: Map<String, String>,
+        val message: String,
+        val isError: Boolean = false
+    )
+
+    fun execute(script: String): List<StateFrame> {
+        val frames = mutableListOf<StateFrame>()
+        val state = LinkedHashMap<String, String>()
+        frames += StateFrame(
+            index = 0,
+            command = "(initial)",
+            snapshot = emptyMap(),
+            message = "Fresh workspace ready"
+        )
+
+        var nextIndex = 1
+        val lines = script.lines()
+        for (rawLine in lines) {
+            val line = rawLine.trim()
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue
+            }
+
+            val result = processCommand(line, state)
+            frames += StateFrame(
+                index = nextIndex++,
+                command = line,
+                snapshot = LinkedHashMap(state),
+                message = result.message,
+                isError = result.isError
+            )
+
+            if (result.isTerminal) {
+                break
+            }
+        }
+
+        return frames
+    }
+
+    private fun processCommand(
+        command: String,
+        state: LinkedHashMap<String, String>
+    ): CommandResult {
+        val tokens = command.split(" ")
+            .filter { it.isNotBlank() }
+        if (tokens.isEmpty()) {
+            return CommandResult("Skipped empty command")
+        }
+
+        val keyword = tokens.first().uppercase()
+        val tail = tokens.drop(1)
+
+        return when (keyword) {
+            "SET" -> {
+                val key = tail.getOrNull(0)
+                    ?: return CommandResult.error("SET requires a key")
+                val value = extractValue(command, key)
+                state[key] = value
+                CommandResult("Set $key = \"$value\"")
+            }
+
+            "APPEND" -> {
+                val key = tail.getOrNull(0)
+                    ?: return CommandResult.error("APPEND requires a key")
+                val addition = extractValue(command, key)
+                val current = state[key]
+                state[key] = when (current) {
+                    null -> addition
+                    else -> current + addition
+                }
+                CommandResult("Appended \"$addition\" to $key")
+            }
+
+            "INCR" -> {
+                val key = tail.getOrNull(0)
+                    ?: return CommandResult.error("INCR requires a key")
+                val amountText = tail.getOrNull(1) ?: "1"
+                val amount = amountText.toIntOrNull()
+                    ?: return CommandResult.error("INCR amount must be an integer")
+                val current = state[key]?.toIntOrNull() ?: 0
+                val updated = current + amount
+                state[key] = updated.toString()
+                CommandResult("Incremented $key by $amount (now $updated)")
+            }
+
+            "DELETE" -> {
+                val key = tail.getOrNull(0)
+                    ?: return CommandResult.error("DELETE requires a key")
+                val existed = state.remove(key) != null
+                CommandResult(
+                    if (existed) "Removed $key" else "Nothing to remove for $key"
+                )
+            }
+
+            "CLEAR" -> {
+                state.clear()
+                CommandResult("Cleared all entries")
+            }
+
+            "EMIT" -> {
+                val message = command.substringAfter(' ', "").ifBlank { "(empty signal)" }
+                CommandResult("Note: $message")
+            }
+
+            "SNAPSHOT" -> {
+                val name = tail.joinToString(" ")
+                val label = if (name.isBlank()) "untitled" else name
+                CommandResult("Snapshot saved: $label")
+            }
+
+            "HALT" -> {
+                CommandResult("Simulation halted", isTerminal = true)
+            }
+
+            else -> CommandResult.error("Unknown command: $keyword")
+        }
+    }
+
+    private fun extractValue(command: String, key: String): String {
+        val marker = "$key "
+        val position = command.indexOf(marker)
+        if (position < 0) {
+            return command.substringAfter(' ', "").trim()
+        }
+        return command.substring(position + marker.length).trim().ifBlank { "" }
+    }
+
+    private data class CommandResult(
+        val message: String,
+        val isTerminal: Boolean = false,
+        val isError: Boolean = false
+    ) {
+        companion object {
+            fun error(message: String): CommandResult = CommandResult(
+                message = "Error: $message",
+                isTerminal = true,
+                isError = true
+            )
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxPanel.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxPanel.kt
@@ -1,0 +1,214 @@
+package com.intellij.advancedExpressionFolding.view.sandbox
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.ui.CollectionListModel
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.JBSplitter
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+
+internal class DslSandboxPanel(project: Project) : SimpleToolWindowPanel(true, true) {
+
+    private val engine = DslSandboxEngine()
+    private val historyModel = CollectionListModel<DslSandboxEngine.StateFrame>()
+    private val scriptArea = JBTextArea(initialScript).apply {
+        lineWrap = false
+        wrapStyleWord = false
+        margin = JBUI.insets(4)
+    }
+    private val historyList = JBList(historyModel)
+    private val statePreview = JBTextArea().apply {
+        isEditable = false
+        lineWrap = true
+        wrapStyleWord = true
+        emptyText.text = "Run the script to inspect state snapshots"
+    }
+    private val statusLabel = JBLabel("Idle")
+    private val runButton = JButton("Run Script")
+    private val rollbackButton = JButton("Rollback to Selection")
+
+    private var frames: MutableList<DslSandboxEngine.StateFrame> = mutableListOf()
+
+    init {
+        scriptArea.preferredSize = Dimension(400, 240)
+        historyList.cellRenderer = createHistoryRenderer()
+        historyList.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        historyList.addListSelectionListener {
+            val index = historyList.selectedIndex
+            updateStatePreview(index)
+            updateControls()
+        }
+
+        runButton.addActionListener { runScript() }
+        rollbackButton.addActionListener { rollbackToSelection() }
+        rollbackButton.isEnabled = false
+
+        toolbar = createToolbarPanel()
+        setContent(createContentPanel())
+
+        runScript()
+    }
+
+    private fun createToolbarPanel(): JComponent {
+        return JPanel(FlowLayout(FlowLayout.LEFT, 8, 4)).apply {
+            add(runButton)
+            add(rollbackButton)
+            add(statusLabel)
+        }
+    }
+
+    private fun createContentPanel(): JComponent {
+        val scriptPanel = JPanel(BorderLayout()).apply {
+            add(JBLabel("Scenario Script"), BorderLayout.NORTH)
+            add(JBScrollPane(scriptArea), BorderLayout.CENTER)
+        }
+
+        val historyPanel = JPanel(BorderLayout()).apply {
+            add(JBLabel("Execution Timeline"), BorderLayout.NORTH)
+            add(JBScrollPane(historyList), BorderLayout.CENTER)
+        }
+
+        val previewPanel = JPanel(BorderLayout()).apply {
+            add(JBLabel("State Snapshot"), BorderLayout.NORTH)
+            add(JBScrollPane(statePreview), BorderLayout.CENTER)
+        }
+
+        val rightSplitter = JBSplitter(true, 0.45f)
+        rightSplitter.firstComponent = historyPanel
+        rightSplitter.secondComponent = previewPanel
+
+        val mainSplitter = JBSplitter(false, 0.4f)
+        mainSplitter.firstComponent = scriptPanel
+        mainSplitter.secondComponent = rightSplitter
+
+        return mainSplitter
+    }
+
+    private fun runScript() {
+        val result = try {
+            engine.execute(scriptArea.text)
+        } catch (t: Throwable) {
+            listOf(
+                DslSandboxEngine.StateFrame(
+                    index = 0,
+                    command = "(initial)",
+                    snapshot = emptyMap(),
+                    message = "Error: ${t.message ?: t.javaClass.simpleName}",
+                    isError = true
+                )
+            )
+        }
+
+        frames = result.toMutableList()
+        historyModel.replaceAll(frames)
+        historyList.selectedIndex = frames.lastIndex
+        updateStatePreview(historyList.selectedIndex)
+        statusLabel.text = frames.lastOrNull()?.message ?: "Idle"
+        updateControls()
+    }
+
+    private fun rollbackToSelection() {
+        val index = historyList.selectedIndex
+        if (index <= 0 || index >= frames.size) {
+            return
+        }
+        frames = frames.take(index + 1).toMutableList()
+        historyModel.replaceAll(frames)
+        historyList.selectedIndex = index
+        statusLabel.text = "Rolled back to #$index"
+        updateStatePreview(index)
+        updateControls()
+    }
+
+    private fun updateStatePreview(index: Int) {
+        val frame = frames.getOrNull(index)
+        statePreview.text = when (frame) {
+            null -> "No frame selected"
+            else -> buildString {
+                appendLine(formatState(frame.snapshot))
+                appendLine()
+                append(frame.message)
+            }
+        }
+    }
+
+    private fun formatState(state: Map<String, String>): String {
+        if (state.isEmpty()) {
+            return "{ }"
+        }
+        return buildString {
+            appendLine("{")
+            state.entries.forEachIndexed { idx, entry ->
+                append("  ")
+                append(entry.key)
+                append(": \"")
+                append(entry.value)
+                append("\"")
+                if (idx < state.size - 1) {
+                    append(',')
+                }
+                appendLine()
+            }
+            append('}')
+        }
+    }
+
+    private fun updateControls() {
+        if (frames.isEmpty()) {
+            rollbackButton.isEnabled = false
+            return
+        }
+        val selection = historyList.selectedIndex
+        rollbackButton.isEnabled = selection in 0 until frames.lastIndex
+        val errorIndex = frames.indexOfLast { it.isError }
+        if (errorIndex >= 0 && selection == frames.lastIndex) {
+            statusLabel.text = frames[errorIndex].message
+        }
+    }
+
+    private fun createHistoryRenderer(): ColoredListCellRenderer<DslSandboxEngine.StateFrame> {
+        return object : ColoredListCellRenderer<DslSandboxEngine.StateFrame>() {
+            override fun customizeCellRenderer(
+                list: javax.swing.JList<out DslSandboxEngine.StateFrame>,
+                value: DslSandboxEngine.StateFrame?,
+                index: Int,
+                selected: Boolean,
+                hasFocus: Boolean
+            ) {
+                if (value == null) return
+                val title = if (value.index == 0) "Initial state" else "#${value.index} ${value.command}"
+                val attributes = if (value.isError) SimpleTextAttributes.ERROR_ATTRIBUTES else SimpleTextAttributes.REGULAR_ATTRIBUTES
+                append(title, attributes)
+                append("  ", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                append(value.message, if (value.isError) SimpleTextAttributes.ERROR_ATTRIBUTES else SimpleTextAttributes.GRAYED_ATTRIBUTES)
+            }
+        }
+    }
+
+    companion object {
+        private val initialScript = """
+            # Prototype DSL scenario
+            SET arena Eclipse
+            SET energy 5
+            INCR energy 3
+            APPEND log Launch Sequence ->
+            SNAPSHOT warm-up
+            EMIT All systems green
+            INCR energy -2
+            DELETE arena
+            HALT
+        """.trimIndent()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxToolWindowFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxToolWindowFactory.kt
@@ -1,0 +1,15 @@
+package com.intellij.advancedExpressionFolding.view.sandbox
+
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+internal class DslSandboxToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = DslSandboxPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel, "Playground", false)
+        toolWindow.contentManager.addContent(content)
+    }
+}

--- a/test/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxEngineTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/view/sandbox/DslSandboxEngineTest.kt
@@ -1,0 +1,44 @@
+package com.intellij.advancedExpressionFolding.view.sandbox
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DslSandboxEngineTest {
+
+    private val engine = DslSandboxEngine()
+
+    @Test
+    fun `executes happy path script`() {
+        val frames = engine.execute(
+            """
+            SET city NeoTokyo
+            SET cycles 1
+            INCR cycles 2
+            APPEND log Boot
+            DELETE city
+            """.trimIndent()
+        )
+
+        assertEquals(6, frames.size)
+        assertEquals("3", frames[3].snapshot["cycles"])
+        assertEquals(null, frames.last().snapshot["city"])
+        assertTrue(frames.none { it.isError })
+    }
+
+    @Test
+    fun `stops on error and preserves prior state`() {
+        val frames = engine.execute(
+            """
+            SET counter 1
+            INCR counter nope
+            SET counter 5
+            """.trimIndent()
+        )
+
+        assertEquals(3, frames.size)
+        assertTrue(frames.last().isError)
+        assertEquals("1", frames.last().snapshot["counter"])
+        assertTrue(frames.last().message.startsWith("Error:"))
+    }
+}


### PR DESCRIPTION

<img width="777" height="895" alt="1" src="https://github.com/user-attachments/assets/352ae6c1-a5b2-4687-bca2-9fc1c180828d" />


## Summary
- add a DSL sandbox tool window that provides a script editor, execution timeline, and state preview with rollback support
- implement a lightweight DSL engine to drive the simulator and cover it with unit tests

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_6904df2ca19c832e9290d763f878063d