### PR TITLE
Integrate DL4J folding model service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,9 @@ dependencies {
     implementation(libs.jsr305)
     implementation(libs.jackson.dataformat.toml)
     implementation(examplesTestOutput)
+    implementation(libs.dl4j.core)
+    implementation(libs.nd4j.native)
+    implementation(libs.fastutil)
 
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(libs.junit.jupiter.api)

--- a/docs/dl4j_regression_architecture.md
+++ b/docs/dl4j_regression_architecture.md
@@ -1,0 +1,47 @@
+# DL4J Regression Architecture for Language/Framework Adaptation
+
+Poniższy szkic konfiguracji MultiLayerNetwork w DL4J pokazuje minimalną architekturę dla zadania regresji (prawdopodobieństwo złożenia 0.0–1.0) z wektorami cech pochodzącymi z tokenów kodu.
+
+```java
+import org.deeplearning4j.nn.api.OptimizationAlgorithm;
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration;
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
+import org.deeplearning4j.nn.conf.layers.DenseLayer;
+import org.deeplearning4j.nn.conf.layers.OutputLayer;
+import org.deeplearning4j.nn.weights.WeightInit;
+import org.nd4j.linalg.activations.Activation;
+import org.nd4j.linalg.learning.config.Adam;
+import org.nd4j.linalg.lossfunctions.LossFunctions;
+
+int embeddingSize = 128; // wymiar wektorów z Word2Vec/TextVectorizer
+
+MultiLayerConfiguration configuration = new NeuralNetConfiguration.Builder()
+        .seed(42)
+        .weightInit(WeightInit.XAVIER)
+        .updater(new Adam(1e-3))
+        .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+        .list()
+        .layer(new DenseLayer.Builder()
+                .nIn(embeddingSize)
+                .nOut(64)
+                .activation(Activation.RELU)
+                .build())
+        .layer(new DenseLayer.Builder()
+                .nIn(64)
+                .nOut(32)
+                .activation(Activation.RELU)
+                .build())
+        .layer(new OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                .activation(Activation.SIGMOID)
+                .nIn(32)
+                .nOut(1)
+                .build())
+        .build();
+```
+
+## Wektoryzacja cech tekstowych
+- Użyj `Word2Vec` z Deeplearning4j do trenowania wektorów na tokenach kodu (nazwy metod, identyfikatory, słowa kluczowe).
+- Alternatywnie zastosuj `TfidfVectorizer` lub `BagOfWordsVectorizer` z DataVec, aby otrzymać stałe wektory wejściowe.
+- Konwertuj ztokenizowane pliki źródłowe na sekwencje wektorów, a następnie agreguj (np. średnia, sumowanie) do wymiaru `embeddingSize` podanego w konfiguracji.
+
+Ta konfiguracja spełnia wymagania: trzy warstwy (wejście, ukryta, wyjście), warstwy `DenseLayer` z funkcją aktywacji ReLU w ukrytych warstwach oraz `OutputLayer` z aktywacją `SIGMOID` i stratą `MSE` dla regresji.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ jsr305 = "3.0.2"
 pioneer = "2.3.0"
 lombok = "1.18.42"
 kodein = "7.28.0"
+dl4j = "1.0.0-M2.1"
+fastutil = "8.5.14"
 # plugins
 changelog = "2.4.0"
 intelliJPlatform = "2.6.0"
@@ -30,6 +32,9 @@ kodein-di-conf = { group = "org.kodein.di", name = "kodein-di-conf-jvm", version
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+dl4j-core = { module = "org.deeplearning4j:deeplearning4j-core", version.ref = "dl4j" }
+nd4j-native = { module = "org.nd4j:nd4j-native-platform", version.ref = "dl4j" }
+fastutil = { module = "it.unimi.dsi:fastutil", version.ref = "fastutil" }
 
 
 [plugins]

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -18,6 +18,7 @@
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
+        <postStartupActivity implementation="com.intellij.advancedExpressionFolding.ml.FoldingModelStartupActivity"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->
         <intentionAction>
             <language>JAVA</language>

--- a/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding
 import com.google.common.collect.Lists
 import com.google.common.collect.Sets
 import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.ml.FoldingModelService
 import com.intellij.advancedExpressionFolding.processor.asInstance
 import com.intellij.advancedExpressionFolding.processor.cache.CacheExt.invalidateExpired
 import com.intellij.advancedExpressionFolding.processor.cache.Keys
@@ -12,6 +13,7 @@ import com.intellij.advancedExpressionFolding.settings.IConfig
 import com.intellij.lang.ASTNode
 import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.FoldingGroup
 import com.intellij.openapi.project.IndexNotReadyException
@@ -104,6 +106,11 @@ class AdvancedExpressionFoldingBuilder : FoldingBuilderEx(), IConfig by Advanced
             val document = PsiDocumentManager.getInstance(astNode.psi.project).getDocument(astNode.psi.containingFile)
             document?.let {
                 val expression = BuildExpressionExt.getNonSyntheticExpression(element, it)
+                expression?.element?.text?.takeIf(String::isNotBlank)?.let { text ->
+                    foldingModelService.shouldCollapse(text)?.let { predicted ->
+                        return predicted
+                    }
+                }
                 return expression?.isCollapsedByDefault() == true
             }
         } catch (_: IndexNotReadyException) {
@@ -113,6 +120,9 @@ class AdvancedExpressionFoldingBuilder : FoldingBuilderEx(), IConfig by Advanced
     }
 
     private val debugFolding = false
+
+    private val foldingModelService: FoldingModelService
+        get() = service()
 }
 
 var store: Storage = EmptyStorage

