### PR TITLE
Showcase Arrow APIs in folding workflow

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,9 @@ dependencies {
     implementation(libs.jsr305)
     implementation(libs.jackson.dataformat.toml)
     implementation(examplesTestOutput)
+    implementation(libs.arrow.core)
+    implementation(libs.arrow.fx.coroutines)
+    implementation(libs.arrow.optics)
 
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(libs.junit.jupiter.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ jsr305 = "3.0.2"
 pioneer = "2.3.0"
 lombok = "1.18.42"
 kodein = "7.28.0"
+arrow-core = "2.0.0"
+arrow-fx = "2.0.0"
+arrow-optics = "2.0.1"
 # plugins
 changelog = "2.4.0"
 intelliJPlatform = "2.6.0"
@@ -30,6 +33,9 @@ kodein-di-conf = { group = "org.kodein.di", name = "kodein-di-conf-jvm", version
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow-core" }
+arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow-fx" }
+arrow-optics = { module = "io.arrow-kt:arrow-optics", version.ref = "arrow-optics" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- refactor the folding builder to validate context with Arrow Either/raise accumulation and snapshot settings via optics lenses
- add caching helpers that accumulate cache issues and keep resource-safe cleanup while preserving FX `parZip` concurrency

## Testing
- `./gradlew clean build test --console=plain` *(terminated after prolonged runtime without completion in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690518d7b89c832eafe5038e7bf26dd2