### PR TITLE
Use IntelliJ logger in CodeGenerationUtil

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/util/CodeGenerationUtil.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/util/CodeGenerationUtil.kt
@@ -2,10 +2,13 @@ package com.intellij.advancedExpressionFolding.processor.util
 
 import com.intellij.advancedExpressionFolding.processor.isWhitespace
 import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.psi.*
 
 @Suppress("unused")
 object CodeGenerationUtil {
+    private val logger: Logger = Logger.getInstance(CodeGenerationUtil::class.java)
+
     private fun PsiClass.codeStringToPsiElement(code: String): PsiElement? {
         val psiFile = PsiFileFactory.getInstance(project)
             .createFileFromText("temp.java", JavaFileType.INSTANCE, code)
@@ -35,6 +38,8 @@ object CodeGenerationUtil {
 
         val v = KeyCleanerPsiElementVisitor()
         code.accept(v)
-        println(v.elements)
+        if (logger.isDebugEnabled) {
+            logger.debug("Collected code block elements: ${v.elements}")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the diagnostic println in CodeGenerationUtil with IntelliJ logging
- add a class-local Logger instance for debug output

## Testing
- ./gradlew clean build test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_69060df0c020832eb064b3b4339c230a