### PR TITLE
Add RNN-based folding preference predictor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,14 @@ dependencies {
     implementation(libs.annotations)
     implementation(libs.jsr305)
     implementation(libs.jackson.dataformat.toml)
+    implementation("com.kotlinnlp:simplednn:0.14.0") {
+        isTransitive = false
+    }
+    implementation("org.jblas:jblas:1.2.4")
+    implementation("org.slf4j:slf4j-simple:1.7.21")
+    implementation("com.kotlinnlp:utils:2.1.4") {
+        isTransitive = false
+    }
     implementation(examplesTestOutput)
 
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/src/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingDataStorage.kt
@@ -1,0 +1,135 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.openapi.application.PathManager
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+class FoldingDataStorage {
+
+    private val baseDir: Path = PathManager.getConfigDir().resolve("advancedExpressionFolding")
+    private val eventsFile: Path = baseDir.resolve("folding-events.tsv")
+    private val modelFile: Path = baseDir.resolve("folding-model.bin")
+    private val preferenceFile: Path = baseDir.resolve("folding-preference.txt")
+
+    private val lock = ReentrantReadWriteLock()
+    private var cachedEvents: MutableList<FoldingInteraction>? = null
+
+    init {
+        Files.createDirectories(baseDir)
+    }
+
+    fun append(interaction: FoldingInteraction) {
+        lock.write {
+            val events = cachedEvents ?: loadEventsInternal().toMutableList().also { cachedEvents = it }
+            events.add(interaction)
+            Files.writeString(
+                eventsFile,
+                encode(interaction) + "\n",
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND
+            )
+        }
+    }
+
+    fun loadInteractions(): List<FoldingInteraction> = lock.read {
+        cachedEvents?.toList() ?: loadEventsInternal().also { cachedEvents = it.toMutableList() }
+    }
+
+    fun loadRecentInteractions(limit: Int): List<FoldingInteraction> = lock.read {
+        val interactions = cachedEvents ?: loadEventsInternal().also { cachedEvents = it.toMutableList() }
+        if (limit <= 0 || interactions.isEmpty()) emptyList() else interactions.takeLast(limit)
+    }
+
+    fun lastTimestamp(): Long? = lock.read {
+        val events = cachedEvents ?: loadEventsInternal().also { cachedEvents = it.toMutableList() }
+        events.lastOrNull()?.timestamp
+    }
+
+    fun saveModel(snapshot: FoldingRNNModel.Snapshot) {
+        lock.write {
+            ObjectOutputStream(
+                Files.newOutputStream(modelFile, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+            ).use { output ->
+                output.writeObject(snapshot)
+            }
+        }
+    }
+
+    fun readModel(): FoldingRNNModel.Snapshot? = lock.read {
+        if (!Files.exists(modelFile)) return null
+        ObjectInputStream(Files.newInputStream(modelFile)).use { input ->
+            input.readObject() as? FoldingRNNModel.Snapshot
+        }
+    }
+
+    fun saveLastPreference(collapsed: Boolean) {
+        lock.write {
+            Files.writeString(
+                preferenceFile,
+                collapsed.toString(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            )
+        }
+    }
+
+    fun readLastPreference(): Boolean? = lock.read {
+        if (!Files.exists(preferenceFile)) return null
+        Files.readString(preferenceFile).trim().takeIf(String::isNotEmpty)?.toBooleanStrictOrNull()
+    }
+
+    fun count(): Int = lock.read {
+        cachedEvents?.size ?: loadEventsInternal().size
+    }
+
+    private fun encode(interaction: FoldingInteraction): String = buildString {
+        append(interaction.foldingId.replace('\t', ' '))
+        append('\t')
+        append(interaction.timestamp)
+        append('\t')
+        append(interaction.collapsed)
+        append('\t')
+        append(interaction.fileType.replace('\t', ' '))
+        append('\t')
+        append(interaction.foldingType.replace('\t', ' '))
+        append('\t')
+        append(interaction.sessionDurationMillis)
+        append('\t')
+        append(interaction.timeSinceLastMillis)
+    }
+
+    private fun decode(line: String): FoldingInteraction? {
+        val parts = line.split('\t')
+        if (parts.size < 7) return null
+        return FoldingInteraction(
+            foldingId = parts[0],
+            timestamp = parts[1].toLongOrNull() ?: return null,
+            collapsed = parts[2].toBooleanStrictOrNull() ?: return null,
+            fileType = parts[3],
+            foldingType = parts[4],
+            sessionDurationMillis = parts[5].toLongOrNull() ?: return null,
+            timeSinceLastMillis = parts[6].toLongOrNull() ?: return null
+        )
+    }
+
+    private fun loadEventsInternal(): List<FoldingInteraction> {
+        if (!Files.exists(eventsFile)) return emptyList()
+        return Files.readAllLines(eventsFile).mapNotNull(::decode)
+    }
+}
+
+data class FoldingInteraction(
+    val foldingId: String,
+    val timestamp: Long,
+    val collapsed: Boolean,
+    val fileType: String,
+    val foldingType: String,
+    val sessionDurationMillis: Long,
+    val timeSinceLastMillis: Long
+)

--- a/src/com/intellij/advancedExpressionFolding/FoldingEditorCreatedListener.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingEditorCreatedListener.kt
@@ -14,14 +14,19 @@ import kotlin.time.Duration.Companion.seconds
 class FoldingEditorCreatedListener : EditorFactoryListener {
 
     override fun editorCreated(event: EditorFactoryEvent) {
+        val predictor = FoldingPredictor.get()
+        predictor.registerEditor(event.editor)
         CoroutineScope(Dispatchers.EDT).launch {
             delay(1.seconds)
             runWriteAction {
-                FoldingService.get().fold(event.editor, true)
+                predictor.applyPredictions(event.editor)
             }
         }
     }
 
-    override fun editorReleased(event: EditorFactoryEvent) = FoldingService.get().clearAllKeys(event.editor)
+    override fun editorReleased(event: EditorFactoryEvent) {
+        FoldingPredictor.get().unregisterEditor(event.editor)
+        FoldingService.get().clearAllKeys(event.editor)
+    }
 
 }

--- a/src/com/intellij/advancedExpressionFolding/FoldingEventCollector.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingEventCollector.kt
@@ -1,0 +1,97 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.FoldRegion
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiDocumentManager
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+/**
+ * Collects user initiated folding actions and forwards them to the [FoldingPredictor].
+ */
+object FoldingEventCollector {
+
+    private val sessionStartKey: Key<Long> = Key.create("advancedExpressionFolding.sessionStart")
+    private val installedKey: Key<Boolean> = Key.create("advancedExpressionFolding.collectorInstalled")
+
+    fun attach(editor: Editor) {
+        if (editor.getUserData(installedKey) == true) {
+            return
+        }
+        editor.putUserData(installedKey, true)
+        editor.putUserData(sessionStartKey, editor.getUserData(sessionStartKey) ?: System.currentTimeMillis())
+        registerListener(editor)
+    }
+
+    fun detach(editor: Editor) {
+        editor.putUserData(installedKey, null)
+    }
+
+    fun sessionDuration(editor: Editor, now: Long): Long = now - editor.sessionStart()
+
+    private fun registerListener(editor: Editor) {
+        val listenerClass = runCatching {
+            Class.forName("com.intellij.openapi.editor.event.FoldingListener")
+        }.getOrNull() ?: return
+        val handler = InvocationHandler { _, method, args ->
+            if (method.isFoldingStateChange && !args.isNullOrEmpty()) {
+                val region = extractRegion(args[0])
+                if (region != null) {
+                    handleRegionStateChange(editor, region)
+                }
+            }
+            null
+        }
+        val listener = Proxy.newProxyInstance(listenerClass.classLoader, arrayOf(listenerClass), handler)
+        val multicaster = EditorFactory.getInstance().eventMulticaster
+        val addMethod = multicaster::class.java.methods.find { it.name == "addFoldingListener" && it.parameterCount >= 2 } ?: return
+        addMethod.invoke(multicaster, listener, editor)
+    }
+
+    private fun extractRegion(event: Any): FoldRegion? {
+        val method = event::class.java.methods.find { it.name == "getFoldRegion" && it.parameterCount == 0 }
+        return runCatching { method?.invoke(event) as? FoldRegion }.getOrNull()
+    }
+
+    private fun handleRegionStateChange(editor: Editor, region: FoldRegion) {
+        if (!region.isAdvancedExpressionFoldingGroup) {
+            return
+        }
+        val project = editor.project ?: return
+        val predictor = FoldingPredictor.get()
+        if (!predictor.shouldCollectEvents()) {
+            return
+        }
+        val psiFile = project.psiFile(editor) ?: return
+        val event = FoldingEvent(
+            foldingId = FoldingPredictor.computeFoldingId(psiFile, region),
+            timestamp = System.currentTimeMillis(),
+            collapsed = !region.isExpanded,
+            fileType = psiFile.fileType.name,
+            foldingType = FoldingPredictor.describeRegion(region),
+            sessionDurationMillis = System.currentTimeMillis() - editor.sessionStart()
+        )
+        predictor.onUserAction(event)
+    }
+
+    private fun Project.psiFile(editor: Editor) = PsiDocumentManager.getInstance(this).getPsiFile(editor.document)
+
+    private fun Editor.sessionStart(): Long =
+        getUserData(sessionStartKey) ?: System.currentTimeMillis().also { putUserData(sessionStartKey, it) }
+}
+
+private val Method.isFoldingStateChange: Boolean
+    get() = name == "foldingStateChanged" && parameterCount == 1
+
+data class FoldingEvent(
+    val foldingId: String,
+    val timestamp: Long,
+    val collapsed: Boolean,
+    val fileType: String,
+    val foldingType: String,
+    val sessionDurationMillis: Long
+)

--- a/src/com/intellij/advancedExpressionFolding/FoldingPredictor.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingPredictor.kt
@@ -1,0 +1,318 @@
+package com.intellij.advancedExpressionFolding
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.FoldRegion
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.ZoneId
+import java.util.ArrayDeque
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.abs
+import kotlin.math.min
+import kotlin.time.Duration.Companion.hours
+
+@Service(Service.Level.APP)
+class FoldingPredictor {
+
+    private val storage = FoldingDataStorage()
+    private val model = FoldingRNNModel(FEATURE_SIZE, hiddenUnits = HIDDEN_UNITS)
+    private val scope = FoldingServiceCoroutineScope.get()
+
+    private val suppressionCounter = AtomicInteger(0)
+    private val trainingInProgress = AtomicBoolean(false)
+    private val stateLock = Any()
+
+    @Volatile
+    private var lastEventTimestamp: Long? = null
+
+    @Volatile
+    private var lastPreference: Boolean? = null
+
+    @Volatile
+    private var trainedOnCount: Int = 0
+
+    init {
+        val interactions = storage.loadInteractions()
+        lastEventTimestamp = interactions.lastOrNull()?.timestamp ?: storage.lastTimestamp()
+        lastPreference = storage.readLastPreference() ?: interactions.lastOrNull()?.collapsed
+        storage.readModel()?.let(model::load)
+        if (model.isReady()) {
+            trainedOnCount = interactions.size
+        }
+    }
+
+    fun registerEditor(editor: Editor) {
+        FoldingEventCollector.attach(editor)
+    }
+
+    fun unregisterEditor(editor: Editor) {
+        FoldingEventCollector.detach(editor)
+    }
+
+    fun onUserAction(event: FoldingEvent) {
+        val interaction = synchronized(stateLock) {
+            val delta = lastEventTimestamp?.let { event.timestamp - it } ?: 0L
+            lastEventTimestamp = event.timestamp
+            FoldingInteraction(
+                foldingId = event.foldingId,
+                timestamp = event.timestamp,
+                collapsed = event.collapsed,
+                fileType = event.fileType,
+                foldingType = event.foldingType,
+                sessionDurationMillis = event.sessionDurationMillis,
+                timeSinceLastMillis = delta
+            ).also { interaction ->
+                storage.append(interaction)
+                lastPreference = interaction.collapsed
+                storage.saveLastPreference(interaction.collapsed)
+            }
+        }
+        maybeScheduleTraining()
+    }
+
+    fun applyPredictions(editor: Editor) {
+        val project = editor.project ?: return
+        val psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return
+        val regions = editor.foldingModel.allFoldRegions.filter(FoldRegion::isAdvancedExpressionFoldingGroup)
+        if (regions.isEmpty()) {
+            return
+        }
+        val now = System.currentTimeMillis()
+        val sessionDuration = FoldingEventCollector.sessionDuration(editor, now)
+        val timeSinceLast = synchronized(stateLock) { lastEventTimestamp?.let { now - it } ?: 0L }
+        val previous = storage.loadRecentInteractions(SEQUENCE_WINDOW - 1)
+        val fallback = synchronized(stateLock) { lastPreference }
+        val canPredict = model.isReady()
+
+        runWithoutCollection {
+            editor.foldingModel.runBatchFoldingOperation {
+                regions.forEach { region ->
+                    val candidate = CandidateContext(
+                        foldingId = computeFoldingId(psiFile, region),
+                        timestamp = now,
+                        fileType = psiFile.fileType.name,
+                        foldingType = describeRegion(region),
+                        sessionDurationMillis = sessionDuration,
+                        timeSinceLastMillis = timeSinceLast
+                    )
+                    val probability = if (canPredict) predictCandidate(previous, candidate) else null
+                    val desiredCollapsed = decideDesiredState(probability, fallback)
+                    desiredCollapsed?.let { region.isExpanded = !it }
+                }
+            }
+        }
+    }
+
+    fun shouldCollectEvents(): Boolean = suppressionCounter.get() == 0
+
+    fun runWithoutCollection(block: () -> Unit) {
+        suppressionCounter.incrementAndGet()
+        try {
+            block()
+        } finally {
+            suppressionCounter.decrementAndGet()
+        }
+    }
+
+    private fun maybeScheduleTraining() {
+        val count = storage.count()
+        if (count < MIN_EVENTS_FOR_TRAINING) {
+            return
+        }
+        val trainedCountSnapshot = trainedOnCount
+        if (count - trainedCountSnapshot < RETRAIN_THRESHOLD) {
+            return
+        }
+        if (!trainingInProgress.compareAndSet(false, true)) {
+            return
+        }
+        scope.launch {
+            try {
+                trainModel()
+            } finally {
+                trainingInProgress.set(false)
+            }
+        }
+    }
+
+    private fun trainModel() {
+        val interactions = storage.loadInteractions()
+        if (interactions.size < MIN_EVENTS_FOR_TRAINING) {
+            return
+        }
+        val dataset = buildTrainingDataset(interactions)
+        if (dataset.isEmpty()) {
+            return
+        }
+        model.train(dataset)
+        storage.saveModel(model.snapshot())
+        trainedOnCount = interactions.size
+    }
+
+    private fun buildTrainingDataset(events: List<FoldingInteraction>): List<FoldingTrainingExample> {
+        if (events.isEmpty()) {
+            return emptyList()
+        }
+        val examples = mutableListOf<FoldingTrainingExample>()
+        events.forEachIndexed { index, _ ->
+            val from = (index - SEQUENCE_WINDOW + 1).coerceAtLeast(0)
+            val relevant = events.subList(from, index + 1)
+            val history = ArrayDeque<Boolean>()
+            val sequence = mutableListOf<DoubleArray>()
+            relevant.forEach { event ->
+                sequence.add(
+                    buildFeatureVector(
+                        timestamp = event.timestamp,
+                        fileType = event.fileType,
+                        foldingType = event.foldingType,
+                        sessionDurationMillis = event.sessionDurationMillis,
+                        timeSinceLastMillis = event.timeSinceLastMillis,
+                        actionHistory = history.toList()
+                    )
+                )
+                history.addLast(event.collapsed)
+                if (history.size > WINDOW_FOR_SEQUENCE) {
+                    history.removeFirst()
+                }
+            }
+            val label = if (relevant.last().collapsed) 1.0 else 0.0
+            examples.add(FoldingTrainingExample(sequence, label))
+        }
+        return examples
+    }
+
+    private fun predictCandidate(previous: List<FoldingInteraction>, candidate: CandidateContext): Double? {
+        val sequence = buildSequence(previous, candidate)
+        if (sequence.isEmpty()) {
+            return null
+        }
+        return model.predict(sequence)
+    }
+
+    private fun buildSequence(previous: List<FoldingInteraction>, candidate: CandidateContext): List<DoubleArray> {
+        val history = ArrayDeque<Boolean>()
+        val features = mutableListOf<DoubleArray>()
+        val trimmed = if (previous.size >= SEQUENCE_WINDOW - 1) {
+            previous.takeLast(SEQUENCE_WINDOW - 1)
+        } else {
+            previous
+        }
+        trimmed.forEach { interaction ->
+            features.add(
+                buildFeatureVector(
+                    timestamp = interaction.timestamp,
+                    fileType = interaction.fileType,
+                    foldingType = interaction.foldingType,
+                    sessionDurationMillis = interaction.sessionDurationMillis,
+                    timeSinceLastMillis = interaction.timeSinceLastMillis,
+                    actionHistory = history.toList()
+                )
+            )
+            history.addLast(interaction.collapsed)
+            if (history.size > WINDOW_FOR_SEQUENCE) {
+                history.removeFirst()
+            }
+        }
+        features.add(
+            buildFeatureVector(
+                timestamp = candidate.timestamp,
+                fileType = candidate.fileType,
+                foldingType = candidate.foldingType,
+                sessionDurationMillis = candidate.sessionDurationMillis,
+                timeSinceLastMillis = candidate.timeSinceLastMillis,
+                actionHistory = history.toList()
+            )
+        )
+        return features
+    }
+
+    private fun buildFeatureVector(
+        timestamp: Long,
+        fileType: String,
+        foldingType: String,
+        sessionDurationMillis: Long,
+        timeSinceLastMillis: Long,
+        actionHistory: List<Boolean>
+    ): DoubleArray {
+        val zoned = Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault())
+        val hour = zoned.hour / 23.0
+        val day = zoned.dayOfWeek.ordinal / 6.0
+        val timeSince = normalize(timeSinceLastMillis, TIME_NORMALIZER_MILLIS)
+        val session = normalize(sessionDurationMillis, SESSION_NORMALIZER_MILLIS)
+        val fileFeature = hashFeature(fileType)
+        val foldingFeature = hashFeature(foldingType)
+        val collapsedRatio = if (actionHistory.isEmpty()) 0.5 else actionHistory.count { it }.toDouble() / actionHistory.size
+        val lastAction = when {
+            actionHistory.isEmpty() -> 0.5
+            actionHistory.last() -> 1.0
+            else -> 0.0
+        }
+        val momentumWindow = actionHistory.takeLast(min(3, actionHistory.size))
+        val momentum = if (momentumWindow.isEmpty()) 0.5 else momentumWindow.count { it }.toDouble() / momentumWindow.size
+        val historyFill = (actionHistory.size.toDouble() / WINDOW_FOR_SEQUENCE).coerceIn(0.0, 1.0)
+        return doubleArrayOf(hour, day, timeSince, session, fileFeature, foldingFeature, collapsedRatio, lastAction, momentum, historyFill)
+    }
+
+    private fun decideDesiredState(probability: Double?, fallback: Boolean?): Boolean? {
+        probability ?: return fallback
+        return when {
+            probability >= CONFIDENCE_THRESHOLD -> true
+            (1.0 - probability) >= CONFIDENCE_THRESHOLD -> false
+            else -> fallback
+        }
+    }
+
+    companion object {
+        private const val FEATURE_SIZE = 10
+        private const val HIDDEN_UNITS = 64
+        private const val MIN_EVENTS_FOR_TRAINING = 120
+        private const val RETRAIN_THRESHOLD = 50
+        private const val SEQUENCE_WINDOW = 12
+        private const val WINDOW_FOR_SEQUENCE = 10
+        private const val CONFIDENCE_THRESHOLD = 0.7
+        private val TIME_NORMALIZER_MILLIS = (3.hours).inWholeMilliseconds.toDouble()
+        private val SESSION_NORMALIZER_MILLIS = (4.hours).inWholeMilliseconds.toDouble()
+
+        fun get(): FoldingPredictor = service()
+
+        fun computeFoldingId(psiFile: PsiFile, region: FoldRegion): String {
+            val fileId = psiFile.virtualFile?.path ?: psiFile.name
+            return buildString {
+                append(fileId)
+                append(":")
+                append(region.startOffset)
+                append(":")
+                append(region.endOffset)
+            }
+        }
+
+        fun describeRegion(region: FoldRegion): String =
+            region.group?.toString() ?: region.placeholderText.orEmpty()
+    }
+
+    private fun normalize(value: Long, maxValue: Double): Double {
+        if (maxValue <= 0.0) {
+            return 0.0
+        }
+        return (value.toDouble() / maxValue).coerceIn(0.0, 1.0)
+    }
+
+    private fun hashFeature(value: String): Double {
+        val hashed = abs(value.hashCode()) % 1000
+        return hashed / 1000.0
+    }
+
+    private data class CandidateContext(
+        val foldingId: String,
+        val timestamp: Long,
+        val fileType: String,
+        val foldingType: String,
+        val sessionDurationMillis: Long,
+        val timeSinceLastMillis: Long
+    )
+}

--- a/src/com/intellij/advancedExpressionFolding/FoldingRNNModel.kt
+++ b/src/com/intellij/advancedExpressionFolding/FoldingRNNModel.kt
@@ -1,0 +1,130 @@
+package com.intellij.advancedExpressionFolding
+
+import com.kotlinnlp.simplednn.core.functionalities.activations.Sigmoid
+import com.kotlinnlp.simplednn.core.functionalities.activations.Tanh
+import com.kotlinnlp.simplednn.core.functionalities.updatemethods.learningrate.LearningRateMethod
+import com.kotlinnlp.simplednn.core.layers.LayerType
+import com.kotlinnlp.simplednn.core.layers.StackedLayersParameters
+import com.kotlinnlp.simplednn.core.functionalities.losses.LossCalculator
+import com.kotlinnlp.simplednn.core.neuralnetwork.preset.SimpleRecurrentNeuralNetwork
+import com.kotlinnlp.simplednn.core.neuralprocessor.recurrent.RecurrentNeuralProcessor
+import com.kotlinnlp.simplednn.core.optimizer.ParamsOptimizer
+import com.kotlinnlp.simplednn.simplemath.ndarray.dense.DenseNDArray
+import com.kotlinnlp.simplednn.simplemath.ndarray.dense.DenseNDArrayFactory
+import java.io.Serializable
+import kotlin.math.ln
+
+class FoldingRNNModel(private val featureSize: Int, private val hiddenUnits: Int = 64) {
+
+    private var parameters: StackedLayersParameters = createParameters()
+    private var processor: RecurrentNeuralProcessor<DenseNDArray> = createProcessor(parameters)
+    @Volatile
+    private var trained: Boolean = false
+
+    fun isReady(): Boolean = trained
+
+    fun load(snapshot: Snapshot) {
+        if (snapshot.featureSize != featureSize || snapshot.hiddenUnits != hiddenUnits) {
+            return
+        }
+        parameters = snapshot.parameters
+        processor = createProcessor(parameters)
+        trained = snapshot.trained
+    }
+
+    fun snapshot(): Snapshot = Snapshot(parameters, featureSize, hiddenUnits, trained)
+
+    fun train(examples: List<FoldingTrainingExample>, epochs: Int = 3, batchSize: Int = 8) {
+        if (examples.isEmpty()) {
+            return
+        }
+        processor = createProcessor(parameters)
+        val optimizer = ParamsOptimizer(LearningRateMethod(learningRate = 0.01))
+        repeat(epochs) {
+            optimizer.newEpoch()
+            examples.shuffled().chunked(batchSize).forEach { batch ->
+                optimizer.newBatch()
+                batch.forEach { example ->
+                    optimizer.newExample()
+                    val inputSequence = example.sequence.map { DenseNDArrayFactory.arrayOf(it) }
+                    val output = processor.forward(
+                        input = inputSequence,
+                        initHiddenArrays = null,
+                        saveContributions = false
+                    )
+                    val gold = DenseNDArrayFactory.arrayOf(doubleArrayOf(example.label))
+                    val errors = BinaryCrossEntropyCalculator.calculateErrors(output, gold)
+                    processor.backward(errors)
+                    val copy = batch.size > 1
+                    optimizer.accumulate(processor.getParamsErrors(copy = copy), copy = copy)
+                }
+                optimizer.update()
+            }
+        }
+        trained = true
+    }
+
+    fun predict(sequence: List<DoubleArray>): Double {
+        if (!trained || sequence.isEmpty()) {
+            return 0.5
+        }
+        val inputSequence = sequence.map { DenseNDArrayFactory.arrayOf(it) }
+        val output = processor.forward(
+            input = inputSequence,
+            initHiddenArrays = null,
+            saveContributions = false
+        )
+        return clampProbability(output[0])
+    }
+
+    private fun createParameters(): StackedLayersParameters = SimpleRecurrentNeuralNetwork(
+        inputSize = featureSize,
+        inputType = LayerType.Input.Dense,
+        hiddenSize = hiddenUnits,
+        hiddenActivation = Tanh,
+        numOfHidden = 1,
+        outputSize = 1,
+        outputActivation = Sigmoid
+    )
+
+    private fun createProcessor(params: StackedLayersParameters): RecurrentNeuralProcessor<DenseNDArray> =
+        RecurrentNeuralProcessor<DenseNDArray>(model = params, propagateToInput = false)
+
+    data class Snapshot(
+        val parameters: StackedLayersParameters,
+        val featureSize: Int,
+        val hiddenUnits: Int,
+        val trained: Boolean
+    ) : Serializable
+}
+
+data class FoldingTrainingExample(
+    val sequence: List<DoubleArray>,
+    val label: Double
+)
+
+private object BinaryCrossEntropyCalculator : LossCalculator {
+
+    override fun calculateLoss(output: DenseNDArray, outputGold: DenseNDArray): DenseNDArray {
+        val prediction = clampProbability(output[0])
+        val target = outputGold[0].coerceIn(0.0, 1.0)
+        val loss = -(target * ln(prediction) + (1.0 - target) * ln(1.0 - prediction))
+        return DenseNDArrayFactory.arrayOf(doubleArrayOf(loss))
+    }
+
+    override fun calculateErrors(output: DenseNDArray, outputGold: DenseNDArray): DenseNDArray {
+        val errors = output.copy()
+        val prediction = clampProbability(output[0])
+        val target = outputGold[0].coerceIn(0.0, 1.0)
+        errors[0] = prediction - target
+        return errors
+    }
+}
+
+private const val PROBABILITY_EPS = 1e-6
+
+private fun clampProbability(value: Double): Double = when {
+    value < PROBABILITY_EPS -> PROBABILITY_EPS
+    value > 1.0 - PROBABILITY_EPS -> 1.0 - PROBABILITY_EPS
+    else -> value
+}


### PR DESCRIPTION
## Summary
- add SimpleDNN and support dependencies to the Gradle build to enable folding preference modeling
- implement collection, persistence, and training support for folding interaction events
- integrate an RNN-backed predictor with editor lifecycle to apply confident folding state predictions

## Testing
- `./gradlew clean build test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6905ff24e868832eb0566c25686c071b