### PR TITLE
Introduce list-based folding builders

### DIFF
--- a/docs/build-fold-regions-migration.md
+++ b/docs/build-fold-regions-migration.md
@@ -1,0 +1,63 @@
+# Expression Folding Migration
+
+The `Expression.buildFoldRegions` API now exposes `buildFoldRegionsList` helpers that
+receive a mutable list instead of returning an array. The following classes currently
+override the deprecated array-based API and should migrate to the list-based variant:
+
+- com.intellij.advancedExpressionFolding.expression.Function
+- com.intellij.advancedExpressionFolding.expression.Operation
+- com.intellij.advancedExpressionFolding.expression.SyntheticExpressionImpl
+- com.intellij.advancedExpressionFolding.expression.VariableDeclarationImpl
+- com.intellij.advancedExpressionFolding.expression.controlflow.AbstractControlFlowCodeBlock
+- com.intellij.advancedExpressionFolding.expression.controlflow.CompactControlFlowExpression
+- com.intellij.advancedExpressionFolding.expression.controlflow.ElvisExpression
+- com.intellij.advancedExpressionFolding.expression.controlflow.ForEachIndexedStatement
+- com.intellij.advancedExpressionFolding.expression.controlflow.ForEachStatement
+- com.intellij.advancedExpressionFolding.expression.controlflow.ForStatement
+- com.intellij.advancedExpressionFolding.expression.controlflow.IfExpression
+- com.intellij.advancedExpressionFolding.expression.controlflow.SemicolonExpression
+- com.intellij.advancedExpressionFolding.expression.controlflow.ShortElvisExpression
+- com.intellij.advancedExpressionFolding.expression.literal.ArrayLiteral
+- com.intellij.advancedExpressionFolding.expression.literal.InterpolatedString
+- com.intellij.advancedExpressionFolding.expression.literal.ListLiteral
+- com.intellij.advancedExpressionFolding.expression.literal.LocalDateLiteral
+- com.intellij.advancedExpressionFolding.expression.literal.NumberLiteral
+- com.intellij.advancedExpressionFolding.expression.literal.SetLiteral
+- com.intellij.advancedExpressionFolding.expression.literal.StringLiteral
+- com.intellij.advancedExpressionFolding.expression.math.advanced.Cbrt
+- com.intellij.advancedExpressionFolding.expression.math.advanced.Exp
+- com.intellij.advancedExpressionFolding.expression.math.advanced.Pow
+- com.intellij.advancedExpressionFolding.expression.math.basic.Abs
+- com.intellij.advancedExpressionFolding.expression.operation.Get
+- com.intellij.advancedExpressionFolding.expression.operation.basic.Append
+- com.intellij.advancedExpressionFolding.expression.operation.basic.TypeCast
+- com.intellij.advancedExpressionFolding.expression.operation.basic.Variable
+- com.intellij.advancedExpressionFolding.expression.operation.collection.ArrayGet
+- com.intellij.advancedExpressionFolding.expression.operation.collection.ArrayStream
+- com.intellij.advancedExpressionFolding.expression.operation.collection.Collect
+- com.intellij.advancedExpressionFolding.expression.operation.collection.Put
+- com.intellij.advancedExpressionFolding.expression.operation.collection.Range
+- com.intellij.advancedExpressionFolding.expression.operation.collection.Slice
+- com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalMapSafeCallParam
+- com.intellij.advancedExpressionFolding.expression.operation.optional.OptionalNotNullAssertionGet
+- com.intellij.advancedExpressionFolding.expression.operation.stream.StreamExpression
+- com.intellij.advancedExpressionFolding.expression.operation.stream.StreamMapCallParam
+- com.intellij.advancedExpressionFolding.expression.operation.stream.StringExpression
+- com.intellij.advancedExpressionFolding.expression.property.Getter
+- com.intellij.advancedExpressionFolding.expression.property.GetterRecord
+- com.intellij.advancedExpressionFolding.expression.property.Setter
+- com.intellij.advancedExpressionFolding.expression.semantic.AbstractMultiExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.AbstractSingleChildExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.BuilderShiftExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.FastExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.kotlin.ElvisReturnNull
+- com.intellij.advancedExpressionFolding.expression.semantic.kotlin.FieldConstExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.kotlin.IfNullSafeExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.kotlin.IfNullSafePrintlnExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.kotlin.LetReturnIt
+- com.intellij.advancedExpressionFolding.expression.semantic.lombok.ClassAnnotationExpression
+- com.intellij.advancedExpressionFolding.expression.semantic.lombok.NullAnnotationExpression
+
+Classes and interfaces that delegate to these implementations (for example,
+`com.intellij.advancedExpressionFolding.expression.property.IGetter`) should
+also adopt the new API when their implementations migrate.

--- a/src/com/intellij/advancedExpressionFolding/expression/Expression.kt
+++ b/src/com/intellij/advancedExpressionFolding/expression/Expression.kt
@@ -28,14 +28,18 @@ abstract class Expression protected constructor() {
         return false
     }
 
+    @Deprecated("Use buildFoldRegionsList")
     open fun buildFoldRegions(
         element: PsiElement,
         document: Document,
         parent: Expression?
     ): Array<FoldingDescriptor> {
-        return EMPTY_ARRAY
+        val foldings = mutableListOf<FoldingDescriptor>()
+        buildFoldRegionsList(element, document, parent, foldings)
+        return foldings.toTypedArray()
     }
 
+    @Deprecated("Use buildFoldRegionsList")
     open fun buildFoldRegions(
         element: PsiElement,
         document: Document,
@@ -44,7 +48,38 @@ abstract class Expression protected constructor() {
         overflowLeftPlaceholder: String?,
         overflowRightPlaceholder: String?
     ): Array<FoldingDescriptor> {
-        return buildFoldRegions(element, document, parent)
+        val foldings = mutableListOf<FoldingDescriptor>()
+        buildFoldRegionsList(
+            element,
+            document,
+            parent,
+            overflowGroup,
+            overflowLeftPlaceholder,
+            overflowRightPlaceholder,
+            foldings
+        )
+        return foldings.toTypedArray()
+    }
+
+    open fun buildFoldRegionsList(
+        element: PsiElement,
+        document: Document,
+        parent: Expression?,
+        foldings: MutableList<FoldingDescriptor>
+    ) {
+        // Default implementation does not contribute folding descriptors.
+    }
+
+    open fun buildFoldRegionsList(
+        element: PsiElement,
+        document: Document,
+        parent: Expression?,
+        overflowGroup: FoldingGroup?,
+        overflowLeftPlaceholder: String?,
+        overflowRightPlaceholder: String?,
+        foldings: MutableList<FoldingDescriptor>
+    ) {
+        buildFoldRegionsList(element, document, parent, foldings)
     }
 
     open fun isCollapsedByDefault(): Boolean = true


### PR DESCRIPTION
## Summary
- add list-based folding builder hooks to `Expression` and deprecate the array-based helpers
- document all expression implementations that still need to migrate to the new folding builder contract

## Testing
- ./gradlew clean build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e34d65c1c832eab8b82f3d2ab5b0d)