### PR TITLE
Move feature research docs into wiki clone

### DIFF
--- a/wiki-clone/feature-details/arithmeticExpressions.md
+++ b/wiki-clone/feature-details/arithmeticExpressions.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:25:54.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "arithmeticExpressions feature"
+tags: [research, codebase, feature, arithmeticExpressions]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: arithmeticExpressions feature
+
+**Date**: 2025-11-01T11:25:54.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `arithmeticExpressions` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds BigDecimal, BigInteger, and Math operations into infix math. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `arithmeticExpressions` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `arithmeticExpressions` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `arithmeticExpressions` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/math/AbstractMathMethodCall.kt` references `arithmeticExpressions` within `AbstractMathMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `arithmeticExpressions`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt` exercises folding behavior tied to `arithmeticExpressions`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `arithmeticExpressions`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/math/AbstractMathMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/assertsCollapse.md
+++ b/wiki-clone/feature-details/assertsCollapse.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:25:55.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "assertsCollapse feature"
+tags: [research, codebase, feature, assertsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: assertsCollapse feature
+
+**Date**: 2025-11-01T11:25:55.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `assertsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds assert statements into terse checks. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `assertsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt` defines or persists the `assertsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `assertsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt` references `assertsCollapse` within `IfExpression`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt` exercises folding behavior tied to `assertsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt` exercises folding behavior tied to `assertsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/castExpressionsCollapse.md
+++ b/wiki-clone/feature-details/castExpressionsCollapse.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:25:56.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "castExpressionsCollapse feature"
+tags: [research, codebase, feature, castExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: castExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:25:56.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `castExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds explicit type cast calls into concise Kotlin-style expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `castExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `castExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `castExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt` references `castExpressionsCollapse` within `ExpressionBuilders`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `castExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/checkExpressionsCollapse.md
+++ b/wiki-clone/feature-details/checkExpressionsCollapse.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:25:57.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "checkExpressionsCollapse feature"
+tags: [research, codebase, feature, checkExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: checkExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:25:57.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `checkExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds null checks and Elvis patterns into safe-call expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `checkExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `checkExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `checkExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt` references `checkExpressionsCollapse` within `IfExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `checkExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `checkExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/compactControlFlowSyntaxCollapse.md
+++ b/wiki-clone/feature-details/compactControlFlowSyntaxCollapse.md
@@ -1,0 +1,71 @@
+---
+date: 2025-11-01T11:25:58.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "compactControlFlowSyntaxCollapse feature"
+tags: [research, codebase, feature, compactControlFlowSyntaxCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: compactControlFlowSyntaxCollapse feature
+
+**Date**: 2025-11-01T11:25:58.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `compactControlFlowSyntaxCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds compact if/else syntax inspired by Go. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `compactControlFlowSyntaxCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt` defines or persists the `compactControlFlowSyntaxCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `compactControlFlowSyntaxCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachIndexedStatement.kt` references `compactControlFlowSyntaxCollapse` within `ForEachIndexedStatement`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt` references `compactControlFlowSyntaxCollapse` within `ForEachStatement`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt` references `compactControlFlowSyntaxCollapse` within `ForStatement`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt` references `compactControlFlowSyntaxCollapse` within `IfExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt` references `compactControlFlowSyntaxCollapse` within `ForStatementExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt` references `compactControlFlowSyntaxCollapse` within `IfExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/LoopExt.kt` references `compactControlFlowSyntaxCollapse` within `LoopExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/core/ControlFlowExpressionBuilders.kt` references `compactControlFlowSyntaxCollapse` within `ControlFlowExpressionBuilders`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt` exercises folding behavior tied to `compactControlFlowSyntaxCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachIndexedStatement.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForEachStatement.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/LoopExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/core/ControlFlowExpressionBuilders.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/comparingExpressionsCollapse.md
+++ b/wiki-clone/feature-details/comparingExpressionsCollapse.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:25:59.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "comparingExpressionsCollapse feature"
+tags: [research, codebase, feature, comparingExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: comparingExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:25:59.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `comparingExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds equals and compareTo calls into direct comparison expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `comparingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `comparingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `comparingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt` references `comparingExpressionsCollapse` within `BinaryExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt` references `comparingExpressionsCollapse` within `PrefixExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/EqualsMethodCall.kt` references `comparingExpressionsCollapse` within `EqualsMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `comparingExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/EqualsMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/comparingLocalDatesCollapse.md
+++ b/wiki-clone/feature-details/comparingLocalDatesCollapse.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:00.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "comparingLocalDatesCollapse feature"
+tags: [research, codebase, feature, comparingLocalDatesCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: comparingLocalDatesCollapse feature
+
+**Date**: 2025-11-01T11:26:00.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `comparingLocalDatesCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds java.time isBefore/isAfter checks into readable date comparisons. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `comparingLocalDatesCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt` defines or persists the `comparingLocalDatesCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `comparingLocalDatesCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt` references `comparingLocalDatesCollapse` within `PrefixExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/AfterDateMethodCall.kt` references `comparingLocalDatesCollapse` within `AfterDateMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/BeforeDateMethodCall.kt` references `comparingLocalDatesCollapse` within `BeforeDateMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt` exercises folding behavior tied to `comparingLocalDatesCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PrefixExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/AfterDateMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/BeforeDateMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/concatenationExpressionsCollapse.md
+++ b/wiki-clone/feature-details/concatenationExpressionsCollapse.md
@@ -1,0 +1,77 @@
+---
+date: 2025-11-01T11:26:01.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "concatenationExpressionsCollapse feature"
+tags: [research, codebase, feature, concatenationExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: concatenationExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:01.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `concatenationExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds StringBuilder append chains, collection add/remove calls, interpolated strings, and stream collectors into compact expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `concatenationExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `concatenationExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `concatenationExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt` references `concatenationExpressionsCollapse` within `IfExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt` references `concatenationExpressionsCollapse` within `AppendMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/CharAtMethodCall.kt` references `concatenationExpressionsCollapse` within `CharAtMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt` references `concatenationExpressionsCollapse` within `CollectionAddAllMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddMethodCall.kt` references `concatenationExpressionsCollapse` within `CollectionAddMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveAllMethodCall.kt` references `concatenationExpressionsCollapse` within `CollectionRemoveAllMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveMethodCall.kt` references `concatenationExpressionsCollapse` within `CollectionRemoveMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionStreamMethodCall.kt` references `concatenationExpressionsCollapse` within `CollectionStreamMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamCollectMethodCall.kt` references `concatenationExpressionsCollapse` within `StreamCollectMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMethodCall.kt` references `concatenationExpressionsCollapse` within `StreamMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt` exercises folding behavior tied to `concatenationExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `concatenationExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/IfExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/AppendMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/CharAtMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddAllMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionAddMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveAllMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionRemoveMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionStreamMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamCollectMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/StreamMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/const.md
+++ b/wiki-clone/feature-details/const.md
@@ -1,0 +1,115 @@
+---
+date: 2025-11-01T11:26:02.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "const feature"
+tags: [research, codebase, feature, const]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: const feature
+
+**Date**: 2025-11-01T11:26:02.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `const` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds static final fields into Kotlin-style const declarations. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `const` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `const` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `const` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt` defines or persists the `const` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/EditorExtensions.kt` references `const` within `EditorExtensions`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/diff/DiffFoldingTemporaryEditor.kt` references `const` within `DiffFoldingTemporaryEditor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/Expression.kt` references `const` within `Expression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt` references `const` within `ForStatement`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt` references `const` within `LocalDateLiteral`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/collection/Range.kt` references `const` within `Range`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/kotlin/FieldConstExpression.kt` references `const` within `FieldConstExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt` references `const` within `Keys`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt` references `const` within `PsiFieldExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt` references `const` within `FieldShiftExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/ConstExt.kt` references `const` within `ConstExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt` references `const` within `LombokConstructorExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt` references `const` within `LombokExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokPostConstructorExt.kt` references `const` within `LombokPostConstructorExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt` references `const` within `MethodCallFactory`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/reference/ReferenceExpressionExt.kt` references `const` within `ReferenceExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt` references `const` within `AbstractLoggingAnnotationCompletionContributor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt` references `const` within `LoggableAnnotationCompletionContributor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt` references `const` within `MainAnnotationCompletionContributor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt` references `const` within `TracingLoggableAnnotationCompletionContributor`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt` exercises folding behavior tied to `const`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `const`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `const`.
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt` exercises folding behavior tied to `const`.
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt` exercises folding behavior tied to `const`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `const`.
+- `examples/data/EmojifyTestData.java` provides example input demonstrating `const`.
+- `folded/ConstTestData-folded.java` shows folded output illustrating `const`.
+- `folded/ConstructorReferenceNotationWithConstTestData-folded.java` shows folded output illustrating `const`.
+- `folded/EmojifyTestData-folded.java` shows folded output illustrating `const`.
+
+## Code References
+- `examples/data/EmojifyTestData.java`
+- `folded/ConstTestData-folded.java`
+- `folded/ConstructorReferenceNotationWithConstTestData-folded.java`
+- `folded/EmojifyTestData-folded.java`
+- `src/com/intellij/advancedExpressionFolding/EditorExtensions.kt`
+- `src/com/intellij/advancedExpressionFolding/diff/DiffFoldingTemporaryEditor.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/Expression.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/ForStatement.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/collection/Range.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/kotlin/FieldConstExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/cache/Keys.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/ConstExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokPostConstructorExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/reference/ReferenceExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/constructorReferenceNotation.md
+++ b/wiki-clone/feature-details/constructorReferenceNotation.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:03.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "constructorReferenceNotation feature"
+tags: [research, codebase, feature, constructorReferenceNotation]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: constructorReferenceNotation feature
+
+**Date**: 2025-11-01T11:26:03.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `constructorReferenceNotation` feature behave within Advanced Expression Folding?
+
+## Summary
+Simplifies constructor references and inline field initialization. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `constructorReferenceNotation` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `constructorReferenceNotation` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `constructorReferenceNotation` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt` references `constructorReferenceNotation` within `PsiFieldExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `constructorReferenceNotation`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `constructorReferenceNotation`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/controlFlowMultiStatementCodeBlockCollapse.md
+++ b/wiki-clone/feature-details/controlFlowMultiStatementCodeBlockCollapse.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:26:04.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "controlFlowMultiStatementCodeBlockCollapse feature"
+tags: [research, codebase, feature, controlFlowMultiStatementCodeBlockCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: controlFlowMultiStatementCodeBlockCollapse feature
+
+**Date**: 2025-11-01T11:26:04.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `controlFlowMultiStatementCodeBlockCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds multi-statement control-flow braces in read-only files. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `controlFlowMultiStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt` defines or persists the `controlFlowMultiStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `controlFlowMultiStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiCodeBlockExt.kt` references `controlFlowMultiStatementCodeBlockCollapse` within `PsiCodeBlockExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt` exercises folding behavior tied to `controlFlowMultiStatementCodeBlockCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiCodeBlockExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/controlFlowSingleStatementCodeBlockCollapse.md
+++ b/wiki-clone/feature-details/controlFlowSingleStatementCodeBlockCollapse.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:26:05.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "controlFlowSingleStatementCodeBlockCollapse feature"
+tags: [research, codebase, feature, controlFlowSingleStatementCodeBlockCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: controlFlowSingleStatementCodeBlockCollapse feature
+
+**Date**: 2025-11-01T11:26:05.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `controlFlowSingleStatementCodeBlockCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds single-statement control-flow braces in read-only files. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `controlFlowSingleStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt` defines or persists the `controlFlowSingleStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `controlFlowSingleStatementCodeBlockCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiCodeBlockExt.kt` references `controlFlowSingleStatementCodeBlockCollapse` within `PsiCodeBlockExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt` exercises folding behavior tied to `controlFlowSingleStatementCodeBlockCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiCodeBlockExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ControlFlowState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ControlFlowFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/destructuring.md
+++ b/wiki-clone/feature-details/destructuring.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:06.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "destructuring feature"
+tags: [research, codebase, feature, destructuring]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: destructuring feature
+
+**Date**: 2025-11-01T11:26:06.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `destructuring` feature behave within Advanced Expression Folding?
+
+## Summary
+![Array destructuring without var/val folded inline](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/3391702f-8632-4539-9e81-60f52f7ee006) Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `destructuring` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `destructuring` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `destructuring` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt` references `destructuring` within `PsiDeclarationStatementExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `destructuring`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt` exercises folding behavior tied to `destructuring`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `destructuring`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/dynamic.md
+++ b/wiki-clone/feature-details/dynamic.md
@@ -1,0 +1,85 @@
+---
+date: 2025-11-01T11:26:07.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "dynamic feature"
+tags: [research, codebase, feature, dynamic]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: dynamic feature
+
+**Date**: 2025-11-01T11:26:07.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `dynamic` feature behave within Advanced Expression Folding?
+
+## Summary
+Applies dynamic naming to methods based on a configuration file. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `dynamic` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt` defines or persists the `dynamic` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `dynamic` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `dynamic` within `PsiMethodExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt` references `dynamic` within `MethodCallFactory`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt` references `dynamic` within `AddDynamicMethodFoldingIntention`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt` references `dynamic` within `ConfigurationParser`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt` references `dynamic` within `DynamicDialog`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicExt.kt` references `dynamic` within `DynamicExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCall.kt` references `dynamic` within `DynamicMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt` references `dynamic` within `DynamicMethodCallData`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt` references `dynamic` within `IDynamicDataProvider`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/FoldingTestState.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/folding/util/TestDynamicDataProvider.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `dynamic`.
+- `test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt` exercises folding behavior tied to `dynamic`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallFactory.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/AddDynamicMethodFoldingIntention.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParser.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicDialog.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/IDynamicDataProvider.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/BaseTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/FoldingTestState.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/util/TestDynamicDataProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+- `test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/emojify.md
+++ b/wiki-clone/feature-details/emojify.md
@@ -1,0 +1,63 @@
+---
+date: 2025-11-01T11:26:08.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "emojify feature"
+tags: [research, codebase, feature, emojify]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: emojify feature
+
+**Date**: 2025-11-01T11:26:08.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `emojify` feature behave within Advanced Expression Folding?
+
+## Summary
+Replaces select syntax elements with emoji equivalents. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `emojify` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt` defines or persists the `emojify` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `emojify` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt` references `emojify` within `ExperimentalExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt` references `emojify` within `PsiJavaTokenExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt` exercises folding behavior tied to `emojify`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt` exercises folding behavior tied to `emojify`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `emojify`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/language/ExperimentalExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiJavaTokenExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/experimental.md
+++ b/wiki-clone/feature-details/experimental.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:09.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "experimental feature"
+tags: [research, codebase, feature, experimental]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: experimental feature
+
+**Date**: 2025-11-01T11:26:09.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `experimental` feature behave within Advanced Expression Folding?
+
+## Summary
+Enables experimental folding prototypes. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `experimental` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt` defines or persists the `experimental` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `experimental` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt` references `experimental` within `PsiTryStatementExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt` references `experimental` within `MethodCallExpressionExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `experimental`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `experimental`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/expressionFunc.md
+++ b/wiki-clone/feature-details/expressionFunc.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:10.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "expressionFunc feature"
+tags: [research, codebase, feature, expressionFunc]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: expressionFunc feature
+
+**Date**: 2025-11-01T11:26:10.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `expressionFunc` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds single-expression methods into expression-bodied functions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `expressionFunc` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `expressionFunc` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `expressionFunc` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `expressionFunc` within `PsiMethodExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `expressionFunc`.
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt` exercises folding behavior tied to `expressionFunc`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `expressionFunc`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/feature-settings-overview.md
+++ b/wiki-clone/feature-details/feature-settings-overview.md
@@ -1,0 +1,42 @@
+---
+date: 2025-11-01T11:26:11.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "feature-settings-overview feature"
+tags: [research, codebase, feature, feature-settings-overview]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: feature-settings-overview feature
+
+**Date**: 2025-11-01T11:26:11.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `feature-settings-overview` feature behave within Advanced Expression Folding?
+
+## Summary
+![New Advanced Expression Folding settings panel](https://github.com/user-attachments/assets/45e0d314-d19f-4c06-96a8-3d6555d8ca4a) Default state value: `unspecified`.
+
+## Detailed Findings
+## Code References
+- None
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/fieldShift.md
+++ b/wiki-clone/feature-details/fieldShift.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:12.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "fieldShift feature"
+tags: [research, codebase, feature, fieldShift]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: fieldShift feature
+
+**Date**: 2025-11-01T11:26:12.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `fieldShift` feature behave within Advanced Expression Folding?
+
+## Summary
+[video](https://youtu.be/qANBuozPpvM) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `fieldShift` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `fieldShift` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `fieldShift` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt` references `fieldShift` within `FieldShiftExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `fieldShift`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `fieldShift`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `fieldShift`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/language/FieldShiftExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/finalEmoji.md
+++ b/wiki-clone/feature-details/finalEmoji.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:13.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "finalEmoji feature"
+tags: [research, codebase, feature, finalEmoji]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: finalEmoji feature
+
+**Date**: 2025-11-01T11:26:13.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `finalEmoji` feature behave within Advanced Expression Folding?
+
+## Summary
+Replaces final modifiers with lock emoji markers. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `finalEmoji` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt` defines or persists the `finalEmoji` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `finalEmoji` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt` references `finalEmoji` within `PsiKeywordExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt` exercises folding behavior tied to `finalEmoji`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt` exercises folding behavior tied to `finalEmoji`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `finalEmoji`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/finalRemoval.md
+++ b/wiki-clone/feature-details/finalRemoval.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:14.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "finalRemoval feature"
+tags: [research, codebase, feature, finalRemoval]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: finalRemoval feature
+
+**Date**: 2025-11-01T11:26:14.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `finalRemoval` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds the final modifier away from non-field declarations. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `finalRemoval` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt` defines or persists the `finalRemoval` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `finalRemoval` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt` references `finalRemoval` within `PsiKeywordExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt` exercises folding behavior tied to `finalRemoval`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `finalRemoval`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/token/PsiKeywordExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/EmojiVisibilityState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/EmojiVisibilityFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/getExpressionsCollapse.md
+++ b/wiki-clone/feature-details/getExpressionsCollapse.md
@@ -1,0 +1,73 @@
+---
+date: 2025-11-01T11:26:15.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "getExpressionsCollapse feature"
+tags: [research, codebase, feature, getExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: getExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:15.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `getExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds collection access and literal builders into indexed or map-style expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `getExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `getExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `getExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt` references `getExpressionsCollapse` within `ExpressionBuilders`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PsiArrayAccessExpressionExt.kt` references `getExpressionsCollapse` within `PsiArrayAccessExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/ArraysListMethodCall.kt` references `getExpressionsCollapse` within `ArraysListMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionGetMethodCall.kt` references `getExpressionsCollapse` within `CollectionGetMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableListMethodCall.kt` references `getExpressionsCollapse` within `CollectionsUnmodifiableListMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableSetMethodCall.kt` references `getExpressionsCollapse` within `CollectionsUnmodifiableSetMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt` references `getExpressionsCollapse` within `MapPutMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt` references `getExpressionsCollapse` within `NewExpressionExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `getExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `getExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/expression/PsiArrayAccessExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/ArraysListMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionGetMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableListMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/CollectionsUnmodifiableSetMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/collection/MapPutMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/reference/NewExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/getSetExpressionsCollapse.md
+++ b/wiki-clone/feature-details/getSetExpressionsCollapse.md
@@ -1,0 +1,63 @@
+---
+date: 2025-11-01T11:26:16.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "getSetExpressionsCollapse feature"
+tags: [research, codebase, feature, getSetExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: getSetExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:16.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `getSetExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds Java getter and setter calls into property-style access. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `getSetExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `getSetExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `getSetExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt` references `getSetExpressionsCollapse` within `MethodCallExpressionExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `getSetExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `getSetExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `getSetExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt` exercises folding behavior tied to `getSetExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/MethodCallExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/globalOn.md
+++ b/wiki-clone/feature-details/globalOn.md
@@ -1,0 +1,67 @@
+---
+date: 2025-11-01T11:26:17.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "globalOn feature"
+tags: [research, codebase, feature, globalOn]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: globalOn feature
+
+**Date**: 2025-11-01T11:26:17.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `globalOn` feature behave within Advanced Expression Folding?
+
+## Summary
+![Keymap actions configured for folding and unfolding](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/35863f50-d441-4402-8172-db6e75962350) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `globalOn` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt` defines or persists the `globalOn` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/IConfig.kt` defines or persists the `globalOn` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt` references `globalOn` within `AdvancedExpressionFoldingBuilder`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/action/FoldingOnAction.kt` references `globalOn` within `FoldingOnAction`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/action/GlobalToggleFoldingAction.kt` references `globalOn` within `GlobalToggleFoldingAction`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt` exercises folding behavior tied to `globalOn`.
+- `test/com/intellij/advancedExpressionFolding/unit/FoldingActionsTest.kt` exercises folding behavior tied to `globalOn`.
+- `test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt` exercises folding behavior tied to `globalOn`.
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt` exercises folding behavior tied to `globalOn`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt`
+- `src/com/intellij/advancedExpressionFolding/action/FoldingOnAction.kt`
+- `src/com/intellij/advancedExpressionFolding/action/GlobalToggleFoldingAction.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/IConfig.kt`
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/FoldingActionsTest.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/ifNullSafe.md
+++ b/wiki-clone/feature-details/ifNullSafe.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:18.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "ifNullSafe feature"
+tags: [research, codebase, feature, ifNullSafe]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: ifNullSafe feature
+
+**Date**: 2025-11-01T11:26:18.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `ifNullSafe` feature behave within Advanced Expression Folding?
+
+## Summary
+[video](https://www.youtube.com/watch?v=zvpvhn7ISAw) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `ifNullSafe` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `ifNullSafe` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `ifNullSafe` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt` references `ifNullSafe` within `IfNullSafeExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafePrintlnExt.kt` references `ifNullSafe` within `IfNullSafePrintlnExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `ifNullSafe`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `ifNullSafe`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafeExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafePrintlnExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/interfaceExtensionProperties.md
+++ b/wiki-clone/feature-details/interfaceExtensionProperties.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:19.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "interfaceExtensionProperties feature"
+tags: [research, codebase, feature, interfaceExtensionProperties]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: interfaceExtensionProperties feature
+
+**Date**: 2025-11-01T11:26:19.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `interfaceExtensionProperties` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds interface getters and setters into Kotlin extension properties. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `interfaceExtensionProperties` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt` defines or persists the `interfaceExtensionProperties` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `interfaceExtensionProperties` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `interfaceExtensionProperties` within `PsiMethodExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt` references `interfaceExtensionProperties` within `InterfacePropertiesExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt` exercises folding behavior tied to `interfaceExtensionProperties`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `interfaceExtensionProperties`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/kotlinQuickReturn.md
+++ b/wiki-clone/feature-details/kotlinQuickReturn.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:26:20.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "kotlinQuickReturn feature"
+tags: [research, codebase, feature, kotlinQuickReturn]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: kotlinQuickReturn feature
+
+**Date**: 2025-11-01T11:26:20.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `kotlinQuickReturn` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds Kotlin let/return idioms into quick-return expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `kotlinQuickReturn` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `kotlinQuickReturn` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `kotlinQuickReturn` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/LetReturnExt.kt` references `kotlinQuickReturn` within `LetReturnExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `kotlinQuickReturn`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/LetReturnExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/localDateLiteralCollapse.md
+++ b/wiki-clone/feature-details/localDateLiteralCollapse.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:26:21.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "localDateLiteralCollapse feature"
+tags: [research, codebase, feature, localDateLiteralCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: localDateLiteralCollapse feature
+
+**Date**: 2025-11-01T11:26:21.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `localDateLiteralCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds LocalDate.of(...) literals into inline YYYY-MM-DD forms. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `localDateLiteralCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt` defines or persists the `localDateLiteralCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `localDateLiteralCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt` references `localDateLiteralCollapse` within `CreateDateFactoryMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt` exercises folding behavior tied to `localDateLiteralCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/localDateLiteralPostfixCollapse.md
+++ b/wiki-clone/feature-details/localDateLiteralPostfixCollapse.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:22.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "localDateLiteralPostfixCollapse feature"
+tags: [research, codebase, feature, localDateLiteralPostfixCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: localDateLiteralPostfixCollapse feature
+
+**Date**: 2025-11-01T11:26:22.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `localDateLiteralPostfixCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds postfix LocalDate literals such as 2018Y-02M-12D. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `localDateLiteralPostfixCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt` defines or persists the `localDateLiteralPostfixCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `localDateLiteralPostfixCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt` references `localDateLiteralPostfixCollapse` within `LocalDateLiteral`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt` references `localDateLiteralPostfixCollapse` within `CreateDateFactoryMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt` exercises folding behavior tied to `localDateLiteralPostfixCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/expression/literal/LocalDateLiteral.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/date/CreateDateFactoryMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/DateOperationsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/DateOperationsFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/logFolding.md
+++ b/wiki-clone/feature-details/logFolding.md
@@ -1,0 +1,63 @@
+---
+date: 2025-11-01T11:26:23.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "logFolding feature"
+tags: [research, codebase, feature, logFolding]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: logFolding feature
+
+**Date**: 2025-11-01T11:26:23.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `logFolding` feature behave within Advanced Expression Folding?
+
+## Summary
+![Log statement before folding its bracketed payload](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/948c1f47-9185-4b7c-a8d0-d72f3d064fa5) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `logFolding` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LogFoldingState.kt` defines or persists the `logFolding` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/NewState.kt` defines or persists the `logFolding` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `logFolding` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt` references `logFolding` within `LiteralExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt` references `logFolding` within `LoggerBracketsExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt` references `logFolding` within `LoggerBracketsExtensionBase`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt` exercises folding behavior tied to `logFolding`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LogFoldingState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/NewState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/logFoldingTextBlocks.md
+++ b/wiki-clone/feature-details/logFoldingTextBlocks.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:24.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "logFoldingTextBlocks feature"
+tags: [research, codebase, feature, logFoldingTextBlocks]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: logFoldingTextBlocks feature
+
+**Date**: 2025-11-01T11:26:24.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `logFoldingTextBlocks` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds log Text Blocks into compact placeholders. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `logFoldingTextBlocks` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LogFoldingState.kt` defines or persists the `logFoldingTextBlocks` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `logFoldingTextBlocks` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt` references `logFoldingTextBlocks` within `LiteralExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt` references `logFoldingTextBlocks` within `LoggerBracketsExtensionBase`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt` exercises folding behavior tied to `logFoldingTextBlocks`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/expression/LiteralExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/logger/LoggerBracketsExtensionBase.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LogFoldingState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LogFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/lombok.md
+++ b/wiki-clone/feature-details/lombok.md
@@ -1,0 +1,125 @@
+---
+date: 2025-11-01T11:26:25.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "lombok feature"
+tags: [research, codebase, feature, lombok]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: lombok feature
+
+**Date**: 2025-11-01T11:26:25.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `lombok` feature behave within Advanced Expression Folding?
+
+## Summary
+![Animated overview of Lombok folding support](https://github.com/user-attachments/assets/7d2bdcf7-15ad-45a2-9aad-1f596443c4d7) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `lombok` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt` defines or persists the `lombok` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/NewState.kt` defines or persists the `lombok` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `lombok` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/ClassAnnotationExpression.kt` references `lombok` within `ClassAnnotationExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/FieldAnnotationExpression.kt` references `lombok` within `FieldAnnotationExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/InterfacePropertiesExpression.kt` references `lombok` within `InterfacePropertiesExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/MethodAnnotationExpression.kt` references `lombok` within `MethodAnnotationExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/NullAnnotationExpression.kt` references `lombok` within `NullAnnotationExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt` references `lombok` within `PsiTryStatementExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt` references `lombok` within `PsiClassExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt` references `lombok` within `PsiFieldExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `lombok` within `PsiMethodExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt` references `lombok` within `NullableExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt` references `lombok` within `AnnotationExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/FieldLevelAnnotation.kt` references `lombok` within `FieldLevelAnnotation`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt` references `lombok` within `InterfacePropertiesExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt` references `lombok` within `LombokConstructorExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt` references `lombok` within `LombokExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt` references `lombok` within `LombokFieldExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFoldingAnnotation.kt` references `lombok` within `LombokFoldingAnnotation`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokMethodExt.kt` references `lombok` within `LombokMethodExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokPostConstructorExt.kt` references `lombok` within `LombokPostConstructorExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/MethodBodyInspector.kt` references `lombok` within `MethodBodyInspector`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/MethodType.kt` references `lombok` within `MethodType`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt` references `lombok` within `SummaryParentOverrideExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `lombok`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `lombok`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt` exercises folding behavior tied to `lombok`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt` exercises folding behavior tied to `lombok`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `lombok`.
+- `examples/build.gradle.kts` provides example input demonstrating `lombok`.
+- `examples/data/LombokPatternOffNegativeTestData.java` provides example input demonstrating `lombok`.
+- `examples/data/LombokPatternOffTestData.java` provides example input demonstrating `lombok`.
+- `examples/data/LombokTestData.java` provides example input demonstrating `lombok`.
+- `examples/gradle/libs.versions.toml` provides example input demonstrating `lombok`.
+- `folded/LombokPatternOffNegativeTestData-folded.java` shows folded output illustrating `lombok`.
+- `folded/LombokPatternOffTestData-folded.java` shows folded output illustrating `lombok`.
+- `folded/LombokTestData-folded.java` shows folded output illustrating `lombok`.
+
+## Code References
+- `examples/build.gradle.kts`
+- `examples/data/LombokPatternOffNegativeTestData.java`
+- `examples/data/LombokPatternOffTestData.java`
+- `examples/data/LombokTestData.java`
+- `examples/gradle/libs.versions.toml`
+- `folded/LombokPatternOffNegativeTestData-folded.java`
+- `folded/LombokPatternOffTestData-folded.java`
+- `folded/LombokTestData-folded.java`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/ClassAnnotationExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/FieldAnnotationExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/InterfacePropertiesExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/MethodAnnotationExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/semantic/lombok/NullAnnotationExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/PsiTryStatementExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/FieldLevelAnnotation.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokConstructorExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFoldingAnnotation.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokPostConstructorExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/MethodBodyInspector.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/MethodType.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/SummaryParentOverrideExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/NewState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/full/FullFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/lombokDirtyOff.md
+++ b/wiki-clone/feature-details/lombokDirtyOff.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:26.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "lombokDirtyOff feature"
+tags: [research, codebase, feature, lombokDirtyOff]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: lombokDirtyOff feature
+
+**Date**: 2025-11-01T11:26:26.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `lombokDirtyOff` feature behave within Advanced Expression Folding?
+
+## Summary
+Skips folding Lombok accessors marked as dirty. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `lombokDirtyOff` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt` defines or persists the `lombokDirtyOff` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `lombokDirtyOff` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt` references `lombokDirtyOff` within `LombokFieldExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt` exercises folding behavior tied to `lombokDirtyOff`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `lombokDirtyOff`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/LombokFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/lombokPatternOff.md
+++ b/wiki-clone/feature-details/lombokPatternOff.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:27.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "lombokPatternOff feature"
+tags: [research, codebase, feature, lombokPatternOff]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: lombokPatternOff feature
+
+**Date**: 2025-11-01T11:26:27.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `lombokPatternOff` feature behave within Advanced Expression Folding?
+
+## Summary
+Uses a regex to disable Lombok folding for matching classes. Default state value: `unspecified`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `lombokPatternOff` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt` defines or persists the `lombokPatternOff` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `lombokPatternOff` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt` references `lombokPatternOff` within `AnnotationExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt` exercises folding behavior tied to `lombokPatternOff`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `lombokPatternOff`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/AnnotationExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/memoryImprovement.md
+++ b/wiki-clone/feature-details/memoryImprovement.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:28.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "memoryImprovement feature"
+tags: [research, codebase, feature, memoryImprovement]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: memoryImprovement feature
+
+**Date**: 2025-11-01T11:26:28.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `memoryImprovement` feature behave within Advanced Expression Folding?
+
+## Summary
+* only for files in **testData** folder Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `memoryImprovement` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt` defines or persists the `memoryImprovement` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/IConfig.kt` defines or persists the `memoryImprovement` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `memoryImprovement` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt` references `memoryImprovement` within `AdvancedExpressionFoldingBuilder`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt` exercises folding behavior tied to `memoryImprovement`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/IConfig.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/methodDefaultParameters.md
+++ b/wiki-clone/feature-details/methodDefaultParameters.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:29.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "methodDefaultParameters feature"
+tags: [research, codebase, feature, methodDefaultParameters]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: methodDefaultParameters feature
+
+**Date**: 2025-11-01T11:26:29.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `methodDefaultParameters` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds overloads into default-parameter annotations. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `methodDefaultParameters` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `methodDefaultParameters` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `methodDefaultParameters` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt` references `methodDefaultParameters` within `PsiClassExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `methodDefaultParameters`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `methodDefaultParameters`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/nullable.md
+++ b/wiki-clone/feature-details/nullable.md
@@ -1,0 +1,73 @@
+---
+date: 2025-11-01T11:26:30.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "nullable feature"
+tags: [research, codebase, feature, nullable]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: nullable feature
+
+**Date**: 2025-11-01T11:26:30.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `nullable` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds nullability annotations into ? and !! markers. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `nullable` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `nullable` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `nullable` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt` references `nullable` within `PsiFieldExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt` references `nullable` within `NullableExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt` references `nullable` within `InterfacePropertiesExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt` references `nullable` within `CheckNotNullMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt` exercises folding behavior tied to `nullable`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `nullable`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt` exercises folding behavior tied to `nullable`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `nullable`.
+- `examples/data/InterfaceExtensionPropertiesTestData.java` provides example input demonstrating `nullable`.
+- `folded/InterfaceExtensionPropertiesTestData-folded.java` shows folded output illustrating `nullable`.
+
+## Code References
+- `examples/data/InterfaceExtensionPropertiesTestData.java`
+- `folded/InterfaceExtensionPropertiesTestData-folded.java`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiFieldExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/NullableExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/lombok/InterfacePropertiesExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/nullable/CheckNotNullMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/GlobalSettingsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/LombokFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/optional.md
+++ b/wiki-clone/feature-details/optional.md
@@ -1,0 +1,93 @@
+---
+date: 2025-11-01T11:26:31.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "optional feature"
+tags: [research, codebase, feature, optional]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: optional feature
+
+**Date**: 2025-11-01T11:26:31.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `optional` feature behave within Advanced Expression Folding?
+
+## Summary
+Displays java.util.Optional flows as Kotlin-style null-safe chains. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `optional` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/CollectionsStreamsState.kt` defines or persists the `optional` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `optional` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapCall.kt` references `optional` within `OptionalMapCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCall.kt` references `optional` within `OptionalMapSafeCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCallParam.kt` references `optional` within `OptionalMapSafeCallParam`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt` references `optional` within `OptionalNotNullAssertionGet`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOf.kt` references `optional` within `OptionalOf`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOfNullable.kt` references `optional` within `OptionalOfNullable`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOrElseElvis.kt` references `optional` within `OptionalOrElseElvis`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/AbstractOptionalMethodCall.kt` references `optional` within `AbstractOptionalMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalGetMethodCall.kt` references `optional` within `OptionalGetMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalMapMethodCall.kt` references `optional` within `OptionalMapMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfMethodCall.kt` references `optional` within `OptionalOfMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfNullableMethodCall.kt` references `optional` within `OptionalOfNullableMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOrElseMethodCall.kt` references `optional` within `OptionalOrElseMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt` references `optional` within `MethodReferenceExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt` exercises folding behavior tied to `optional`.
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt` exercises folding behavior tied to `optional`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `optional`.
+- `test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt` exercises folding behavior tied to `optional`.
+- `examples/data/EmojifyTestData.java` provides example input demonstrating `optional`.
+- `folded/EmojifyTestData-folded.java` shows folded output illustrating `optional`.
+
+## Code References
+- `examples/data/EmojifyTestData.java`
+- `folded/EmojifyTestData-folded.java`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapCall.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCall.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalMapSafeCallParam.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalNotNullAssertionGet.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOf.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOfNullable.kt`
+- `src/com/intellij/advancedExpressionFolding/expression/operation/optional/OptionalOrElseElvis.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/AbstractOptionalMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalGetMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalMapMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOfNullableMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/optional/OptionalOrElseMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/CollectionsStreamsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+- `test/com/intellij/advancedExpressionFolding/unit/PlaceholderFoldingBuilderTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/overrideHide.md
+++ b/wiki-clone/feature-details/overrideHide.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:32.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "overrideHide feature"
+tags: [research, codebase, feature, overrideHide]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: overrideHide feature
+
+**Date**: 2025-11-01T11:26:32.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `overrideHide` feature behave within Advanced Expression Folding?
+
+## Summary
+Hides @Override annotations from view. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `overrideHide` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt` defines or persists the `overrideHide` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `overrideHide` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `overrideHide` within `PsiMethodExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt` exercises folding behavior tied to `overrideHide`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `overrideHide`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/patternMatchingInstanceof.md
+++ b/wiki-clone/feature-details/patternMatchingInstanceof.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:33.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "patternMatchingInstanceof feature"
+tags: [research, codebase, feature, patternMatchingInstanceof]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: patternMatchingInstanceof feature
+
+**Date**: 2025-11-01T11:26:33.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `patternMatchingInstanceof` feature behave within Advanced Expression Folding?
+
+## Summary
+Applies pattern matching to `instanceof` checks for more concise and readable code. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `patternMatchingInstanceof` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `patternMatchingInstanceof` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `patternMatchingInstanceof` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt` references `patternMatchingInstanceof` within `IfExpression`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `patternMatchingInstanceof`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `patternMatchingInstanceof`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/println.md
+++ b/wiki-clone/feature-details/println.md
@@ -1,0 +1,213 @@
+---
+date: 2025-11-01T11:26:34.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "println feature"
+tags: [research, codebase, feature, println]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: println feature
+
+**Date**: 2025-11-01T11:26:34.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `println` feature behave within Advanced Expression Folding?
+
+## Summary
+![System.out.println call folded to println](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/assets/3055326/75a5224f-7b52-4b71-9774-2814e8a867ba) Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `println` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt` defines or persists the `println` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `println` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafePrintlnExt.kt` references `println` within `IfNullSafePrintlnExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt` references `println` within `PrintlnExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/PrintlnMethodCall.kt` references `println` within `PrintlnMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/util/CodeGenerationUtil.kt` references `println` within `CodeGenerationUtil`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt` references `println` within `LoggableAnnotationCompletionContributor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt` references `println` within `MainAnnotationCompletionContributor`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/folding/crazy/CrazyFoldingTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/folding/util/FoldingDataStorage.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/folding/util/GitUtils.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/performance/PerformanceTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `println`.
+- `test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `println`.
+- `examples/data/AppendSetterInterpolatedStringTestData.java` provides example input demonstrating `println`.
+- `examples/data/CompactControlFlowTestData.java` provides example input demonstrating `println`.
+- `examples/data/ConcatenationTestData.java` provides example input demonstrating `println`.
+- `examples/data/ControlFlowMultiStatementTestData.java` provides example input demonstrating `println`.
+- `examples/data/ControlFlowSingleStatementTestData.java` provides example input demonstrating `println`.
+- `examples/data/DynamicTestData.java` provides example input demonstrating `println`.
+- `examples/data/ElvisTestData.java` provides example input demonstrating `println`.
+- `examples/data/EmojifyTestData.java` provides example input demonstrating `println`.
+- `examples/data/EqualsCompareTestData.java` provides example input demonstrating `println`.
+- `examples/data/ExperimentalTestData.java` provides example input demonstrating `println`.
+- `examples/data/ForRangeTestData.java` provides example input demonstrating `println`.
+- `examples/data/GetSetPutTestData.java` provides example input demonstrating `println`.
+- `examples/data/GetterSetterTestData.java` provides example input demonstrating `println`.
+- `examples/data/IfNullSafeData.java` provides example input demonstrating `println`.
+- `examples/data/InterpolatedStringTestData.java` provides example input demonstrating `println`.
+- `examples/data/LetReturnIt.java` provides example input demonstrating `println`.
+- `examples/data/LogBrackets.java` provides example input demonstrating `println`.
+- `examples/data/LogFoldingTextBlocksTestData.java` provides example input demonstrating `println`.
+- `examples/data/NullableAnnotationCheckNotNullTestData.java` provides example input demonstrating `println`.
+- `examples/data/OverrideHideTestData.java` provides example input demonstrating `println`.
+- `examples/data/PatternMatchingInstanceofTestData.java` provides example input demonstrating `println`.
+- `examples/data/PatternMatchingRecordPatternEdgeCasesTestData.java` provides example input demonstrating `println`.
+- `examples/data/PatternMatchingRecordPatternTestData.java` provides example input demonstrating `println`.
+- `examples/data/PrintlnTestData.java` provides example input demonstrating `println`.
+- `examples/data/PseudoAnnotationsLoggableTestData.java` provides example input demonstrating `println`.
+- `examples/data/SemicolonTestData.java` provides example input demonstrating `println`.
+- `examples/data/SliceTestData.java` provides example input demonstrating `println`.
+- `examples/data/StringBuilderTestData.java` provides example input demonstrating `println`.
+- `examples/data/SummaryParentOverrideTestData.java` provides example input demonstrating `println`.
+- `examples/data/SuppressWarningsHideTestData.java` provides example input demonstrating `println`.
+- `examples/data/TypeCastTestData.java` provides example input demonstrating `println`.
+- `examples/data/VarTestData.java` provides example input demonstrating `println`.
+- `folded/AppendSetterInterpolatedStringTestData-folded.java` shows folded output illustrating `println`.
+- `folded/CompactControlFlowTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ConcatenationTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ControlFlowMultiStatementTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ControlFlowSingleStatementTestData-folded.java` shows folded output illustrating `println`.
+- `folded/DynamicTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ElvisTestData-folded.java` shows folded output illustrating `println`.
+- `folded/EmojifyTestData-folded.java` shows folded output illustrating `println`.
+- `folded/EqualsCompareTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ExperimentalTestData-folded.java` shows folded output illustrating `println`.
+- `folded/ForRangeTestData-folded.java` shows folded output illustrating `println`.
+- `folded/GetSetPutTestData-folded.java` shows folded output illustrating `println`.
+- `folded/GetterSetterTestData-folded.java` shows folded output illustrating `println`.
+- `folded/IfNullSafeData-folded.java` shows folded output illustrating `println`.
+- `folded/InterpolatedStringTestData-folded.java` shows folded output illustrating `println`.
+- `folded/LetReturnIt-folded.java` shows folded output illustrating `println`.
+- `folded/LogBrackets-folded.java` shows folded output illustrating `println`.
+- `folded/LogFoldingTextBlocksTestData-folded.java` shows folded output illustrating `println`.
+- `folded/NullableAnnotationCheckNotNullTestData-folded.java` shows folded output illustrating `println`.
+- `folded/OverrideHideTestData-folded.java` shows folded output illustrating `println`.
+- `folded/PatternMatchingInstanceofTestData-folded.java` shows folded output illustrating `println`.
+- `folded/PatternMatchingRecordPatternEdgeCasesTestData-folded.java` shows folded output illustrating `println`.
+- `folded/PatternMatchingRecordPatternTestData-folded.java` shows folded output illustrating `println`.
+- `folded/PrintlnTestData-folded.java` shows folded output illustrating `println`.
+- `folded/SemicolonTestData-folded.java` shows folded output illustrating `println`.
+- `folded/SliceTestData-folded.java` shows folded output illustrating `println`.
+- `folded/StringBuilderTestData-folded.java` shows folded output illustrating `println`.
+- `folded/SummaryParentOverrideTestData-folded.java` shows folded output illustrating `println`.
+- `folded/SuppressWarningsHideTestData-folded.java` shows folded output illustrating `println`.
+- `folded/TypeCastTestData-folded.java` shows folded output illustrating `println`.
+- `folded/VarTestData-folded.java` shows folded output illustrating `println`.
+
+## Code References
+- `examples/data/AppendSetterInterpolatedStringTestData.java`
+- `examples/data/CompactControlFlowTestData.java`
+- `examples/data/ConcatenationTestData.java`
+- `examples/data/ControlFlowMultiStatementTestData.java`
+- `examples/data/ControlFlowSingleStatementTestData.java`
+- `examples/data/DynamicTestData.java`
+- `examples/data/ElvisTestData.java`
+- `examples/data/EmojifyTestData.java`
+- `examples/data/EqualsCompareTestData.java`
+- `examples/data/ExperimentalTestData.java`
+- `examples/data/ForRangeTestData.java`
+- `examples/data/GetSetPutTestData.java`
+- `examples/data/GetterSetterTestData.java`
+- `examples/data/IfNullSafeData.java`
+- `examples/data/InterpolatedStringTestData.java`
+- `examples/data/LetReturnIt.java`
+- `examples/data/LogBrackets.java`
+- `examples/data/LogFoldingTextBlocksTestData.java`
+- `examples/data/NullableAnnotationCheckNotNullTestData.java`
+- `examples/data/OverrideHideTestData.java`
+- `examples/data/PatternMatchingInstanceofTestData.java`
+- `examples/data/PatternMatchingRecordPatternEdgeCasesTestData.java`
+- `examples/data/PatternMatchingRecordPatternTestData.java`
+- `examples/data/PrintlnTestData.java`
+- `examples/data/PseudoAnnotationsLoggableTestData.java`
+- `examples/data/SemicolonTestData.java`
+- `examples/data/SliceTestData.java`
+- `examples/data/StringBuilderTestData.java`
+- `examples/data/SummaryParentOverrideTestData.java`
+- `examples/data/SuppressWarningsHideTestData.java`
+- `examples/data/TypeCastTestData.java`
+- `examples/data/VarTestData.java`
+- `folded/AppendSetterInterpolatedStringTestData-folded.java`
+- `folded/CompactControlFlowTestData-folded.java`
+- `folded/ConcatenationTestData-folded.java`
+- `folded/ControlFlowMultiStatementTestData-folded.java`
+- `folded/ControlFlowSingleStatementTestData-folded.java`
+- `folded/DynamicTestData-folded.java`
+- `folded/ElvisTestData-folded.java`
+- `folded/EmojifyTestData-folded.java`
+- `folded/EqualsCompareTestData-folded.java`
+- `folded/ExperimentalTestData-folded.java`
+- `folded/ForRangeTestData-folded.java`
+- `folded/GetSetPutTestData-folded.java`
+- `folded/GetterSetterTestData-folded.java`
+- `folded/IfNullSafeData-folded.java`
+- `folded/InterpolatedStringTestData-folded.java`
+- `folded/LetReturnIt-folded.java`
+- `folded/LogBrackets-folded.java`
+- `folded/LogFoldingTextBlocksTestData-folded.java`
+- `folded/NullableAnnotationCheckNotNullTestData-folded.java`
+- `folded/OverrideHideTestData-folded.java`
+- `folded/PatternMatchingInstanceofTestData-folded.java`
+- `folded/PatternMatchingRecordPatternEdgeCasesTestData-folded.java`
+- `folded/PatternMatchingRecordPatternTestData-folded.java`
+- `folded/PrintlnTestData-folded.java`
+- `folded/SemicolonTestData-folded.java`
+- `folded/SliceTestData-folded.java`
+- `folded/StringBuilderTestData-folded.java`
+- `folded/SummaryParentOverrideTestData-folded.java`
+- `folded/SuppressWarningsHideTestData-folded.java`
+- `folded/TypeCastTestData-folded.java`
+- `folded/VarTestData-folded.java`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/IfNullSafePrintlnExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/language/kotlin/PrintlnExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/PrintlnMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/util/CodeGenerationUtil.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/KotlinLanguageState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/crazy/CrazyFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/util/FoldingDataStorage.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/util/GitUtils.kt`
+- `test/com/intellij/advancedExpressionFolding/integration/IntegrationTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/PerformanceTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/pseudoAnnotations.md
+++ b/wiki-clone/feature-details/pseudoAnnotations.md
@@ -1,0 +1,63 @@
+---
+date: 2025-11-01T11:26:35.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "pseudoAnnotations feature"
+tags: [research, codebase, feature, pseudoAnnotations]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: pseudoAnnotations feature
+
+**Date**: 2025-11-01T11:26:35.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `pseudoAnnotations` feature behave within Advanced Expression Folding?
+
+## Summary
+https://github.com/user-attachments/assets/53ad15ef-2c32-4fe4-a857-d36114d020aa Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `pseudoAnnotations` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt` defines or persists the `pseudoAnnotations` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `pseudoAnnotations` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt` references `pseudoAnnotations` within `AbstractLoggingAnnotationCompletionContributor`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt` references `pseudoAnnotations` within `MainAnnotationCompletionContributor`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `pseudoAnnotations`.
+- `test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `pseudoAnnotations`.
+- `test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt` exercises folding behavior tied to `pseudoAnnotations`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/pseudo/AbstractLoggingAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributor.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/LombokState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/LoggableAnnotationCompletionContributorTest.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/MainAnnotationCompletionContributorTest.kt`
+- `test/com/intellij/advancedExpressionFolding/pseudo/TracingLoggableAnnotationCompletionContributorTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/rangeExpressionsCollapse.md
+++ b/wiki-clone/feature-details/rangeExpressionsCollapse.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:36.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "rangeExpressionsCollapse feature"
+tags: [research, codebase, feature, rangeExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: rangeExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:36.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `rangeExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds indexed loops into Kotlin-style range expressions. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `rangeExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `rangeExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `rangeExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt` references `rangeExpressionsCollapse` within `ForStatementExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt` references `rangeExpressionsCollapse` within `BinaryExpressionExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `rangeExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/expression/BinaryExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/semicolonsCollapse.md
+++ b/wiki-clone/feature-details/semicolonsCollapse.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:37.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "semicolonsCollapse feature"
+tags: [research, codebase, feature, semicolonsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: semicolonsCollapse feature
+
+**Date**: 2025-11-01T11:26:37.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `semicolonsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds redundant semicolons inside read-only files. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `semicolonsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt` defines or persists the `semicolonsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `semicolonsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt` references `semicolonsCollapse` within `IfExpression`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt` references `semicolonsCollapse` within `LexicalExpressionBuilders`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/UnclassifiedFeatureFoldingTest.kt` exercises folding behavior tied to `semicolonsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/expression/controlflow/IfExpression.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/UnclassifiedFeatureState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/UnclassifiedFeatureFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/slicingExpressionsCollapse.md
+++ b/wiki-clone/feature-details/slicingExpressionsCollapse.md
@@ -1,0 +1,57 @@
+---
+date: 2025-11-01T11:26:38.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "slicingExpressionsCollapse feature"
+tags: [research, codebase, feature, slicingExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: slicingExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:38.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `slicingExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds List.subList and String.substring calls into concise slice notation. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `slicingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `slicingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `slicingExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/SubstringOrSubListMethodCall.kt` references `slicingExpressionsCollapse` within `SubstringOrSubListMethodCall`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `slicingExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/basic/SubstringOrSubListMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/streamSpread.md
+++ b/wiki-clone/feature-details/streamSpread.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:39.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "streamSpread feature"
+tags: [research, codebase, feature, streamSpread]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: streamSpread feature
+
+**Date**: 2025-11-01T11:26:39.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `streamSpread` feature behave within Advanced Expression Folding?
+
+## Summary
+Displays stream pipelines using Groovy-style spread notation. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `streamSpread` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/CollectionsStreamsState.kt` defines or persists the `streamSpread` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `streamSpread` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/AbstractStreamMethodCall.kt` references `streamSpread` within `AbstractStreamMethodCall`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt` references `streamSpread` within `MethodReferenceExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt` exercises folding behavior tied to `streamSpread`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/methodcall/stream/AbstractStreamMethodCall.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/reference/MethodReferenceExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/CollectionsStreamsState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/CollectionsStreamsFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/summaryParentOverride.md
+++ b/wiki-clone/feature-details/summaryParentOverride.md
@@ -1,0 +1,61 @@
+---
+date: 2025-11-01T11:26:40.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "summaryParentOverride feature"
+tags: [research, codebase, feature, summaryParentOverride]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: summaryParentOverride feature
+
+**Date**: 2025-11-01T11:26:40.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `summaryParentOverride` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds overridden methods into parent summary stubs. Default state value: `false`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `summaryParentOverride` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt` defines or persists the `summaryParentOverride` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `summaryParentOverride` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt` references `summaryParentOverride` within `PsiClassExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `summaryParentOverride` within `PsiMethodExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt` exercises folding behavior tied to `summaryParentOverride`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `summaryParentOverride`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiClassExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/suppressWarningsHide.md
+++ b/wiki-clone/feature-details/suppressWarningsHide.md
@@ -1,0 +1,59 @@
+---
+date: 2025-11-01T11:26:41.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "suppressWarningsHide feature"
+tags: [research, codebase, feature, suppressWarningsHide]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: suppressWarningsHide feature
+
+**Date**: 2025-11-01T11:26:41.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `suppressWarningsHide` feature behave within Advanced Expression Folding?
+
+## Summary
+Hides @SuppressWarnings annotations from view. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `suppressWarningsHide` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt` defines or persists the `suppressWarningsHide` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `suppressWarningsHide` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt` references `suppressWarningsHide` within `PsiMethodExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt` exercises folding behavior tied to `suppressWarningsHide`.
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt` exercises folding behavior tied to `suppressWarningsHide`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiMethodExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/HidingSuppressionState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/HidingSuppressionFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/performance/performanceResult.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None

--- a/wiki-clone/feature-details/varExpressionsCollapse.md
+++ b/wiki-clone/feature-details/varExpressionsCollapse.md
@@ -1,0 +1,65 @@
+---
+date: 2025-11-01T11:26:42.203417+00:00
+researcher: gpt-5-codex
+git_commit: 089f76a81c48eb501fbb924c437c3b59cb175f27
+branch: work
+repository: AdvancedExpressionFolding
+topic: "varExpressionsCollapse feature"
+tags: [research, codebase, feature, varExpressionsCollapse]
+status: complete
+last_updated: 2025-11-01
+last_updated_by: gpt-5-codex
+---
+
+# Research: varExpressionsCollapse feature
+
+**Date**: 2025-11-01T11:26:42.203417+00:00
+**Researcher**: gpt-5-codex
+**Git Commit**: 089f76a81c48eb501fbb924c437c3b59cb175f27
+**Branch**: work
+**Repository**: AdvancedExpressionFolding
+
+## Research Question
+How does the `varExpressionsCollapse` feature behave within Advanced Expression Folding?
+
+## Summary
+Folds variable declarations into val/var style declarations. Default state value: `true`.
+
+## Detailed Findings
+### Settings Integration
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt` defines or persists the `varExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt` defines or persists the `varExpressionsCollapse` toggle, establishing defaults and UI bindings.
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt` defines or persists the `varExpressionsCollapse` toggle, establishing defaults and UI bindings.
+
+### Folding Processors
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt` references `varExpressionsCollapse` within `ForStatementExpressionExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/core/DeclarationBuilders.kt` references `varExpressionsCollapse` within `DeclarationBuilders`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt` references `varExpressionsCollapse` within `PsiDeclarationStatementExt`, controlling folding logic when enabled.
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt` references `varExpressionsCollapse` within `PsiVariableExt`, controlling folding logic when enabled.
+
+### Tests and Samples
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt` exercises folding behavior tied to `varExpressionsCollapse`.
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt` exercises folding behavior tied to `varExpressionsCollapse`.
+
+## Code References
+- `src/com/intellij/advancedExpressionFolding/processor/controlflow/ForStatementExpressionExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/core/DeclarationBuilders.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiDeclarationStatementExt.kt`
+- `src/com/intellij/advancedExpressionFolding/processor/declaration/PsiVariableExt.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/ExpressionCollapseState.kt`
+- `src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/ExpressionCollapseFoldingTest.kt`
+- `test/com/intellij/advancedExpressionFolding/folding/base/folding/KotlinLanguageFoldingTest.kt`
+
+## Architecture Insights
+`NewState` composes feature toggles through interface delegation, and processors guard their transformations with the feature flag to avoid unwanted folding.
+
+## Historical Context (from thoughts/)
+- None
+
+## Related Research
+- None
+
+## Open Questions
+- None


### PR DESCRIPTION
## Summary
- move the feature research documents from `thoughts/shared/research` into `wiki-clone/feature-details`
- drop the timestamp prefixes so each markdown file name matches its feature toggle

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_6905c9d7e364832eb89ed90aa8d770a7