### PR TITLE
Use PsiUtil.isEffectivelyFinal when available

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/Helper.kt
@@ -31,6 +31,7 @@ import com.intellij.psi.PsiStatement
 import com.intellij.psi.PsiTypes
 import com.intellij.psi.PsiVariable
 import com.intellij.psi.SyntaxTraverser
+import com.intellij.psi.util.PsiUtil
 
 object Helper {
 
@@ -84,6 +85,17 @@ object Helper {
     }
 
     fun calculateIfFinal(element: PsiVariable): Boolean {
+        val psiUtilMethod = runCatching {
+            PsiUtil::class.java.getMethod("isEffectivelyFinal", PsiVariable::class.java)
+        }.getOrNull()
+        if (psiUtilMethod != null) {
+            return (runCatching { psiUtilMethod.invoke(null, element) }.getOrNull() as? Boolean) ?: false
+        }
+
+        return calculateIfFinalFallback(element)
+    }
+
+    private fun calculateIfFinalFallback(element: PsiVariable): Boolean {
         val modifiers: PsiModifierList = element.modifierList ?: return false
         var isFinal = modifiers.hasExplicitModifier(PsiModifier.FINAL)
         if (!isFinal) {


### PR DESCRIPTION
## Summary
- attempt to use the platform's PsiUtil.isEffectivelyFinal via reflection when present
- fall back to the previous manual finality detection logic to preserve behaviour when the API is missing

## Testing
- ./gradlew test --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_690611b9ce0c832e8f3d0be4fdd9f9f6