### PR TITLE
Use Kotlin emptyList in MathRandomMethodCall

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRandomMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/math/MathRandomMethodCall.kt
@@ -4,7 +4,6 @@ import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.advanced.Random
 import com.intellij.advancedExpressionFolding.processor.methodcall.Context
 import com.intellij.psi.PsiMethodCallExpression
-import java.util.*
 
 class MathRandomMethodCall : AbstractMathMethodCall() {
     override val methodNames by lazy { listOf("random") }
@@ -15,6 +14,6 @@ class MathRandomMethodCall : AbstractMathMethodCall() {
     ): Expression? = Random(
         element,
         element.textRange,
-        Collections.emptyList()
+        emptyList()
     )
 }


### PR DESCRIPTION
## Summary
- replace the java.util.Collections usage in MathRandomMethodCall with Kotlin's emptyList to keep the implementation idiomatic

## Testing
- TERM=dumb ./gradlew --console=plain clean build test


------
https://chatgpt.com/codex/tasks/task_e_69060e1e84b4832e9cf871460e4d972d