### PR TITLE
Use PropertyUtilBase for property name detection

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/PropertyUtil.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/PropertyUtil.kt
@@ -1,14 +1,24 @@
 package com.intellij.advancedExpressionFolding.processor.util
 
+import com.intellij.psi.util.PropertyUtilBase
+
 object PropertyUtil {
     fun guessPropertyName(text: String): String {
-        val startPos = when {
-            text.startsWith("get") || text.startsWith("set") -> 3
-            text.startsWith("with") -> 4
-            text.startsWith("is") -> 2
-            else -> 0
-        }
-        val builder = StringBuilder(text.substring(startPos))
+        val withoutPrefix = text
+            .removePrefix("get")
+            .removePrefix("set")
+            .removePrefix("is")
+            .removePrefix("with")
+
+        return PropertyUtilBase.getPropertyName(withoutPrefix)
+            ?: PropertyUtilBase.getPropertyName(text)?.takeUnless { it == withoutPrefix }
+            ?: PropertyUtilBase.getPropertyName("get$withoutPrefix")?.takeUnless { it == withoutPrefix }
+            ?: decapitalizeLeadingUppercase(withoutPrefix)
+    }
+
+    private fun decapitalizeLeadingUppercase(value: String): String {
+        if (value.isEmpty()) return value
+        val builder = StringBuilder(value)
         for (i in builder.indices) {
             val current = builder[i]
             if (current.isUpperCase() && (i == builder.lastIndex || builder[i + 1].isUpperCase() || i == 0)) {

--- a/test/com/intellij/advancedExpressionFolding/unit/PropertyUtilTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/unit/PropertyUtilTest.kt
@@ -18,5 +18,6 @@ class PropertyUtilTest {
         assertEquals("enabledByDefault", guessPropertyName("isEnabledByDefault"))
         assertEquals("html", guessPropertyName("getHTML"))
         assertEquals("htmlText", guessPropertyName("isHTMLText"))
+        assertEquals("name", guessPropertyName("withName"))
     }
 }


### PR DESCRIPTION
## Summary
- leverage `PropertyUtilBase` within `guessPropertyName` while preserving existing fallback logic for atypical prefixes
- add a unit test covering `with`-prefixed accessors

## Testing
- ./gradlew test --tests "com.intellij.advancedExpressionFolding.unit.PropertyUtilTest" --console=plain --stacktrace --no-daemon -x examples:test

------
https://chatgpt.com/codex/tasks/task_e_69060facc328832ea2d3af1485b19974