### PR TITLE
Add folding interaction analytics listener

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,12 @@
         <!-- Application-level service that persists plugin settings -->
         <applicationService
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.analytics.FoldingInteractionCollectorService"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.analytics.FoldingInteractionStorageService"/>
+        <applicationService
+                serviceImplementation="com.intellij.advancedExpressionFolding.analytics.FoldingFeatureExtractorService"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->

--- a/src/com/intellij/advancedExpressionFolding/analytics/FoldingFeatureExtractorService.kt
+++ b/src/com/intellij/advancedExpressionFolding/analytics/FoldingFeatureExtractorService.kt
@@ -1,0 +1,33 @@
+package com.intellij.advancedExpressionFolding.analytics
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+@Service(Service.Level.APP)
+class FoldingFeatureExtractorService {
+
+    data class FoldingFeatures(
+        val elementType: String,
+        val textLength: Int,
+        val lineCount: Int,
+    )
+
+    fun extract(element: PsiElement, document: Document): FoldingFeatures {
+        val textRange = element.textRange
+        val safeEndOffset = textRange.endOffset.coerceAtMost(document.textLength)
+        val startLine = document.getLineNumber(textRange.startOffset)
+        val endLine = document.getLineNumber(safeEndOffset)
+
+        return FoldingFeatures(
+            element.node?.elementType?.toString().orEmpty(),
+            textRange.length,
+            (endLine - startLine + 1).coerceAtLeast(1),
+        )
+    }
+
+    companion object {
+        fun getInstance(): FoldingFeatureExtractorService = service()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/analytics/FoldingInteractionCollectorService.kt
+++ b/src/com/intellij/advancedExpressionFolding/analytics/FoldingInteractionCollectorService.kt
@@ -1,0 +1,123 @@
+package com.intellij.advancedExpressionFolding.analytics
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.FoldRegion
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.ProjectLocator
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import java.lang.reflect.Proxy
+
+@Service(Service.Level.APP)
+class FoldingInteractionCollectorService : Disposable {
+
+    private val foldingListener: Any?
+
+    init {
+        foldingListener = createListener()?.also { listener ->
+            addListener(listener)
+        }
+    }
+
+    private fun handleFoldRegionStateChange(region: FoldRegion) {
+        if (!region.isValid || ApplicationManager.getApplication().isUnitTestMode) {
+            return
+        }
+
+        val document = region.document
+        val virtualFile = FileDocumentManager.getInstance().getFile(document) ?: return
+        val project = ProjectLocator.getInstance().guessProjectForFile(virtualFile) ?: return
+        val psiDocumentManager = PsiDocumentManager.getInstance(project)
+        psiDocumentManager.commitDocument(document)
+        val psiFile = PsiManager.getInstance(project).findFile(virtualFile) ?: return
+
+        val element = findElement(psiFile, region) ?: return
+        val features = FoldingFeatureExtractorService.getInstance().extract(element, document)
+
+        val storage = FoldingInteractionStorageService.getInstance()
+        storage.addRecord(
+            FoldingInteractionStorageService.Record(
+                elementType = features.elementType,
+                textLength = features.textLength,
+                lineCount = features.lineCount,
+                label = if (region.isExpanded) 0 else 1,
+            ),
+        )
+    }
+
+    override fun dispose() {
+        // nothing to dispose
+    }
+
+    private fun createListener(): Any? {
+        val classLoader = EditorFactory::class.java.classLoader
+        val listenerClass = sequenceOf(
+            "com.intellij.openapi.editor.event.EditorFoldingListener",
+            "com.intellij.openapi.editor.event.FoldingListener",
+        ).mapNotNull { className ->
+            runCatching { Class.forName(className, false, classLoader) }.getOrNull()
+        }.firstOrNull() ?: return null
+
+        return Proxy.newProxyInstance(classLoader, arrayOf(listenerClass)) { _, method, args ->
+            when (method.name) {
+                "onFoldRegionStateChange" -> {
+                    val region = args?.getOrNull(0) as? FoldRegion ?: return@newProxyInstance null
+                    handleFoldRegionStateChange(region)
+                }
+                "onFoldProcessingEnd" -> {
+                    val editor = args?.getOrNull(0) as? Editor ?: return@newProxyInstance null
+                    handleFoldProcessingEnd(editor)
+                }
+            }
+            null
+        }
+    }
+
+    private fun addListener(listener: Any) {
+        val multicaster = EditorFactory.getInstance().eventMulticaster
+        val listenerClass = listener.javaClass.interfaces.firstOrNull() ?: return
+        val method = sequenceOf(
+            "addEditorFoldingListener",
+            "addFoldingListener",
+        ).mapNotNull { name ->
+            runCatching { multicaster.javaClass.getMethod(name, listenerClass, Disposable::class.java) }.getOrNull()
+        }.firstOrNull() ?: return
+
+        method.invoke(multicaster, listener, this)
+    }
+
+    private fun handleFoldProcessingEnd(@Suppress("UNUSED_PARAMETER") editor: Editor) {
+        // no-op
+    }
+
+    private fun findElement(file: PsiFile, region: FoldRegion): PsiElement? {
+        val start = region.startOffset
+        val end = (region.endOffset - 1).coerceAtLeast(start)
+        var current = file.findElementAt(start)
+
+        while (current != null) {
+            val range = current.textRange ?: break
+            if (range.containsRange(start, end)) {
+                return current
+            }
+            current = current.parent
+        }
+        return null
+    }
+
+    companion object {
+        fun getInstance(): FoldingInteractionCollectorService = service()
+    }
+}
+
+private fun com.intellij.openapi.util.TextRange.containsRange(start: Int, end: Int): Boolean {
+    if (start < 0 || end < 0) return false
+    return start >= this.startOffset && end <= this.endOffset
+}

--- a/src/com/intellij/advancedExpressionFolding/analytics/FoldingInteractionStorageService.kt
+++ b/src/com/intellij/advancedExpressionFolding/analytics/FoldingInteractionStorageService.kt
@@ -1,0 +1,52 @@
+package com.intellij.advancedExpressionFolding.analytics
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.openapi.components.service
+import com.intellij.util.xmlb.annotations.Attribute
+import com.intellij.util.xmlb.annotations.Tag
+import com.intellij.util.xmlb.annotations.XCollection
+
+@Service(Service.Level.APP)
+@State(
+    name = "AdvancedExpressionFoldingInteractionStorage",
+    storages = [Storage("advancedExpressionFoldingInteractions.xml")],
+)
+class FoldingInteractionStorageService : PersistentStateComponent<FoldingInteractionStorageService.State> {
+
+    @Tag("records")
+    data class State(
+        @XCollection(style = XCollection.Style.v2)
+        var records: MutableList<Record> = mutableListOf(),
+    )
+
+    @Tag("record")
+    data class Record(
+        @Attribute("elementType")
+        var elementType: String = "",
+        @Attribute("textLength")
+        var textLength: Int = 0,
+        @Attribute("lineCount")
+        var lineCount: Int = 0,
+        @Attribute("label")
+        var label: Int = 0,
+    )
+
+    private var state = State()
+
+    override fun getState(): State = state
+
+    override fun loadState(state: State) {
+        this.state = state
+    }
+
+    fun addRecord(record: Record) {
+        state.records.add(record)
+    }
+
+    companion object {
+        fun getInstance(): FoldingInteractionStorageService = service()
+    }
+}


### PR DESCRIPTION
## Summary
- add application-level services for extracting folding features and storing interaction records
- register a listener that uses reflection to hook into folding state changes and persist features with labels

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_6905c6a48d80832e86dbb3fd943cebc7