### PR TITLE
Add rule discovery pipeline for fold rule clustering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,10 @@ dependencies {
     implementation(libs.jsr305)
     implementation(libs.jackson.dataformat.toml)
     implementation(examplesTestOutput)
+    implementation(libs.multik.core)
+    implementation(libs.multik.default)
+    implementation(libs.multik.kotlin)
+    implementation(libs.commons.math3)
 
     testRuntimeOnly(libs.junit.jupiter.engine)
     testImplementation(libs.junit.jupiter.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ jsr305 = "3.0.2"
 pioneer = "2.3.0"
 lombok = "1.18.42"
 kodein = "7.28.0"
+multik = "0.2.2"
+commons-math = "3.6.1"
 # plugins
 changelog = "2.4.0"
 intelliJPlatform = "2.6.0"
@@ -30,6 +32,10 @@ kodein-di-conf = { group = "org.kodein.di", name = "kodein-di-conf-jvm", version
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+multik-core = { module = "org.jetbrains.kotlinx:multik-core", version.ref = "multik" }
+multik-default = { module = "org.jetbrains.kotlinx:multik-default", version.ref = "multik" }
+multik-kotlin = { module = "org.jetbrains.kotlinx:multik-kotlin", version.ref = "multik" }
+commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math" }
 
 
 [plugins]

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
         <!-- Application-level service that persists plugin settings -->
         <applicationService
                 serviceImplementation="com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings"/>
+        <projectService
+                serviceImplementation="com.intellij.advancedExpressionFolding.discovery.RuleDiscoveryManager"/>
         <!-- Listens for editor lifecycle to fold code one second after the editor opens and clear on release -->
         <editorFactoryListener implementation="com.intellij.advancedExpressionFolding.FoldingEditorCreatedListener"/>
         <!-- Adds an Alt+Enter intention on method names to fold calls dynamically -->
@@ -39,6 +41,12 @@
         <notificationGroup id="Advanced Expression Folding"
                            displayType="BALLOON"
                            isLogByDefault="true"/>
+
+        <postStartupActivity implementation="com.intellij.advancedExpressionFolding.discovery.RuleDiscoveryStartupActivity"/>
+
+        <toolWindow id="Fold Rule Discovery"
+                    anchor="left"
+                    factoryClass="com.intellij.advancedExpressionFolding.discovery.RuleDiscoveryToolWindowFactory"/>
 
         <!-- Suggests pseudo-annotations supported by the plugin -->
         <completion.contributor

--- a/src/com/intellij/advancedExpressionFolding/discovery/CandidateFamily.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/CandidateFamily.kt
@@ -1,0 +1,9 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+internal enum class CandidateFamily(val id: String) {
+    CHAIN_CALL("chainCall"),
+    GUARD_IF("guardIf"),
+    LOGGER_LINE("loggerLine"),
+    BUILDER_BLOCK("builderBlock"),
+    LONG_PARAMETER_LIST("longParameterList")
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/FeatureDictionary.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/FeatureDictionary.kt
@@ -1,0 +1,201 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import java.util.Locale
+import kotlin.math.roundToInt
+
+internal data class FeatureDescriptor(
+    val index: Int,
+    val key: String,
+    val description: String,
+    val allowPredicate: Boolean = true,
+    val psiCheck: (PredicateClause) -> String,
+    val predicateLine: (PredicateClause) -> String
+)
+
+internal object FeatureDictionary {
+    const val FEATURE_COUNT: Int = 18
+
+    private val descriptors: List<FeatureDescriptor> = listOf(
+        FeatureDescriptor(
+            index = 0,
+            key = "languageId",
+            description = "Language hash",
+            allowPredicate = false,
+            psiCheck = ::unsupported,
+            predicateLine = ::unsupportedLine
+        ),
+        FeatureDescriptor(
+            index = 1,
+            key = "extensionId",
+            description = "File extension hash",
+            allowPredicate = false,
+            psiCheck = ::unsupported,
+            predicateLine = ::unsupportedLine
+        ),
+        FeatureDescriptor(
+            index = 2,
+            key = "psiKindId",
+            description = "PSI node kind hash",
+            allowPredicate = false,
+            psiCheck = ::unsupported,
+            predicateLine = ::unsupportedLine
+        ),
+        FeatureDescriptor(
+            index = 3,
+            key = "foldTypeId",
+            description = "Candidate family hash",
+            allowPredicate = false,
+            psiCheck = ::unsupported,
+            predicateLine = ::unsupportedLine
+        ),
+        FeatureDescriptor(
+            index = 4,
+            key = "depth",
+            description = "Depth in PSI tree",
+            psiCheck = { clause -> comparison("depth", clause) },
+            predicateLine = { clause -> "depth(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 5,
+            key = "tokenSpan",
+            description = "Token span length",
+            psiCheck = { clause -> comparison("token span", clause) },
+            predicateLine = { clause -> "tokenSpan(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 6,
+            key = "lineSpan",
+            description = "Line span length",
+            psiCheck = { clause -> comparison("line span", clause) },
+            predicateLine = { clause -> "lineSpan(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 7,
+            key = "siblingCount",
+            description = "Sibling count",
+            psiCheck = { clause -> comparison("sibling count", clause) },
+            predicateLine = { clause -> "siblingCount(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 8,
+            key = "childCount",
+            description = "Child count",
+            psiCheck = { clause -> comparison("child count", clause) },
+            predicateLine = { clause -> "childCount(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 9,
+            key = "chainLength",
+            description = "Chain length",
+            psiCheck = { clause -> comparison("chain length", clause) },
+            predicateLine = { clause -> "chainLength(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 10,
+            key = "loggerCall",
+            description = "Contains logger call",
+            psiCheck = { clause ->
+                if (clause.operator == ComparisonOperator.GREATER_OR_EQUAL) {
+                    "logger call present"
+                } else {
+                    "logger call absent"
+                }
+            },
+            predicateLine = { clause ->
+                val expected = clause.operator == ComparisonOperator.GREATER_OR_EQUAL
+                "hasLoggerCall(element) == ${expected}"
+            }
+        ),
+        FeatureDescriptor(
+            index = 11,
+            key = "nullCheck",
+            description = "Contains null-check",
+            psiCheck = { clause ->
+                if (clause.operator == ComparisonOperator.GREATER_OR_EQUAL) {
+                    "includes null check"
+                } else {
+                    "no null check"
+                }
+            },
+            predicateLine = { clause ->
+                val expected = clause.operator == ComparisonOperator.GREATER_OR_EQUAL
+                "hasNullCheck(element) == ${expected}"
+            }
+        ),
+        FeatureDescriptor(
+            index = 12,
+            key = "commentDensity",
+            description = "Comment density",
+            psiCheck = { clause -> comparison("comment density", clause, 2) },
+            predicateLine = { clause -> "commentDensity(element) ${symbol(clause)} ${formatDouble(clause.originalThreshold, 2)}" }
+        ),
+        FeatureDescriptor(
+            index = 13,
+            key = "indentLevel",
+            description = "Indent level",
+            psiCheck = { clause -> comparison("indent level", clause) },
+            predicateLine = { clause -> "indentLevel(element) ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 14,
+            key = "nestingIf",
+            description = "Ancestor if-count",
+            psiCheck = { clause -> comparison("if nesting", clause) },
+            predicateLine = { clause -> "nestingHistogram(element)[0] ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 15,
+            key = "nestingLoop",
+            description = "Ancestor loop-count",
+            psiCheck = { clause -> comparison("loop nesting", clause) },
+            predicateLine = { clause -> "nestingHistogram(element)[1] ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 16,
+            key = "nestingTry",
+            description = "Ancestor try-count",
+            psiCheck = { clause -> comparison("try nesting", clause) },
+            predicateLine = { clause -> "nestingHistogram(element)[2] ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        ),
+        FeatureDescriptor(
+            index = 17,
+            key = "nestingLambda",
+            description = "Ancestor lambda-count",
+            psiCheck = { clause -> comparison("lambda nesting", clause) },
+            predicateLine = { clause -> "nestingHistogram(element)[3] ${symbol(clause)} ${formatInt(clause.originalThreshold)}" }
+        )
+    )
+
+    fun descriptor(index: Int): FeatureDescriptor = descriptors[index]
+
+    fun allowedPredicateIndices(): List<Int> = descriptors.filter { it.allowPredicate }.map { it.index }
+
+    private fun unsupported(@Suppress("UNUSED_PARAMETER") clause: PredicateClause): String =
+        "not supported"
+
+    private fun unsupportedLine(@Suppress("UNUSED_PARAMETER") clause: PredicateClause): String =
+        "// not supported"
+
+    private fun symbol(clause: PredicateClause): String = when (clause.operator) {
+        ComparisonOperator.GREATER_OR_EQUAL -> ">="
+        ComparisonOperator.LESS_OR_EQUAL -> "<="
+    }
+
+    private fun comparison(label: String, clause: PredicateClause, decimals: Int = 0): String {
+        val formatted = if (decimals == 0) {
+            formatInt(clause.originalThreshold)
+        } else {
+            formatDouble(clause.originalThreshold, decimals)
+        }
+        val operator = when (clause.operator) {
+            ComparisonOperator.GREATER_OR_EQUAL -> "≥"
+            ComparisonOperator.LESS_OR_EQUAL -> "≤"
+        }
+        return "$label $operator $formatted"
+    }
+
+    private fun formatInt(value: Double): Int = value.roundToInt()
+
+    private fun formatDouble(value: Double, decimals: Int): String =
+        String.format(Locale.US, "%.${decimals}f", value)
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/FeatureStandardizer.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/FeatureStandardizer.kt
@@ -1,0 +1,55 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import org.jetbrains.kotlinx.multik.api.d1array
+import org.jetbrains.kotlinx.multik.api.mk
+import org.jetbrains.kotlinx.multik.ndarray.data.get
+import kotlin.math.sqrt
+
+internal data class StandardizationResult(
+    val occurrences: List<StandardizedOccurrence>,
+    val means: DoubleArray,
+    val std: DoubleArray
+)
+
+internal class FeatureStandardizer {
+
+    fun standardize(occurrences: List<CandidateOccurrence>): StandardizationResult {
+        if (occurrences.isEmpty()) {
+            val zeros = DoubleArray(FeatureDictionary.FEATURE_COUNT)
+            val ones = DoubleArray(FeatureDictionary.FEATURE_COUNT) { 1.0 }
+            return StandardizationResult(emptyList(), zeros, ones)
+        }
+
+        val featureCount = FeatureDictionary.FEATURE_COUNT
+        val rows = occurrences.size
+        val means = DoubleArray(featureCount)
+        val std = DoubleArray(featureCount)
+
+        for (col in 0 until featureCount) {
+            var sum = 0.0
+            occurrences.forEach { sum += it.features[col] }
+            val mean = sum / rows.toDouble()
+            means[col] = mean
+
+            var sumSquares = 0.0
+            occurrences.forEach { occurrence ->
+                val diff = occurrence.features[col] - mean
+                sumSquares += diff * diff
+            }
+            val variance = sumSquares / rows.toDouble()
+            val stdValue = sqrt(variance)
+            std[col] = if (stdValue == 0.0 || stdValue.isNaN()) 1.0 else stdValue
+        }
+
+        val standardized = occurrences.map { occurrence ->
+            val normalizedVector = mk.d1array(featureCount) { featureIndex ->
+                val centered = (occurrence.features[featureIndex] - means[featureIndex]) / std[featureIndex]
+                centered.coerceIn(-4.0, 4.0)
+            }
+            val normalizedArray = DoubleArray(featureCount) { index -> normalizedVector[index] }
+            StandardizedOccurrence(occurrence, normalizedArray)
+        }
+
+        return StandardizationResult(standardized, means, std)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/IndexedPoint.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/IndexedPoint.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import org.apache.commons.math3.ml.clustering.Clusterable
+
+internal data class IndexedPoint(
+    val index: Int,
+    private val coordinates: DoubleArray
+) : Clusterable {
+    override fun getPoint(): DoubleArray = coordinates
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/ParameterSelector.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/ParameterSelector.kt
@@ -1,0 +1,125 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import org.apache.commons.math3.ml.clustering.DBSCANClusterer
+import org.apache.commons.math3.ml.clustering.Cluster
+import kotlin.math.min
+import kotlin.math.sqrt
+
+internal data class DbscanParameters(
+    val eps: Double,
+    val minPts: Int,
+    val noiseRate: Double,
+    val coreRatio: Double
+)
+
+internal class ParameterSelector(
+    private val data: Array<DoubleArray>,
+    private val epsCandidates: DoubleArray,
+    private val minPtsCandidates: IntArray
+) {
+
+    fun select(): DbscanParameters? {
+        if (data.isEmpty()) {
+            return null
+        }
+        val validationPoints = createValidationPoints()
+        val globalMedian = medianDistance(validationPoints)
+        var best: DbscanParameters? = null
+        var bestScore = Double.POSITIVE_INFINITY
+
+        for (eps in epsCandidates) {
+            for (minPts in minPtsCandidates) {
+                val clusterer = DBSCANClusterer<IndexedPoint>(eps, minPts)
+                val clusters = clusterer.cluster(validationPoints)
+                if (clusters.isEmpty()) {
+                    continue
+                }
+                val labels = IntArray(validationPoints.size) { -1 }
+                clusters.forEachIndexed { clusterId, cluster ->
+                    cluster.points.forEach { point ->
+                        labels[point.index] = clusterId
+                    }
+                }
+                val noiseCount = labels.count { it == -1 }
+                val noiseRate = noiseCount.toDouble() / validationPoints.size.toDouble()
+                val coreRatio = 1.0 - noiseRate
+                if (coreRatio < 0.6 || noiseRate > 0.4) {
+                    continue
+                }
+                val intraMedian = intraClusterMedian(clusters)
+                val ratio = if (globalMedian == 0.0) Double.POSITIVE_INFINITY else intraMedian / globalMedian
+                if (ratio < bestScore) {
+                    bestScore = ratio
+                    best = DbscanParameters(eps, minPts, noiseRate, coreRatio)
+                }
+            }
+        }
+
+        return best
+    }
+
+    private fun createValidationPoints(): List<IndexedPoint> {
+        val size = min(data.size, MAX_VALIDATION)
+        return (0 until size).map { index -> IndexedPoint(index, data[index]) }
+    }
+
+    private fun medianDistance(points: List<IndexedPoint>): Double {
+        val dimension = points.first().point.size
+        val centroid = DoubleArray(dimension)
+        points.forEach { point ->
+            val vector = point.point
+            for (i in vector.indices) {
+                centroid[i] += vector[i]
+            }
+        }
+        for (i in centroid.indices) {
+            centroid[i] /= points.size.toDouble()
+        }
+        val distances = points.map { euclidean(it.point, centroid) }.sorted()
+        return distances[distances.size / 2]
+    }
+
+    private fun intraClusterMedian(clusters: List<Cluster<IndexedPoint>>): Double {
+        if (clusters.isEmpty()) {
+            return Double.POSITIVE_INFINITY
+        }
+        val values = mutableListOf<Double>()
+        clusters.forEach { cluster ->
+            val clusterPoints = cluster.points
+            if (clusterPoints.isEmpty()) {
+                return@forEach
+            }
+            val centroid = DoubleArray(clusterPoints.first().point.size)
+            clusterPoints.forEach { point ->
+                val vector = point.point
+                for (i in vector.indices) {
+                    centroid[i] += vector[i]
+                }
+            }
+            for (i in centroid.indices) {
+                centroid[i] /= clusterPoints.size.toDouble()
+            }
+            clusterPoints.forEach { point ->
+                values += euclidean(point.point, centroid)
+            }
+        }
+        if (values.isEmpty()) {
+            return Double.POSITIVE_INFINITY
+        }
+        val sorted = values.sorted()
+        return sorted[sorted.size / 2]
+    }
+
+    private fun euclidean(a: DoubleArray, b: DoubleArray): Double {
+        var sum = 0.0
+        for (i in a.indices) {
+            val diff = a[i] - b[i]
+            sum += diff * diff
+        }
+        return sqrt(sum)
+    }
+
+    companion object {
+        private const val MAX_VALIDATION = 800
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/PredicateSynthesizer.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/PredicateSynthesizer.kt
@@ -1,0 +1,221 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import kotlin.math.abs
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+
+internal data class PredicateSynthesis(
+    val predicate: RulePredicate,
+    val description: String,
+    val psiChecks: List<String>,
+    val snippet: String
+)
+
+internal class PredicateSynthesizer(
+    private val means: DoubleArray,
+    private val std: DoubleArray
+) {
+
+    fun synthesize(
+        clusterIndices: List<Int>,
+        train: List<StandardizedOccurrence>,
+        negatives: List<StandardizedOccurrence>
+    ): PredicateSynthesis? {
+        if (clusterIndices.isEmpty()) {
+            return null
+        }
+
+        val allowedFeatures = FeatureDictionary.allowedPredicateIndices()
+        val membership = BooleanArray(train.size)
+        clusterIndices.forEach { membership[it] = true }
+
+        val mutualInformation = allowedFeatures.associateWith { index ->
+            computeMutualInformation(index, train, membership)
+        }
+
+        val ranked = mutualInformation.entries
+            .sortedByDescending { it.value }
+            .map { it.key }
+
+        val predicateClauses = mutableListOf<PredicateClause>()
+
+        for (featureIndex in ranked.take(MAX_FEATURES)) {
+            val clause = buildClause(featureIndex, predicateClauses, clusterIndices, train, negatives) ?: continue
+            predicateClauses += clause
+            val coverage = coverage(clusterIndices, predicateClauses, train)
+            val falsePositiveRate = falsePositiveRate(predicateClauses, negatives)
+            if (coverage >= REQUIRED_COVERAGE && falsePositiveRate <= MAX_FALSE_POSITIVE) {
+                break
+            }
+        }
+
+        if (predicateClauses.isEmpty()) {
+            return null
+        }
+
+        val coverage = coverage(clusterIndices, predicateClauses, train)
+        val falsePositiveRate = falsePositiveRate(predicateClauses, negatives)
+        if (coverage < REQUIRED_COVERAGE || falsePositiveRate > MAX_FALSE_POSITIVE) {
+            return null
+        }
+
+        val predicate = RulePredicate(predicateClauses)
+        val descriptors = predicateClauses.map { FeatureDictionary.descriptor(it.featureIndex) }
+        val description = descriptors.joinToString(", ") { it.description }
+        val psiChecks = predicateClauses.map { clause ->
+            val descriptor = FeatureDictionary.descriptor(clause.featureIndex)
+            descriptor.psiCheck(clause)
+        }
+        val snippet = buildSnippet(predicateClauses)
+
+        return PredicateSynthesis(predicate, description, psiChecks, snippet)
+    }
+
+    private fun buildSnippet(clauses: List<PredicateClause>): String {
+        val body = clauses.joinToString(separator = " &&\n        ") { clause ->
+            val descriptor = FeatureDictionary.descriptor(clause.featureIndex)
+            descriptor.predicateLine(clause)
+        }
+        return "fun matches(element: PsiElement): Boolean =\n        $body"
+    }
+
+    private fun buildClause(
+        featureIndex: Int,
+        existing: List<PredicateClause>,
+        clusterIndices: List<Int>,
+        train: List<StandardizedOccurrence>,
+        negatives: List<StandardizedOccurrence>
+    ): PredicateClause? {
+        val clusterValues = clusterIndices.map { train[it].standardized[featureIndex] }.sorted()
+        if (clusterValues.isEmpty()) {
+            return null
+        }
+        val lower = percentile(clusterValues, 0.1)
+        val upper = percentile(clusterValues, 0.9)
+        val candidates = listOf(
+            ComparisonCandidate(ComparisonOperator.GREATER_OR_EQUAL, lower),
+            ComparisonCandidate(ComparisonOperator.LESS_OR_EQUAL, upper)
+        )
+
+        var bestClause: PredicateClause? = null
+        var bestScore = Double.POSITIVE_INFINITY
+
+        for (candidate in candidates) {
+            val clause = predicateClause(featureIndex, candidate)
+            val combined = existing + clause
+            val coverage = coverage(clusterIndices, combined, train)
+            val falsePositive = falsePositiveRate(combined, negatives)
+            if (coverage < REQUIRED_COVERAGE || falsePositive > MAX_FALSE_POSITIVE) {
+                continue
+            }
+            val score = falsePositive + (1.0 - coverage)
+            if (score < bestScore) {
+                bestScore = score
+                bestClause = clause
+            }
+        }
+
+        return bestClause
+    }
+
+    private fun predicateClause(featureIndex: Int, candidate: ComparisonCandidate): PredicateClause {
+        val originalThreshold = candidate.threshold * std[featureIndex] + means[featureIndex]
+        return PredicateClause(featureIndex, candidate.operator, candidate.threshold, originalThreshold)
+    }
+
+    private fun coverage(
+        clusterIndices: List<Int>,
+        clauses: List<PredicateClause>,
+        data: List<StandardizedOccurrence>
+    ): Double {
+        if (clusterIndices.isEmpty()) {
+            return 0.0
+        }
+        val predicate = RulePredicate(clauses)
+        val matches = clusterIndices.count { index -> predicate.matches(data[index].standardized) }
+        return matches.toDouble() / clusterIndices.size.toDouble()
+    }
+
+    private fun falsePositiveRate(clauses: List<PredicateClause>, negatives: List<StandardizedOccurrence>): Double {
+        if (negatives.isEmpty()) {
+            return 0.0
+        }
+        val predicate = RulePredicate(clauses)
+        val matches = negatives.count { occurrence -> predicate.matches(occurrence.standardized) }
+        return matches.toDouble() / negatives.size.toDouble()
+    }
+
+    private fun computeMutualInformation(
+        featureIndex: Int,
+        data: List<StandardizedOccurrence>,
+        membership: BooleanArray
+    ): Double {
+        val values = DoubleArray(data.size) { idx -> data[idx].standardized[featureIndex] }
+        val minValue = values.minOrNull() ?: return 0.0
+        val maxValue = values.maxOrNull() ?: return 0.0
+        if (abs(maxValue - minValue) < 1e-6) {
+            return 0.0
+        }
+        val binCount = 6
+        val step = (maxValue - minValue) / binCount
+        val counts = Array(binCount) { DoubleArray(2) }
+        for (i in values.indices) {
+            var bin = ((values[i] - minValue) / step).toInt()
+            if (bin >= binCount) {
+                bin = binCount - 1
+            }
+            val label = if (membership[i]) 1 else 0
+            counts[bin][label] += 1.0
+        }
+        val total = values.size.toDouble()
+        val labelCounts = DoubleArray(2)
+        counts.forEach { pair ->
+            labelCounts[0] += pair[0]
+            labelCounts[1] += pair[1]
+        }
+        var result = 0.0
+        for (bin in 0 until binCount) {
+            val binTotal = counts[bin][0] + counts[bin][1]
+            if (binTotal == 0.0) continue
+            for (label in 0..1) {
+                val joint = counts[bin][label]
+                if (joint == 0.0) continue
+                val jointProb = joint / total
+                val binProb = binTotal / total
+                val labelProb = labelCounts[label] / total
+                result += jointProb * ln(jointProb / (binProb * labelProb))
+            }
+        }
+        return result
+    }
+
+    private fun percentile(values: List<Double>, percentile: Double): Double {
+        if (values.isEmpty()) {
+            return 0.0
+        }
+        if (values.size == 1) {
+            return values[0]
+        }
+        val clamped = percentile.coerceIn(0.0, 1.0)
+        val position = clamped * (values.size - 1)
+        val index = position.toInt()
+        val fraction = position - index
+        if (index + 1 >= values.size) {
+            return values.last()
+        }
+        return values[index] * (1 - fraction) + values[index + 1] * fraction
+    }
+
+    private data class ComparisonCandidate(
+        val operator: ComparisonOperator,
+        val threshold: Double
+    )
+
+    companion object {
+        private const val REQUIRED_COVERAGE = 0.9
+        private const val MAX_FALSE_POSITIVE = 0.1
+        private const val MAX_FEATURES = 3
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleClusterer.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleClusterer.kt
@@ -1,0 +1,141 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import org.apache.commons.math3.ml.clustering.DBSCANClusterer
+import kotlin.math.sqrt
+
+internal data class ClusterOutput(
+    val rules: List<RuleCandidate>,
+    val noiseContribution: Double
+)
+
+internal class RuleClusterer(
+    private val language: String,
+    private val family: String,
+    private val occurrences: List<StandardizedOccurrence>,
+    private val means: DoubleArray,
+    private val std: DoubleArray,
+    private val epsCandidates: DoubleArray = doubleArrayOf(0.8, 1.0, 1.2, 1.5),
+    private val minPtsCandidates: IntArray = intArrayOf(8, 12, 16)
+) {
+
+    fun cluster(): ClusterOutput {
+        if (occurrences.isEmpty()) {
+            return ClusterOutput(emptyList(), 0.0)
+        }
+
+        val train = occurrences.filter { it.base.split == DatasetSplit.TRAIN }
+        val holdout = occurrences.filter { it.base.split == DatasetSplit.TEST }
+        if (train.size < minPtsCandidates.minOrNull() ?: 5) {
+            return ClusterOutput(emptyList(), 0.0)
+        }
+
+        val trainData = train.map { it.standardized }.toTypedArray()
+        val selector = ParameterSelector(trainData, epsCandidates, minPtsCandidates)
+        val parameters = selector.select() ?: return ClusterOutput(emptyList(), 0.0)
+
+        val clusterer = DBSCANClusterer<IndexedPoint>(parameters.eps, parameters.minPts)
+        val trainPoints = train.mapIndexed { index, occurrence -> IndexedPoint(index, occurrence.standardized) }
+        val clusters = clusterer.cluster(trainPoints)
+        if (clusters.isEmpty()) {
+            val noiseContribution = occurrences.size.toDouble()
+            return ClusterOutput(emptyList(), noiseContribution)
+        }
+        val labels = IntArray(trainPoints.size) { -1 }
+        clusters.forEachIndexed { clusterId, cluster ->
+            cluster.points.forEach { point ->
+                labels[point.index] = clusterId
+            }
+        }
+        val noiseRate = labels.count { it == -1 }.toDouble() / trainPoints.size.toDouble()
+        val synthesizer = PredicateSynthesizer(means, std)
+        val rules = mutableListOf<RuleCandidate>()
+        var clusterIndex = 0
+
+        clusters.forEachIndexed { label, cluster ->
+            val indices = cluster.points.map { it.index }
+            val negatives = train.filterIndexed { idx, _ -> labels[idx] != label }
+            val synthesis = synthesizer.synthesize(indices, train, negatives) ?: return@forEachIndexed
+            val centroid = centroid(indices, train)
+            val metrics = evaluateHoldout(synthesis.predicate, centroid, parameters.eps, holdout)
+            val support = indices.size
+            if (support < 50 || metrics.precision < 0.8) {
+                return@forEachIndexed
+            }
+            val examples = indices.take(MAX_EXAMPLES).mapNotNull { index ->
+                val base = train[index].base
+                val range = base.metadata.lineRange
+                val snippet = base.metadata.snippet
+                val formattedRange = "${range.first}-${range.last}"
+                RuleExample(base.metadata.fileHash, formattedRange, snippet)
+            }
+            val ruleId = "${family}_${language}_${clusterIndex++}"
+            val candidate = RuleCandidate(
+                id = ruleId,
+                language = language,
+                foldType = family,
+                predicateDescription = synthesis.description,
+                psiChecks = synthesis.psiChecks,
+                predicateSnippet = synthesis.snippet,
+                metrics = metrics.copy(support = support, noiseRate = noiseRate),
+                examples = examples
+            )
+            rules += candidate
+        }
+
+        return ClusterOutput(rules, noiseRate * occurrences.size)
+    }
+
+    private fun centroid(indices: List<Int>, data: List<StandardizedOccurrence>): DoubleArray {
+        val centroid = DoubleArray(FeatureDictionary.FEATURE_COUNT)
+        indices.forEach { index ->
+            val vector = data[index].standardized
+            for (i in vector.indices) {
+                centroid[i] += vector[i]
+            }
+        }
+        for (i in centroid.indices) {
+            centroid[i] /= indices.size.toDouble()
+        }
+        return centroid
+    }
+
+    private fun evaluateHoldout(
+        predicate: RulePredicate,
+        centroid: DoubleArray,
+        eps: Double,
+        holdout: List<StandardizedOccurrence>
+    ): RuleMetrics {
+        var predicted = 0
+        var truePositives = 0
+        var actualPositives = 0
+        for (occurrence in holdout) {
+            val actual = distance(occurrence.standardized, centroid) <= eps
+            if (actual) {
+                actualPositives++
+            }
+            val match = predicate.matches(occurrence.standardized)
+            if (match) {
+                predicted++
+            }
+            if (match && actual) {
+                truePositives++
+            }
+        }
+        val precision = if (predicted == 0) 1.0 else truePositives.toDouble() / predicted.toDouble()
+        val recall = if (actualPositives == 0) 0.0 else truePositives.toDouble() / actualPositives.toDouble()
+        return RuleMetrics(0, precision, recall, 0.0)
+    }
+
+    private fun distance(a: DoubleArray, b: DoubleArray): Double {
+        var sum = 0.0
+        for (i in a.indices) {
+            val diff = a[i] - b[i]
+            sum += diff * diff
+        }
+        return sqrt(sum)
+    }
+
+    companion object {
+        private const val MAX_EXAMPLES = 5
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryFileWriter.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryFileWriter.kt
@@ -1,0 +1,74 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.application.PathManager
+import java.io.BufferedWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+internal object RuleDiscoveryFileWriter {
+
+    private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+    fun write(report: RuleDiscoveryReport) {
+        val configDir = PathManager.getConfigDir()
+        val targetDir = configDir.resolve("advanced-expression-folding")
+        Files.createDirectories(targetDir)
+        val target = targetDir.resolve("rules.yaml")
+        Files.newBufferedWriter(target).use { writer ->
+            writeHeader(writer, report, target)
+            report.rules.forEach { rule ->
+                writeRule(writer, rule)
+            }
+        }
+    }
+
+    private fun writeHeader(writer: BufferedWriter, report: RuleDiscoveryReport, target: Path) {
+        writer.appendLine("# Auto-generated rule discovery report")
+        writer.appendLine("# Generated: ${formatter.format(report.generatedAt.atOffset(ZoneOffset.UTC))}")
+        writer.appendLine("# Target: ${target.toAbsolutePath()}")
+        writer.appendLine("# Total rules: ${report.rules.size}")
+        writer.appendLine("# Stats: occurrences=${report.stats.totalOccurrences}, languages=${report.stats.languagesProcessed}, families=${report.stats.familyCount}, noiseRate=${"%.3f".format(Locale.US, report.stats.overallNoiseRate)}")
+    }
+
+    private fun writeRule(writer: BufferedWriter, rule: RuleCandidate) {
+        writer.appendLine("- id: ${escape(rule.id)}")
+        writer.appendLine("  language: ${escape(rule.language)}")
+        writer.appendLine("  foldType: ${escape(rule.foldType)}")
+        writer.appendLine("  predicateDescription: ${escape(rule.predicateDescription)}")
+        writer.appendLine("  psiChecks:")
+        rule.psiChecks.forEach { check ->
+            writer.appendLine("    - ${escape(check)}")
+        }
+        writer.appendLine("  predicateSnippet: |")
+        rule.predicateSnippet.lines().forEach { line ->
+            writer.appendLine("    ${line.trimEnd()}")
+        }
+        writer.appendLine("  metrics:")
+        writer.appendLine("    support: ${rule.metrics.support}")
+        writer.appendLine("    precision: ${"%.3f".format(Locale.US, rule.metrics.precision)}")
+        writer.appendLine("    recall: ${"%.3f".format(Locale.US, rule.metrics.recall)}")
+        writer.appendLine("    noiseRate: ${"%.3f".format(Locale.US, rule.metrics.noiseRate)}")
+        writer.appendLine("  examples:")
+        rule.examples.take(MAX_EXAMPLES).forEach { example ->
+            writer.appendLine("    - file: ${escape(example.fileHash)}")
+            writer.appendLine("      range: ${escape(example.range)}")
+            writer.appendLine("      code: |")
+            example.code.lines().forEach { line ->
+                writer.appendLine("        ${line.trimEnd()}")
+            }
+        }
+    }
+
+    private fun escape(value: String): String {
+        if (value.isEmpty()) {
+            return "''"
+        }
+        val escaped = value.replace("'", "''")
+        return "'${escaped}'"
+    }
+
+    private const val MAX_EXAMPLES = 5
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryListener.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryListener.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.util.messages.Topic
+
+internal fun interface RuleDiscoveryListener {
+    fun onRulesUpdated(report: RuleDiscoveryReport)
+
+    companion object {
+        val TOPIC: Topic<RuleDiscoveryListener> =
+            Topic.create("advancedExpressionFolding.ruleDiscoveryReport", RuleDiscoveryListener::class.java)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryManager.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryManager.kt
@@ -1,0 +1,99 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+@Service(Service.Level.PROJECT)
+internal class RuleDiscoveryManager(private val project: Project) : Disposable {
+
+    private val stateRef = AtomicReference<RuleDiscoveryReport?>(null)
+    private val running = AtomicBoolean(false)
+    private val scheduler = AppExecutorUtil.getAppScheduledExecutorService()
+    private var scheduledFuture: ScheduledFuture<*>? = null
+
+    init {
+        ApplicationManager.getApplication().messageBus.connect(this)
+            .subscribe(RuleDiscoveryToggleListener.TOPIC, RuleDiscoveryToggleListener { enabled ->
+                if (enabled) {
+                    scheduleScan()
+                } else {
+                    cancelScheduled()
+                }
+            })
+    }
+
+    fun initialize() {
+        if (AdvancedExpressionFoldingSettings.getInstance().state.discoverNewFoldRules) {
+            scheduleScan()
+        }
+    }
+
+    fun currentReport(): RuleDiscoveryReport? = stateRef.get()
+
+    private fun scheduleScan() {
+        if (!running.compareAndSet(false, true)) {
+            return
+        }
+
+        DumbService.getInstance(project).runWhenSmart {
+            cancelScheduled(resetRunning = false)
+            scheduledFuture = scheduler.schedule({
+                if (!AdvancedExpressionFoldingSettings.getInstance().state.discoverNewFoldRules || project.isDisposed) {
+                    running.set(false)
+                    return@schedule
+                }
+                ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Discover fold rules", true) {
+                    override fun run(indicator: ProgressIndicator) {
+                        executePipeline(indicator)
+                    }
+
+                    override fun onFinished() {
+                        running.set(false)
+                    }
+
+                    override fun onCancel() {
+                        running.set(false)
+                    }
+                })
+            }, 5, TimeUnit.SECONDS)
+        }
+    }
+
+    private fun executePipeline(indicator: ProgressIndicator) {
+        val pipeline = RuleDiscoveryPipeline(project)
+        val report = try {
+            pipeline.execute(indicator)
+        } catch (ignored: Throwable) {
+            running.set(false)
+            throw ignored
+        }
+
+        stateRef.set(report)
+        RuleDiscoveryFileWriter.write(report)
+        project.messageBus.syncPublisher(RuleDiscoveryListener.TOPIC).onRulesUpdated(report)
+    }
+
+    private fun cancelScheduled(resetRunning: Boolean = true) {
+        scheduledFuture?.cancel(true)
+        scheduledFuture = null
+        if (resetRunning) {
+            running.set(false)
+        }
+    }
+
+    override fun dispose() {
+        cancelScheduled()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryModels.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryModels.kt
@@ -1,0 +1,95 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.util.TextRange
+import java.time.Instant
+
+internal enum class DatasetSplit {
+    TRAIN,
+    TEST
+}
+
+internal data class CandidateMetadata(
+    val fileHash: String,
+    val psiKind: String,
+    val lineRange: IntRange,
+    val snippet: String,
+    val fileExtension: String?,
+    val indentLevel: Int,
+    val textRange: TextRange
+)
+
+internal data class CandidateOccurrence(
+    val id: String,
+    val language: String,
+    val foldType: String,
+    val features: DoubleArray,
+    val timestamp: Long,
+    val metadata: CandidateMetadata,
+    var split: DatasetSplit = DatasetSplit.TRAIN
+)
+
+internal data class StandardizedOccurrence(
+    val base: CandidateOccurrence,
+    val standardized: DoubleArray
+)
+
+internal data class RuleMetrics(
+    val support: Int,
+    val precision: Double,
+    val recall: Double,
+    val noiseRate: Double
+)
+
+internal data class RuleExample(
+    val fileHash: String,
+    val range: String,
+    val code: String
+)
+
+internal data class RuleCandidate(
+    val id: String,
+    val language: String,
+    val foldType: String,
+    val predicateDescription: String,
+    val psiChecks: List<String>,
+    val predicateSnippet: String,
+    val metrics: RuleMetrics,
+    val examples: List<RuleExample>
+)
+
+internal data class PipelineStats(
+    val totalOccurrences: Int,
+    val languagesProcessed: Int,
+    val familyCount: Int,
+    val overallNoiseRate: Double
+)
+
+internal data class RuleDiscoveryReport(
+    val generatedAt: Instant,
+    val rules: List<RuleCandidate>,
+    val stats: PipelineStats
+)
+
+internal enum class ComparisonOperator {
+    GREATER_OR_EQUAL,
+    LESS_OR_EQUAL
+}
+
+internal data class PredicateClause(
+    val featureIndex: Int,
+    val operator: ComparisonOperator,
+    val threshold: Double,
+    val originalThreshold: Double
+)
+
+internal data class RulePredicate(
+    val clauses: List<PredicateClause>
+) {
+    fun matches(features: DoubleArray): Boolean = clauses.all { clause ->
+        val value = features[clause.featureIndex]
+        when (clause.operator) {
+            ComparisonOperator.GREATER_OR_EQUAL -> value >= clause.threshold
+            ComparisonOperator.LESS_OR_EQUAL -> value <= clause.threshold
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryPanel.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryPanel.kt
@@ -1,0 +1,129 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.ListTableModel
+import com.intellij.util.ui.UIUtil
+import com.intellij.util.ui.ColumnInfo
+import com.intellij.ui.JBSplitter
+import com.intellij.openapi.Disposable
+import java.awt.BorderLayout
+import java.util.Locale
+import javax.swing.BorderFactory
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+
+internal class RuleDiscoveryPanel(project: Project) : JPanel(BorderLayout()), Disposable {
+
+    private val tableModel = ListTableModel<RuleRow>(
+        RuleColumn("ID"),
+        RuleColumn("Language"),
+        SupportColumn(),
+        PrecisionColumn(),
+        RecallColumn()
+    )
+    private val table = JBTable(tableModel)
+    private val detailsArea = JBTextArea()
+    private val statsLabel = JBLabel()
+    private var currentReport: RuleDiscoveryReport? = null
+
+    init {
+        border = BorderFactory.createEmptyBorder(8, 8, 8, 8)
+        table.selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        table.setShowGrid(false)
+        table.emptyText.text = "No rule candidates yet"
+        table.selectionModel.addListSelectionListener {
+            val index = table.selectedRow
+            val rule = if (index in 0 until tableModel.rowCount) {
+                currentReport?.rules?.getOrNull(index)
+            } else null
+            displayRule(rule)
+        }
+
+        detailsArea.isEditable = false
+        detailsArea.background = UIUtil.getPanelBackground()
+        detailsArea.font = UIUtil.getLabelFont()
+
+        val splitter = JBSplitter(true, 0.45f)
+        splitter.firstComponent = JBScrollPane(table)
+
+        val detailPanel = JPanel(BorderLayout())
+        detailPanel.add(statsLabel, BorderLayout.NORTH)
+        detailPanel.add(JBScrollPane(detailsArea), BorderLayout.CENTER)
+        splitter.secondComponent = detailPanel
+
+        add(splitter, BorderLayout.CENTER)
+    }
+
+    fun update(report: RuleDiscoveryReport?) {
+        currentReport = report
+        ApplicationManager.getApplication().invokeLater {
+            val items = report?.rules?.map { RuleRow(it) } ?: emptyList()
+            tableModel.setItems(items)
+            tableModel.fireTableDataChanged()
+            statsLabel.text = report?.let {
+                "${it.rules.size} rules · occurrences=${it.stats.totalOccurrences} · noise=${String.format(Locale.US, "%.2f", it.stats.overallNoiseRate)}"
+            } ?: ""
+            if (tableModel.rowCount > 0) {
+                table.setRowSelectionInterval(0, 0)
+            } else {
+                detailsArea.text = ""
+            }
+        }
+    }
+
+    private fun displayRule(rule: RuleCandidate?) {
+        if (rule == null) {
+            detailsArea.text = ""
+            return
+        }
+        val builder = StringBuilder()
+        builder.appendLine("Description: ${rule.predicateDescription}")
+        builder.appendLine("Psi checks:")
+        rule.psiChecks.forEach { builder.appendLine("  - $it") }
+        builder.appendLine()
+        builder.appendLine("Predicate:")
+        rule.predicateSnippet.lines().forEach { builder.appendLine("  $it") }
+        builder.appendLine()
+        builder.appendLine("Metrics:")
+        builder.appendLine("  Support: ${rule.metrics.support}")
+        builder.appendLine("  Precision: ${String.format(Locale.US, "%.2f", rule.metrics.precision)}")
+        builder.appendLine("  Recall: ${String.format(Locale.US, "%.2f", rule.metrics.recall)}")
+        builder.appendLine("  Noise: ${String.format(Locale.US, "%.2f", rule.metrics.noiseRate)}")
+        builder.appendLine()
+        if (rule.examples.isNotEmpty()) {
+            builder.appendLine("Examples:")
+            rule.examples.forEach { example ->
+                builder.appendLine("  - ${example.fileHash} @ ${example.range}")
+                example.code.lines().forEach { builder.appendLine("      $it") }
+            }
+        }
+        detailsArea.text = builder.toString()
+        detailsArea.caretPosition = 0
+    }
+
+    override fun dispose() {
+    }
+
+    private class RuleColumn(@Suppress("unused") private val name: String) : ColumnInfo<RuleRow, String>(name) {
+        override fun valueOf(item: RuleRow): String = item.rule.id
+    }
+
+    private class SupportColumn : ColumnInfo<RuleRow, Int>("Support") {
+        override fun valueOf(item: RuleRow): Int = item.rule.metrics.support
+    }
+
+    private class PrecisionColumn : ColumnInfo<RuleRow, String>("Precision") {
+        override fun valueOf(item: RuleRow): String = String.format(Locale.US, "%.2f", item.rule.metrics.precision)
+    }
+
+    private class RecallColumn : ColumnInfo<RuleRow, String>("Recall") {
+        override fun valueOf(item: RuleRow): String = String.format(Locale.US, "%.2f", item.rule.metrics.recall)
+    }
+
+    private data class RuleRow(val rule: RuleCandidate)
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryPipeline.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryPipeline.kt
@@ -1,0 +1,76 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import java.time.Instant
+
+internal class RuleDiscoveryPipeline(private val project: Project) {
+
+    fun execute(indicator: ProgressIndicator): RuleDiscoveryReport {
+        indicator.isIndeterminate = false
+        val scanner = RuleDiscoveryScanner()
+        val occurrences = scanner.collect(project, indicator)
+        if (occurrences.isEmpty()) {
+            val emptyStats = PipelineStats(0, 0, 0, 0.0)
+            return RuleDiscoveryReport(Instant.now(), emptyList(), emptyStats)
+        }
+
+        val rules = mutableListOf<RuleCandidate>()
+        val byLanguage = occurrences.groupBy { it.language }
+        var totalNoise = 0.0
+        var familyCount = 0
+
+        val standardizer = FeatureStandardizer()
+
+        byLanguage.forEach { (language, languageOccurrences) ->
+            ProgressManager.checkCanceled()
+            indicator.text = "Analyzing $language"
+            assignSplits(languageOccurrences)
+            val standardized = standardizer.standardize(languageOccurrences)
+            val byFamily = standardized.occurrences.groupBy { it.base.foldType }
+            familyCount += byFamily.size
+            byFamily.forEach { (family, group) ->
+                ProgressManager.checkCanceled()
+                val clusterer = RuleClusterer(language, family, group, standardized.means, standardized.std)
+                val clusterOutput = clusterer.cluster()
+                rules += clusterOutput.rules
+                totalNoise += clusterOutput.noiseContribution
+            }
+        }
+
+        val totalOccurrences = occurrences.size
+        val overallNoiseRate = if (totalOccurrences == 0) 0.0 else totalNoise / totalOccurrences.toDouble()
+
+        return RuleDiscoveryReport(
+            generatedAt = Instant.now(),
+            rules = rules.sortedByDescending { it.metrics.support },
+            stats = PipelineStats(
+                totalOccurrences = totalOccurrences,
+                languagesProcessed = byLanguage.size,
+                familyCount = familyCount,
+                overallNoiseRate = overallNoiseRate
+            )
+        )
+    }
+
+    private fun assignSplits(languageOccurrences: List<CandidateOccurrence>) {
+        val byFamily = languageOccurrences.groupBy { it.foldType }
+        byFamily.values.forEach { familyOccurrences ->
+            if (familyOccurrences.size < 5) {
+                familyOccurrences.forEach { it.split = DatasetSplit.TRAIN }
+                return@forEach
+            }
+            val sorted = familyOccurrences.sortedBy { it.timestamp }
+            val thresholdIndex = (sorted.size * 0.8).toInt().coerceAtMost(sorted.lastIndex)
+            val threshold = sorted[thresholdIndex].timestamp
+            familyOccurrences.forEach { occurrence ->
+                occurrence.split = if (occurrence.timestamp <= threshold) {
+                    DatasetSplit.TRAIN
+                } else {
+                    DatasetSplit.TEST
+                }
+            }
+        }
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryScanner.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryScanner.kt
@@ -1,0 +1,345 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiStatement
+import com.intellij.psi.PsiWhiteSpace
+import com.intellij.psi.PsiIfStatement
+import com.intellij.psi.util.PsiTreeUtil
+import java.security.MessageDigest
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.min
+
+internal class RuleDiscoveryScanner(
+    private val maxSamplesPerFile: Int = 400
+) {
+
+    fun collect(project: Project, indicator: ProgressIndicator): List<CandidateOccurrence> {
+        val files = mutableListOf<VirtualFile>()
+        val fileIndex = ProjectFileIndex.getInstance(project)
+        fileIndex.iterateContent { file ->
+            ProgressManager.checkCanceled()
+            if (!file.isValid || file.isDirectory || file.fileType.isBinary) {
+                return@iterateContent true
+            }
+            files.add(file)
+            true
+        }
+
+        if (files.isEmpty()) {
+            return emptyList()
+        }
+
+        val psiManager = com.intellij.psi.PsiManager.getInstance(project)
+        val documentManager = PsiDocumentManager.getInstance(project)
+        val occurrences = mutableListOf<CandidateOccurrence>()
+
+        files.forEachIndexed { index, file ->
+            ProgressManager.checkCanceled()
+            indicator.checkCanceled()
+            indicator.fraction = index.toDouble() / files.size.coerceAtLeast(1)
+            indicator.text = "Scanning ${file.presentableName()}"
+
+            val fileOccurrences = ReadAction.compute<List<CandidateOccurrence>, RuntimeException> {
+                val psiFile = psiManager.findFile(file) ?: return@compute emptyList()
+                if (psiFile.language.id.isNullOrEmpty()) {
+                    return@compute emptyList()
+                }
+                val document = documentManager.getDocument(psiFile) ?: return@compute emptyList()
+                val collector = CandidateCollector(
+                    psiFile,
+                    document,
+                    file.timeStamp,
+                    hashPath(file)
+                )
+                psiFile.accept(collector)
+                collector.results()
+            }
+            occurrences.addAll(fileOccurrences)
+        }
+
+        return occurrences
+    }
+
+    private fun VirtualFile.presentableName(): String = nameSequence.toString()
+
+    private fun hashPath(file: VirtualFile): String {
+        val digest = MessageDigest.getInstance("SHA-1")
+        val input = file.path.toByteArray()
+        val hashed = digest.digest(input)
+        return hashed.joinToString(separator = "") { String.format(Locale.US, "%02x", it) }
+    }
+
+    private inner class CandidateCollector(
+        private val psiFile: PsiFile,
+        private val document: Document,
+        private val timestamp: Long,
+        private val fileHash: String
+    ) : PsiRecursiveElementWalkingVisitor() {
+
+        private val seenRanges = HashSet<TextRange>()
+        private val results = mutableListOf<CandidateOccurrence>()
+        private var collected = 0
+
+        override fun visitElement(element: PsiElement) {
+            if (collected >= maxSamplesPerFile) {
+                return
+            }
+            ProgressManager.checkCanceled()
+            when (element) {
+                is PsiMethodCallExpression -> handleMethodCall(element)
+                is PsiIfStatement -> handleGuardIf(element)
+            }
+            super.visitElement(element)
+        }
+
+        fun results(): List<CandidateOccurrence> = results
+
+        private fun handleMethodCall(call: PsiMethodCallExpression) {
+            val methodName = call.methodExpression.referenceName ?: return
+            val chainLength = computeChainLength(call)
+            val text = call.text.lowercase(Locale.US)
+            val hasLoggerCall = LOGGER_NAMES.contains(methodName.lowercase(Locale.US)) || text.contains("logger")
+            val longParameterList = call.argumentList.expressions.size >= 6
+            val builderStyle = methodName in BUILDER_METHODS && text.contains("builder")
+
+            if (chainLength > 1) {
+                addCandidate(call, CandidateFamily.CHAIN_CALL, chainLength = chainLength, hasLoggerCall = hasLoggerCall)
+            }
+
+            if (hasLoggerCall) {
+                addCandidate(call, CandidateFamily.LOGGER_LINE, chainLength = chainLength, hasLoggerCall = true)
+            }
+
+            if (longParameterList) {
+                addCandidate(call, CandidateFamily.LONG_PARAMETER_LIST, chainLength = chainLength, hasLoggerCall = hasLoggerCall)
+            }
+
+            if (builderStyle) {
+                addCandidate(call, CandidateFamily.BUILDER_BLOCK, chainLength = chainLength, hasLoggerCall = hasLoggerCall)
+            }
+        }
+
+        private fun handleGuardIf(statement: PsiIfStatement) {
+            val conditionText = statement.condition?.text?.lowercase(Locale.US) ?: return
+            if (!conditionText.contains("null") && !conditionText.contains("instanceof")) {
+                return
+            }
+            val thenBranch = statement.thenBranch ?: return
+            val statements = PsiTreeUtil.getChildrenOfTypeAsList(thenBranch, PsiStatement::class.java)
+            val isGuard = statements.any { stmt ->
+                val text = stmt.text.lowercase(Locale.US)
+                text.contains("return") || text.contains("throw") || text.contains("continue")
+            }
+            if (isGuard) {
+                addCandidate(statement, CandidateFamily.GUARD_IF, hasNullCheck = true)
+            }
+        }
+
+        private fun addCandidate(
+            element: PsiElement,
+            family: CandidateFamily,
+            chainLength: Int = 0,
+            hasLoggerCall: Boolean = false,
+            hasNullCheck: Boolean = false
+        ) {
+            if (collected >= maxSamplesPerFile) {
+                return
+            }
+            val range = element.textRange ?: return
+            if (!seenRanges.add(range)) {
+                return
+            }
+
+            val lineInfo = computeLineInfo(range)
+            val commentDensity = computeCommentDensity(lineInfo.windowRange)
+            val indentLevel = indentLevel(lineInfo.startLine)
+            val nullCheck = hasNullCheck || element.text.contains("null", ignoreCase = true)
+            val loggerFlag = hasLoggerCall || element.text.contains("logger", ignoreCase = true)
+            val histogram = nestingHistogram(element)
+            val features = buildFeatures(
+                element,
+                family,
+                chainLength,
+                loggerFlag,
+                nullCheck,
+                commentDensity,
+                indentLevel,
+                histogram
+            )
+            val snippet = document.getText(lineInfo.captureRange).trimEnd()
+            val metadata = CandidateMetadata(
+                fileHash = fileHash,
+                psiKind = element.javaClass.simpleName,
+                lineRange = IntRange(lineInfo.startLine + 1, lineInfo.endLine + 1),
+                snippet = snippet,
+                fileExtension = psiFile.virtualFile?.extension,
+                indentLevel = indentLevel,
+                textRange = range
+            )
+            val occurrenceId = buildId(range, family)
+            results += CandidateOccurrence(
+                id = occurrenceId,
+                language = psiFile.language.id,
+                foldType = family.id,
+                features = features,
+                timestamp = timestamp,
+                metadata = metadata
+            )
+            collected++
+        }
+
+        private fun buildId(range: TextRange, family: CandidateFamily): String {
+            val fileId = psiFile.virtualFile?.path ?: psiFile.name
+            return "$fileId:${range.startOffset}-${range.endOffset}:${family.id}"
+        }
+
+        private fun computeChainLength(call: PsiMethodCallExpression): Int {
+            var length = 1
+            var qualifier = call.methodExpression.qualifierExpression
+            while (qualifier is PsiMethodCallExpression) {
+                length++
+                qualifier = qualifier.methodExpression.qualifierExpression
+            }
+            return length
+        }
+
+        private fun computeLineInfo(range: TextRange): LineInfo {
+            val startLine = document.getLineNumber(range.startOffset)
+            val endLine = document.getLineNumber(range.endOffset)
+            val captureEndLine = min(document.lineCount - 1, endLine + 1)
+            val captureRange = TextRange(
+                document.getLineStartOffset(startLine),
+                document.getLineEndOffset(captureEndLine)
+            )
+            val windowStartLine = max(0, startLine - 2)
+            val windowEndLine = min(document.lineCount - 1, endLine + 2)
+            val windowRange = TextRange(
+                document.getLineStartOffset(windowStartLine),
+                document.getLineEndOffset(windowEndLine)
+            )
+            return LineInfo(startLine, endLine, captureRange, windowRange)
+        }
+
+        private fun computeCommentDensity(windowRange: TextRange): Double {
+            val comments = PsiTreeUtil.collectElements(psiFile) { element ->
+                element is PsiComment && element.textRange.intersects(windowRange)
+            }
+            val commentLength = comments.sumOf { it.textRange.length }
+            val windowLength = windowRange.length.coerceAtLeast(1)
+            return commentLength.toDouble() / windowLength.toDouble()
+        }
+
+        private fun indentLevel(line: Int): Int {
+            if (line < 0 || line >= document.lineCount) {
+                return 0
+            }
+            val startOffset = document.getLineStartOffset(line)
+            val endOffset = document.getLineEndOffset(line)
+            val text = document.getText(TextRange(startOffset, endOffset))
+            var count = 0
+            for (char in text) {
+                if (char == ' ') {
+                    count++
+                } else if (char == '\t') {
+                    count += 4
+                } else if (!char.isWhitespace()) {
+                    break
+                }
+            }
+            return count / 4
+        }
+
+        private fun nestingHistogram(element: PsiElement): IntArray {
+            val histogram = IntArray(4)
+            var current: PsiElement? = element.parent
+            while (current != null && current !is PsiFile) {
+                when (current) {
+                    is PsiIfStatement -> histogram[0]++
+                    is com.intellij.psi.PsiLoopStatement -> histogram[1]++
+                    is com.intellij.psi.PsiTryStatement -> histogram[2]++
+                    is com.intellij.psi.PsiLambdaExpression -> histogram[3]++
+                }
+                current = current.parent
+            }
+            return histogram
+        }
+
+        private fun childCount(element: PsiElement): Int = element.children.count { it !is PsiWhiteSpace }
+
+        private fun siblingCount(element: PsiElement): Int {
+            val parent = element.parent ?: return 0
+            return parent.children.count { it !is PsiWhiteSpace }
+        }
+
+        private fun buildFeatures(
+            element: PsiElement,
+            family: CandidateFamily,
+            chainLength: Int,
+            hasLoggerCall: Boolean,
+            hasNullCheck: Boolean,
+            commentDensity: Double,
+            indentLevel: Int,
+            histogram: IntArray
+        ): DoubleArray {
+            val range = element.textRange
+            val startLine = document.getLineNumber(range.startOffset)
+            val endLine = document.getLineNumber(range.endOffset)
+            val features = DoubleArray(FeatureDictionary.FEATURE_COUNT)
+            features[0] = psiFile.language.id.hashCode().toDouble()
+            features[1] = (psiFile.virtualFile?.extension?.hashCode() ?: 0).toDouble()
+            features[2] = (element.node?.elementType?.toString()?.hashCode() ?: 0).toDouble()
+            features[3] = family.id.hashCode().toDouble()
+            features[4] = depth(element).toDouble()
+            features[5] = element.textLength.toDouble()
+            features[6] = (endLine - startLine + 1).toDouble()
+            features[7] = siblingCount(element).toDouble()
+            features[8] = childCount(element).toDouble()
+            features[9] = chainLength.toDouble()
+            features[10] = if (hasLoggerCall) 1.0 else 0.0
+            features[11] = if (hasNullCheck) 1.0 else 0.0
+            features[12] = commentDensity
+            features[13] = indentLevel.toDouble()
+            features[14] = histogram[0].toDouble()
+            features[15] = histogram[1].toDouble()
+            features[16] = histogram[2].toDouble()
+            features[17] = histogram[3].toDouble()
+            return features
+        }
+
+        private fun depth(element: PsiElement): Int {
+            var depth = 0
+            var current: PsiElement? = element.parent
+            while (current != null && current !is PsiFile) {
+                depth++
+                current = current.parent
+            }
+            return depth
+        }
+    }
+
+    private data class LineInfo(
+        val startLine: Int,
+        val endLine: Int,
+        val captureRange: TextRange,
+        val windowRange: TextRange
+    )
+
+    companion object {
+        private val LOGGER_NAMES = setOf("debug", "info", "warn", "warning", "error", "trace")
+        private val BUILDER_METHODS = setOf("build", "builder", "create", "with")
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryStartupActivity.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryStartupActivity.kt
@@ -1,0 +1,10 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+internal class RuleDiscoveryStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        project.getService(RuleDiscoveryManager::class.java).initialize()
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryToggleListener.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryToggleListener.kt
@@ -1,0 +1,12 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.util.messages.Topic
+
+fun interface RuleDiscoveryToggleListener {
+    fun onRuleDiscoveryToggle(enabled: Boolean)
+
+    companion object {
+        val TOPIC: Topic<RuleDiscoveryToggleListener> =
+            Topic.create("advancedExpressionFolding.ruleDiscoveryToggle", RuleDiscoveryToggleListener::class.java)
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryToolWindowFactory.kt
+++ b/src/com/intellij/advancedExpressionFolding/discovery/RuleDiscoveryToolWindowFactory.kt
@@ -1,0 +1,27 @@
+package com.intellij.advancedExpressionFolding.discovery
+
+import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.content.ContentFactory
+
+internal class RuleDiscoveryToolWindowFactory : ToolWindowFactory, DumbAware {
+
+    override fun shouldBeAvailable(project: Project): Boolean {
+        return AdvancedExpressionFoldingSettings.getInstance().state.discoverNewFoldRules
+    }
+
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = RuleDiscoveryPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel, "", false)
+        toolWindow.contentManager.addContent(content)
+        val manager = project.getService(RuleDiscoveryManager::class.java)
+        panel.update(manager.currentReport())
+        val connection = project.messageBus.connect(panel)
+        connection.subscribe(RuleDiscoveryListener.TOPIC, RuleDiscoveryListener { report ->
+            panel.update(report)
+        })
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/AdvancedExpressionFoldingSettings.kt
@@ -93,8 +93,7 @@ class AdvancedExpressionFoldingSettings :
         override var overrideHide: Boolean = true,
         override var suppressWarningsHide: Boolean = true,
         override var pseudoAnnotations: Boolean = true,
-        // NEW OPTION VAR
-
+        override var discoverNewFoldRules: Boolean = false,
         override var memoryImprovement: Boolean = true,
         override var experimental: Boolean = false,
 

--- a/src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/GlobalSettingsState.kt
@@ -3,6 +3,7 @@ package com.intellij.advancedExpressionFolding.settings
 interface IGlobalSettingsState : IConfig {
     override var globalOn: Boolean
     override var memoryImprovement: Boolean
+    override var discoverNewFoldRules: Boolean
     val dynamic: Boolean
     val experimental: Boolean
 }
@@ -10,6 +11,7 @@ interface IGlobalSettingsState : IConfig {
 data class GlobalSettingsState(
     override var globalOn: Boolean = true,
     override var memoryImprovement: Boolean = true,
+    override var discoverNewFoldRules: Boolean = false,
     override val dynamic: Boolean = true,
     override val experimental: Boolean = false,
 ) : IGlobalSettingsState

--- a/src/com/intellij/advancedExpressionFolding/settings/IConfig.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/IConfig.kt
@@ -3,4 +3,5 @@ package com.intellij.advancedExpressionFolding.settings
 interface IConfig {
     var globalOn: Boolean
     var memoryImprovement: Boolean
+    var discoverNewFoldRules: Boolean
 }

--- a/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/CheckboxesProvider.kt
@@ -280,7 +280,7 @@ abstract class CheckboxesProvider {
             example(PseudoAnnotationsMainTestData::class)
             link("https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/wiki#pseudoAnnotations")
         }
-        // NEW OPTION
+        registerCheckbox(state::discoverNewFoldRules, "Discover new fold rules (dev)")
         registerCheckbox(state::memoryImprovement, "Memory improvements")
         registerCheckbox(state::experimental, "Experimental features") {
             example(ExperimentalTestData::class)

--- a/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
+++ b/src/com/intellij/advancedExpressionFolding/settings/view/SettingsConfigurable.kt
@@ -1,6 +1,7 @@
 package com.intellij.advancedExpressionFolding.settings.view
 
 import com.intellij.advancedExpressionFolding.action.UpdateFoldedTextColorsAction
+import com.intellij.advancedExpressionFolding.discovery.RuleDiscoveryToggleListener
 import com.intellij.advancedExpressionFolding.settings.AdvancedExpressionFoldingSettings
 import com.intellij.application.options.CodeStyle
 import com.intellij.application.options.editor.EditorOptionsProvider
@@ -10,6 +11,7 @@ import com.intellij.ide.HelpTooltip
 import com.intellij.ide.impl.ProjectUtil
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
@@ -144,12 +146,20 @@ class SettingsConfigurable : EditorOptionsProvider, CheckboxesProvider() {
     }
 
     override fun apply() {
+        val toggleBefore = state.discoverNewFoldRules
         pendingChanges.forEach { (property, value) ->
             property.set(value)
         }
         pendingChanges.clear()
-        
+
         panel.apply()
+
+        val toggleAfter = state.discoverNewFoldRules
+        if (toggleBefore != toggleAfter) {
+            ApplicationManager.getApplication().messageBus
+                .syncPublisher(RuleDiscoveryToggleListener.TOPIC)
+                .onRuleDiscoveryToggle(toggleAfter)
+        }
     }
 
     override fun reset() {

--- a/test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/unit/SettingsTest.kt
@@ -16,7 +16,11 @@ class SettingsTest {
             .filterIsInstance<KMutableProperty1<AdvancedExpressionFoldingSettings.State, *>>()
             .filter { it.returnType.classifier == Boolean::class }
             .map { it as KMutableProperty1<AdvancedExpressionFoldingSettings.State, Boolean> }
-            .filter { it.name != "globalOn" && it.name != "memoryImprovement" }
+            .filter {
+                it.name != "globalOn" &&
+                    it.name != "memoryImprovement" &&
+                    it.name != "discoverNewFoldRules"
+            }
 
     @Test
     fun disableAllTurnsOffEveryProperty() {
@@ -24,6 +28,7 @@ class SettingsTest {
         val state = settings.state
         val initialGlobalOn = state.globalOn
         val initialMemoryImprovement = state.memoryImprovement
+        val initialDiscovery = state.discoverNewFoldRules
 
         settings.enableAll()
         settings.disableAll()
@@ -34,6 +39,7 @@ class SettingsTest {
 
         assertEquals(initialGlobalOn, state.globalOn)
         assertEquals(initialMemoryImprovement, state.memoryImprovement)
+        assertEquals(initialDiscovery, state.discoverNewFoldRules)
     }
 
     @Test
@@ -42,6 +48,7 @@ class SettingsTest {
         val state = settings.state
         state.globalOn = false
         state.memoryImprovement = false
+        state.discoverNewFoldRules = false
         settings.disableAll()
 
         settings.enableAll()
@@ -52,6 +59,7 @@ class SettingsTest {
 
         assertFalse(state.globalOn)
         assertFalse(state.memoryImprovement)
+        assertFalse(state.discoverNewFoldRules)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add PSI scanning and feature standardization to feed a DBSCAN-based rule discovery pipeline
- synthesize predicates, write YAML reports, and expose a tool window driven by a new project service
- introduce a developer toggle and supporting UI/tests plus dependencies for clustering and vector math

## Testing
- `./gradlew --no-daemon clean build test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6906029e5370832e92c847b54d313f92