### PR TITLE
Simplify IntegrationTestApi EDT handling

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
+++ b/src/com/intellij/advancedExpressionFolding/integration/IntegrationTestApi.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.util.Computable
 import org.jetbrains.annotations.TestOnly
 
 @TestOnly
@@ -67,10 +66,11 @@ object IntegrationTestApi {
         return if (application.isDispatchThread) {
             compute()
         } else {
-            application.invokeAndWait(
-                Computable { compute() },
-                ModalityState.defaultModalityState()
-            )
+            var result = 0
+            application.invokeAndWait({
+                result = compute()
+            }, ModalityState.defaultModalityState())
+            result
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the IntegrationTestApi EDT trampoline helpers with an ApplicationManager.invokeAndWait call
- remove the obsolete AtomicReference usage from countAdvancedFoldRegions

## Testing
- Not run (Gradle build hung while calculating task graph)

------
https://chatgpt.com/codex/tasks/task_e_69060ecfe03c832e8dd3605f8e1e6b50