--- a/src/com/intellij/advancedExpressionFolding/ml/FoldingModelService.kt
+++ b/src/com/intellij/advancedExpressionFolding/ml/FoldingModelService.kt
@@ -1,0 +1,152 @@
+package com.intellij.advancedExpressionFolding.ml
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import org.deeplearning4j.nn.api.OptimizationAlgorithm
+import org.deeplearning4j.nn.conf.MultiLayerConfiguration
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration
+import org.deeplearning4j.nn.conf.layers.DenseLayer
+import org.deeplearning4j.nn.conf.layers.OutputLayer
+import org.deeplearning4j.nn.multilayer.MultiLayerNetwork
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4j.util.ModelSerializer
+import org.nd4j.linalg.activations.Activation
+import org.nd4j.linalg.api.ndarray.INDArray
+import org.nd4j.linalg.factory.Nd4j
+import org.nd4j.linalg.learning.config.Adam
+import org.nd4j.linalg.lossfunctions.LossFunctions
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.math.abs
+
+@Service(Service.Level.APP)
+class FoldingModelService {
+    private val log = logger<FoldingModelService>()
+
+    private val embeddingSize = 128
+    private val modelDirectory: Path = Path.of(PathManager.getConfigPath(), "advancedExpressionFolding")
+    private val modelFile: Path = modelDirectory.resolve("folding-model.zip")
+    private val configuration: MultiLayerConfiguration by lazy { buildConfiguration() }
+
+    @Volatile
+    private var modelLoadedFromDisk = false
+
+    @Volatile
+    private var network: MultiLayerNetwork? = loadPersistedNetwork()
+
+    fun warmup() {
+        if (!modelLoadedFromDisk) {
+            network = loadPersistedNetwork()
+        }
+    }
+
+    fun model(): MultiLayerNetwork {
+        var localNetwork = network
+        if (localNetwork == null) {
+            localNetwork = newInitializedNetwork()
+            network = localNetwork
+        }
+        return localNetwork
+    }
+
+    fun shouldCollapse(text: String, threshold: Double = 0.5): Boolean? =
+        predictCollapseProbability(text)?.let { probability -> probability >= threshold }
+
+    fun predictCollapseProbability(text: String): Double? {
+        if (!modelLoadedFromDisk) {
+            return null
+        }
+        val tokens = tokenize(text)
+        if (tokens.isEmpty()) {
+            return null
+        }
+        val features = encode(tokens)
+        return try {
+            model().output(features, false).getDouble(0)
+        } catch (t: Throwable) {
+            log.warn("Failed to execute DL4J folding model inference", t)
+            null
+        }
+    }
+
+    private fun loadPersistedNetwork(): MultiLayerNetwork? {
+        ensureDirectory()
+        if (!Files.exists(modelFile)) {
+            modelLoadedFromDisk = false
+            return null
+        }
+        return try {
+            ModelSerializer.restoreMultiLayerNetwork(modelFile.toFile(), true).also {
+                modelLoadedFromDisk = true
+            }
+        } catch (t: Throwable) {
+            log.warn("Unable to load DL4J folding model from $modelFile", t)
+            modelLoadedFromDisk = false
+            null
+        }
+    }
+
+    private fun newInitializedNetwork(): MultiLayerNetwork = MultiLayerNetwork(configuration).also(MultiLayerNetwork::init)
+
+    private fun ensureDirectory() {
+        try {
+            Files.createDirectories(modelDirectory)
+        } catch (t: Throwable) {
+            log.warn("Unable to create DL4J model directory $modelDirectory", t)
+        }
+    }
+
+    private fun tokenize(text: String): List<String> =
+        TOKEN_REGEX.findAll(text.lowercase()).map { it.value }.filter { it.isNotEmpty() }.toList()
+
+    private fun encode(tokens: List<String>): INDArray {
+        val counts = DoubleArray(embeddingSize)
+        for (token in tokens) {
+            val index = abs(token.hashCode()) % embeddingSize
+            counts[index] += 1.0
+        }
+        val max = counts.maxOrNull() ?: 0.0
+        if (max > 0.0) {
+            for (i in counts.indices) {
+                counts[i] /= max
+            }
+        }
+        return Nd4j.create(counts).reshape(1L, embeddingSize.toLong())
+    }
+
+    private fun buildConfiguration(): MultiLayerConfiguration {
+        return NeuralNetConfiguration.Builder()
+            .seed(42)
+            .weightInit(WeightInit.XAVIER)
+            .updater(Adam(1e-3))
+            .optimizationAlgo(OptimizationAlgorithm.STOCHASTIC_GRADIENT_DESCENT)
+            .list()
+            .layer(
+                DenseLayer.Builder()
+                    .nIn(embeddingSize)
+                    .nOut(64)
+                    .activation(Activation.RELU)
+                    .build()
+            )
+            .layer(
+                DenseLayer.Builder()
+                    .nIn(64)
+                    .nOut(32)
+                    .activation(Activation.RELU)
+                    .build()
+            )
+            .layer(
+                OutputLayer.Builder(LossFunctions.LossFunction.MSE)
+                    .activation(Activation.SIGMOID)
+                    .nIn(32)
+                    .nOut(1)
+                    .build()
+            )
+            .build()
+    }
+
+    companion object {
+        private val TOKEN_REGEX = Regex("[a-z0-9]+")
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/ml/FoldingModelStartupActivity.kt
+++ b/src/com/intellij/advancedExpressionFolding/ml/FoldingModelStartupActivity.kt
@@ -1,0 +1,19 @@
+package com.intellij.advancedExpressionFolding.ml
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import java.nio.file.Files
+import java.nio.file.Path
+
+class FoldingModelStartupActivity : StartupActivity.DumbAware {
+    override fun runActivity(project: Project) {
+        if (Files.exists(modelPath())) {
+            service<FoldingModelService>().warmup()
+        }
+    }
+
+    private fun modelPath(): Path =
+        Path.of(PathManager.getConfigPath(), "advancedExpressionFolding", "folding-model.zip")
+}


### PR DESCRIPTION
twin:
https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/pull/828

https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/b3ec6314f00cc93d40295f2cef06748dc52676fc/src/com/intellij/advancedExpressionFolding/AdvancedExpressionFoldingBuilder.kt#L103-L114

## Summary
- add a DL4J-backed FoldingModelService that loads a persisted network and provides collapse predictions
- create a startup activity that warms the model only when a saved network is present and wire predictions into the folding builder
- pull in DL4J/ND4J dependencies plus fastutil and register the startup hook in plugin metadata

## Testing
- ./gradlew clean build test --console=plain --no-configuration-cache --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_6905c6c8f01c832e85e885a6d76cfc79