### PR TITLE
Use typed parsing for dynamic method configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     implementation(libs.annotations)
     implementation(libs.jsr305)
     implementation(libs.jackson.dataformat.toml)
+    implementation(libs.jackson.module.kotlin)
     implementation(examplesTestOutput)
 
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/docs/docusaurus/features/dynamic-renaming.md
+++ b/docs/docusaurus/features/dynamic-renaming.md
@@ -7,6 +7,16 @@ description: Pull friendly display names for methods from an external configurat
 
 Enable **dynamic** to map fully-qualified method names to human-friendly labels stored in `~/dynamic-ajf2.toml`. The plugin reads the file on the fly and displays the alias wherever the method appears, making domain-specific APIs easier to reason about.
 
+Each table in the TOML file is deserialized directly into a typed configuration, so both keys must be present:
+
+```toml title="~/dynamic-ajf2.toml"
+[renameStaticMethod]
+method = "com.acme.Service#staticMethod"
+newName = "Renamed service method"
+```
+
+Entries missing `method` or `newName` (or containing blank values) are ignored to keep the configuration safe.
+
 ![Dynamic renaming applied to method calls](https://github.com/user-attachments/assets/250e6884-6254-4707-85ac-7c861d3773f2)
 
 - [Source sample](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/DynamicTestData.java)

--- a/docs/docusaurus/options/index.md
+++ b/docs/docusaurus/options/index.md
@@ -236,6 +236,7 @@ Simplifies single-expression functions.
 ## dynamic
 ### Dynamic names for methods based on $user.home/dynamic-ajf2.toml
 Applies dynamic naming to methods based on a configuration file.
+- Each table is loaded as a typed object; provide both `method` and `newName` keys with non-blank values.
 - [Example](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/examples/data/DynamicTestData.java)
 - [Folded](https://github.com/AntoniRokitnicki/AdvancedExpressionFolding/blob/main/folded/DynamicTestData-folded.java)
 - [Documentation](../features/dynamic-renaming.md)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ junit-vintage-engine = { group = "org.junit.vintage", name = "junit-vintage-engi
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
 jackson-dataformat-toml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-toml", version.ref = "jackson" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
 jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version.ref = "jsr305" }
 junit-pioneer = { group = "org.junit-pioneer", name = "junit-pioneer", version.ref = "pioneer" }
 kodein-di-conf = { group = "org.kodein.di", name = "kodein-di-conf-jvm", version.ref = "kodein" }

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/DynamicMethodCallData.kt
@@ -2,7 +2,18 @@ package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodName
 
-data class DynamicMethodCallData(val map: Map<String, String>) {
-    val method: MethodName by map
-    val newName: MethodName by map
+data class DynamicMethodCallData(
+    val method: MethodName = "",
+    val newName: MethodName = "",
+) {
+    fun validatedOrNull(): DynamicMethodCallData? {
+        val normalizedMethod = method.trim()
+        val normalizedNewName = newName.trim()
+
+        if (normalizedMethod.isEmpty() || normalizedNewName.isEmpty()) {
+            return null
+        }
+
+        return copy(method = normalizedMethod, newName = normalizedNewName)
+    }
 }

--- a/test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/performance/MethodCallFactoryPerformanceTest.kt
@@ -64,7 +64,7 @@ class MethodCallFactoryPerformanceTest : BaseTest() {
             invocation++
             return (1..size).map { index ->
                 val method = $$"m${invocation}_$index"
-                DynamicMethodCall(DynamicMethodCallData(mapOf("method" to method, "newName" to $$"n$index")))
+                DynamicMethodCall(DynamicMethodCallData(method = method, newName = $$"n$index"))
             }
         }
     }

--- a/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
+++ b/test/com/intellij/advancedExpressionFolding/processor/methodcall/dynamic/ConfigurationParserTest.kt
@@ -2,6 +2,7 @@ package com.intellij.advancedExpressionFolding.processor.methodcall.dynamic
 
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallFactory
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.nio.file.Files
@@ -10,6 +11,28 @@ import kotlin.io.path.createDirectories
 import kotlin.io.path.writeText
 
 class ConfigurationParserTest {
+
+    @Test
+    fun parseReturnsDynamicMethodCallsForValidEntries() {
+        withTemporaryHome { temporaryHome ->
+            val configPath = temporaryHome.resolve("dynamic-ajf2.toml")
+            configPath.parent?.createDirectories()
+            configPath.writeText(
+                """
+                [valid]
+                method = "sourceMethod"
+                newName = "Renamed method"
+                """.trimIndent(),
+            )
+
+            val parsed = ConfigurationParser.parse()
+
+            assertEquals(1, parsed.size)
+            val data = parsed.single().data
+            assertEquals("sourceMethod", data.method)
+            assertEquals("Renamed method", data.newName)
+        }
+    }
 
     @Test
     fun parseSkipsEntriesMissingRequiredKeys() {


### PR DESCRIPTION
## Summary
- register jackson-module-kotlin on the shared TOML ObjectMapper and deserialize dynamic entries into `DynamicMethodCallData`
- validate required fields when loading dynamic configurations and adjust dependent performance fixture
- document the typed TOML schema and cover successful parsing in unit tests

## Testing
- ./gradlew --no-daemon --no-configuration-cache clean build test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_69060fb81294832e930062aa194874f1