### PR TITLE
Add beginner onboarding tour notification

### DIFF
--- a/docs/beginner-onboarding-tour.md
+++ b/docs/beginner-onboarding-tour.md
@@ -1,0 +1,21 @@
+# Beginner Onboarding Tour
+
+New to Advanced Expression Folding? Spend a minute with this tour to understand the core controls that keep folded code readable.
+
+## 1. Review the folding settings
+- Go to **Settings | Editor | Code Folding | Advanced Expression Folding 2**.
+- The checklist is grouped so you can toggle only the features you care about.
+- Use **Enable all** or **Disable all** to compare the extremes, then keep just what you like.
+
+## 2. Experiment with real examples
+- In the settings panel, use **Checkout Examples to Current Project**.
+- The plugin adds runnable sample files so you can inspect fold hints without touching production code.
+
+## 3. Control folding from the menu
+- Use **Code | Advanced Expression Folding | Folding On/Off** to flip the global switch as you read through code.
+- The **Global toggle** action is safe—your actual source stays untouched.
+
+## Need a reset?
+- Press **Restore defaults** in the settings page to get back to the recommended baseline.
+
+Once you finish these steps the plugin keeps folding silently, so you can focus on the logic instead of boilerplate.

--- a/docs/new-features-brainstorm.md
+++ b/docs/new-features-brainstorm.md
@@ -1,0 +1,3 @@
+# New Features Brainstorm Notes
+
+This document was added to capture brainstorming outputs generated during the creative catalyst workflow exercise.

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -40,6 +40,9 @@
                            displayType="BALLOON"
                            isLogByDefault="true"/>
 
+        <postStartupActivity
+                implementation="com.intellij.advancedExpressionFolding.onboarding.BeginnerOnboardingTourActivity"/>
+
         <!-- Suggests pseudo-annotations supported by the plugin -->
         <completion.contributor
                 language="JAVA"

--- a/src/com/intellij/advancedExpressionFolding/onboarding/BeginnerOnboardingTourActivity.kt
+++ b/src/com/intellij/advancedExpressionFolding/onboarding/BeginnerOnboardingTourActivity.kt
@@ -1,0 +1,56 @@
+package com.intellij.advancedExpressionFolding.onboarding
+
+import com.intellij.advancedExpressionFolding.settings.view.SettingsConfigurable
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+private const val ONBOARDING_SHOWN_KEY = "advanced.expression.folding.onboarding.tour.shown"
+private const val ONBOARDING_DOC_URL =
+    "https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/docs/beginner-onboarding-tour.md"
+
+class BeginnerOnboardingTourActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        val application = ApplicationManager.getApplication()
+        if (application.isUnitTestMode || application.isHeadlessEnvironment) {
+            return
+        }
+
+        val properties = PropertiesComponent.getInstance()
+        if (properties.getBoolean(ONBOARDING_SHOWN_KEY, false)) {
+            return
+        }
+
+        val notificationGroup = NotificationGroupManager.getInstance()
+            .getNotificationGroup("Advanced Expression Folding")
+        val notification = notificationGroup.createNotification(
+            "Quick tour: Advanced Expression Folding",
+            """
+            <p>Welcome aboard! Follow these three steps to see the plugin in action:</p>
+            <ol>
+              <li>Open the folding settings to review the beginner-friendly defaults.</li>
+              <li>Use the “Enable all” and “Disable all” buttons to feel how folds change readability.</li>
+              <li>Check out the bundled examples panel to pull sample files into your project.</li>
+            </ol>
+            """.trimIndent(),
+            NotificationType.INFORMATION
+        )
+
+        notification.addAction(NotificationAction.createSimpleExpiring("Review settings") {
+            ShowSettingsUtil.getInstance().showSettingsDialog(project, SettingsConfigurable::class.java)
+        })
+
+        notification.addAction(NotificationAction.createSimpleExpiring("Read quick guide") {
+            BrowserUtil.browse(ONBOARDING_DOC_URL)
+        })
+
+        notification.notify(project)
+        properties.setValue(ONBOARDING_SHOWN_KEY, true)
+    }
+}


### PR DESCRIPTION
<img width="377" height="234" alt="Screenshot 2025-11-01 at 20 32 09" src="https://github.com/user-attachments/assets/2dea3e16-9f86-41e2-8bc3-9bf8d4121f71" />

First button opens setting

## Summary
- show a one-time onboarding notification after project startup with links to settings and quick guide
- register the activity in the plugin descriptor
- document the beginner onboarding tour steps for reference

## Testing
- ./gradlew clean build test

------
https://chatgpt.com/codex/tasks/task_e_690504b81cdc832ead59a227fb1187b4