### PR TITLE
Remove redundant equality overrides in Random expression

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Random.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/math/advanced/Random.kt
@@ -13,7 +13,4 @@ class Random(
     textRange: TextRange,
     operands: List<Expression>
 ) : Function(element, textRange, "random", operands), ArithmeticExpression {
-    override fun equals(other: Any?): Boolean = false
-
-    override fun hashCode(): Int = (Math.random() * Int.MAX_VALUE).toInt()
 }


### PR DESCRIPTION
## Summary
- remove the custom equals/hashCode overrides from Random so it inherits Function defaults

## Testing
- ./gradlew clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_6906116c08b8832ebdc36b969dc1d8ec