### PR TITLE
Refactor arithmetic method call handlers to share configurable base

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAbsMethodCall.kt
@@ -1,19 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Abs
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticAbsMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("abs") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Abs(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticAbsMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("abs"),
+    argumentArity = ArgumentArity.NO_ARGUMENTS,
+    expressionBuilder = { element, context ->
+        Abs(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAddMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.basic.Add
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticAddMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("add") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Add(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticAddMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("add"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Add(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAndMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.And
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticAndMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("and") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = And(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticAndMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("and"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        And(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticAtan2MethodCall.kt
@@ -1,24 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.trig.Atan2
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticAtan2MethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("atan2") }
-
-    override fun onTwoArguments(
-        element: PsiMethodCallExpression,
-        context: Context,
-        a1: PsiExpression,
-        a2: PsiExpression,
-        a1Expression: Expression,
-        a2Expression: Expression
-    ): Expression? = Atan2(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticAtan2MethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("atan2"),
+    argumentArity = ArgumentArity.TWO_ARGUMENTS,
+    expressionBuilder = { element, context ->
+        Atan2(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticDivideMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
 import com.intellij.advancedExpressionFolding.expression.math.basic.Divide
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticDivideMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("divide") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Divide(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticDivideMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("divide"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Divide(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticGcdMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.advanced.Gcd
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticGcdMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("gcd") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Gcd(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticGcdMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("gcd"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Gcd(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMaxMethodCall.kt
@@ -1,24 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Max
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticMaxMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("max") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? {
-        return Max(
+class ArithmeticMaxMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("max"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Max(
             element,
             element.textRange,
             context.getOperands()
         )
     }
-}
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticMultiplyMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Multiply
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticMultiplyMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("multiply") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Multiply(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticMultiplyMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("multiply"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Multiply(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNegateMethodCall.kt
@@ -1,19 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Negate
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticNegateMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("negate") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Negate(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticNegateMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("negate"),
+    argumentArity = ArgumentArity.NO_ARGUMENTS,
+    expressionBuilder = { element, context ->
+        Negate(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticNotMethodCall.kt
@@ -1,19 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Not
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticNotMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("not") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Not(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticNotMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("not"),
+    argumentArity = ArgumentArity.NO_ARGUMENTS,
+    expressionBuilder = { element, context ->
+        Not(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticOrMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Or
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticOrMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("or") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Or(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticOrMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("or"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Or(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPlusMethodCall.kt
@@ -1,15 +1,11 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticPlusMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("plus") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = context.qualifierExprNullable
-
-}
+class ArithmeticPlusMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("plus"),
+    argumentArity = ArgumentArity.NO_ARGUMENTS,
+    expressionBuilder = { _, context ->
+        context.qualifierExprNullable
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticPowMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.advanced.Pow
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticPowMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("pow") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Pow(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticPowMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("pow"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Pow(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticRemainderMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Remainder
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticRemainderMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("remainder", "mod") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Remainder(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticRemainderMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("remainder", "mod"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Remainder(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftLeftMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.ShiftLeft
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticShiftLeftMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftLeft") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = ShiftLeft(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticShiftLeftMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("shiftLeft"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        ShiftLeft(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticShiftRightMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.ShiftRight
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticShiftRightMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("shiftRight") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = ShiftRight(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticShiftRightMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("shiftRight"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        ShiftRight(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSignumMethodCall.kt
@@ -1,19 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Signum
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticSignumMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("signum") }
-    
-    override fun onNoArguments(
-        element: PsiMethodCallExpression,
-        context: Context
-    ): Expression? = Signum(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticSignumMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("signum"),
+    argumentArity = ArgumentArity.NO_ARGUMENTS,
+    expressionBuilder = { element, context ->
+        Signum(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticSubtractMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.basic.Subtract
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticSubtractMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("subtract") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Subtract(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticSubtractMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("subtract"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Subtract(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ArithmeticXorMethodCall.kt
@@ -1,22 +1,16 @@
 package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.math.bitwise.Xor
-import com.intellij.advancedExpressionFolding.processor.methodcall.Context
-import com.intellij.psi.PsiExpression
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic.ConfiguredArithmeticMethodCall.ArgumentArity
 
-class ArithmeticXorMethodCall : AbstractArithmeticMethodCall() {
-    override val methodNames by lazy { listOf("xor") }
-    
-    override fun onSingleArgument(
-        element: PsiMethodCallExpression,
-        context: Context,
-        argument: PsiExpression,
-        argumentExpression: Expression
-    ): Expression? = Xor(
-        element,
-        element.textRange,
-        context.getOperands()
-    )
-}
+class ArithmeticXorMethodCall : ConfiguredArithmeticMethodCall(
+    methodNames = listOf("xor"),
+    argumentArity = ArgumentArity.SINGLE_ARGUMENT,
+    expressionBuilder = { element, context ->
+        Xor(
+            element,
+            element.textRange,
+            context.getOperands()
+        )
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ConfiguredArithmeticMethodCall.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/methodcall/arithmetic/ConfiguredArithmeticMethodCall.kt
@@ -1,0 +1,51 @@
+package com.intellij.advancedExpressionFolding.processor.methodcall.arithmetic
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.advancedExpressionFolding.processor.methodcall.Context
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethodCallExpression
+
+open class ConfiguredArithmeticMethodCall(
+    override val methodNames: List<String>,
+    private val argumentArity: ArgumentArity,
+    private val expressionBuilder: (PsiMethodCallExpression, Context) -> Expression?
+) : AbstractArithmeticMethodCall() {
+
+    override fun onNoArguments(
+        element: PsiMethodCallExpression,
+        context: Context
+    ): Expression? = buildIfMatches(ArgumentArity.NO_ARGUMENTS, element, context)
+
+    override fun onSingleArgument(
+        element: PsiMethodCallExpression,
+        context: Context,
+        argument: PsiExpression,
+        argumentExpression: Expression
+    ): Expression? = buildIfMatches(ArgumentArity.SINGLE_ARGUMENT, element, context)
+
+    override fun onTwoArguments(
+        element: PsiMethodCallExpression,
+        context: Context,
+        a1: PsiExpression,
+        a2: PsiExpression,
+        a1Expression: Expression,
+        a2Expression: Expression
+    ): Expression? = buildIfMatches(ArgumentArity.TWO_ARGUMENTS, element, context)
+
+    private fun buildIfMatches(
+        expected: ArgumentArity,
+        element: PsiMethodCallExpression,
+        context: Context
+    ): Expression? =
+        if (argumentArity == expected) {
+            expressionBuilder(element, context)
+        } else {
+            null
+        }
+
+    enum class ArgumentArity {
+        NO_ARGUMENTS,
+        SINGLE_ARGUMENT,
+        TWO_ARGUMENTS,
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable arithmetic method call helper that stores method names, arity, and the expression builder
- update the simple BigDecimal/BigInteger arithmetic handlers to delegate to the helper while keeping custom logic untouched

## Testing
- ./gradlew clean build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3514cbfc832e99372eec2279625a)