### PR TITLE
Refactor expression builder registration

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -201,55 +201,7 @@
     <!-- ========================================== -->
     <!-- EXPRESSION BUILDER EXTENSIONS              -->
     <!-- ========================================== -->
-    <extensions defaultExtensionNs="com.github.advanced-java-folding2">
-        <!-- Top-Level Declarations -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ClassBuilder"/>
-
-        <!-- Method & Field Declarations -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.FieldBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.MethodBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ParameterBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.RecordComponentBuilder"/>
-
-        <!-- Code Structure -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.CodeBlockBuilder"/>
-
-        <!-- Control Flow Statements -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.IfStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.SwitchStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.TryStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.CatchSectionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ForStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ForEachStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.WhileStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.DoWhileStatementBuilder"/>
-
-        <!-- Variable Declarations -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.DeclarationStatementBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.VariableBuilder"/>
-
-        <!-- Expressions -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.AssignmentExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ConditionalExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.PolyadicExpressionBuilder"
-                           id="com.intellij.advancedExpressionFolding.polyadicExpressionBuilder"
-                           order="before com.intellij.advancedExpressionFolding.binaryExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.BinaryExpressionBuilder"
-                           id="com.intellij.advancedExpressionFolding.binaryExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.TypeCastExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.PrefixExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ParenthesizedExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.NewExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.MethodCallExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ArrayAccessExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.ReferenceExpressionBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.LiteralExpressionBuilder"/>
-
-        <!-- Tokens & Keywords -->
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.KeywordBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.SemicolonBuilder"/>
-        <expressionBuilder implementation="com.intellij.advancedExpressionFolding.processor.core.TokenBuilder"/>
-    </extensions>
+    <!-- Built-in builders are registered programmatically. -->
     <!-- @formatter:on -->
 
 </idea-plugin>

--- a/src/com/intellij/advancedExpressionFolding/processor/core/ControlFlowExpressionBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/ControlFlowExpressionBuilders.kt
@@ -1,12 +1,10 @@
 package com.intellij.advancedExpressionFolding.processor.core
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.controlflow.CompactControlFlowExpression
 import com.intellij.advancedExpressionFolding.processor.controlflow.ForStatementExpressionExt
 import com.intellij.advancedExpressionFolding.processor.controlflow.IfExt
 import com.intellij.advancedExpressionFolding.processor.controlflow.LoopExt
 import com.intellij.advancedExpressionFolding.processor.controlflow.PsiTryStatementExt
-import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiCatchSection
 import com.intellij.psi.PsiDoWhileStatement
@@ -17,54 +15,39 @@ import com.intellij.psi.PsiSwitchStatement
 import com.intellij.psi.PsiTryStatement
 import com.intellij.psi.PsiWhileStatement
 
-class ForStatementBuilder : BuildExpression<PsiForStatement>(PsiForStatement::class.java) {
-    override fun buildExpression(element: PsiForStatement, document: Document, synthetic: Boolean) =
+internal val controlFlowExpressionBuilders = listOf(
+    registerBuilder<PsiForStatement> { element, document, _ ->
         ForStatementExpressionExt.getForStatementExpression(element, document)
-}
-
-class ForEachStatementBuilder : BuildExpression<PsiForeachStatement>(PsiForeachStatement::class.java) {
-    override fun buildExpression(element: PsiForeachStatement, document: Document, synthetic: Boolean): Expression? =
+    },
+    registerBuilder<PsiForeachStatement> { element, _, _ ->
         LoopExt.getForEachStatementExpression(element)
-}
-
-class IfStatementBuilder : BuildExpression<PsiIfStatement>(PsiIfStatement::class.java) {
-    override fun buildExpression(element: PsiIfStatement, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiIfStatement> { element, document, _ ->
         IfExt.getIfExpression(element, document)
-}
-
-class WhileStatementBuilder : BuildExpression<PsiWhileStatement>(PsiWhileStatement::class.java) {
-    override fun buildExpression(element: PsiWhileStatement, document: Document, synthetic: Boolean): Expression? =
+    },
+    registerBuilder<PsiWhileStatement> { element, _, _ ->
         LoopExt.getWhileStatement(element)
-}
-
-class DoWhileStatementBuilder : BuildExpression<PsiDoWhileStatement>(PsiDoWhileStatement::class.java) {
-    override fun buildExpression(element: PsiDoWhileStatement, document: Document, synthetic: Boolean): Expression? =
+    },
+    registerBuilder<PsiDoWhileStatement> { element, _, _ ->
         LoopExt.getDoWhileStatement(element)
-}
-
-class SwitchStatementBuilder : BuildExpression<PsiSwitchStatement>(PsiSwitchStatement::class.java) {
-    override fun buildExpression(element: PsiSwitchStatement, document: Document, synthetic: Boolean): Expression? =
+    },
+    registerBuilder<PsiSwitchStatement> { element, _, _ ->
         IfExt.getSwitchStatement(element)
-}
-
-class TryStatementBuilder : BuildExpression<PsiTryStatement>(PsiTryStatement::class.java) {
-    override fun buildExpression(element: PsiTryStatement, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiTryStatement> { element, _, _ ->
         PsiTryStatementExt.createExpression(element)
-}
-
-class CatchSectionBuilder : BuildExpression<PsiCatchSection>(PsiCatchSection::class.java) {
-    override fun checkConditions(element: PsiCatchSection) =
+    },
+    registerBuilder<PsiCatchSection>(predicate = {
         compactControlFlowSyntaxCollapse &&
-                element.parameter != null &&
-                element.lParenth != null &&
-                element.rParenth != null
-
-    override fun buildExpression(element: PsiCatchSection, document: Document, synthetic: Boolean): Expression? {
-        val l = element.lParenth ?: return null
-        val r = element.rParenth ?: return null
-        return CompactControlFlowExpression(
+            it.parameter != null &&
+            it.lParenth != null &&
+            it.rParenth != null
+    }) { element, _, _ ->
+        val l = element.lParenth ?: return@registerBuilder null
+        val r = element.rParenth ?: return@registerBuilder null
+        CompactControlFlowExpression(
             element,
             TextRange.create(l.textRange.startOffset, r.textRange.endOffset)
         )
     }
-}
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/DeclarationBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/DeclarationBuilders.kt
@@ -6,7 +6,6 @@ import com.intellij.advancedExpressionFolding.processor.declaration.PsiDeclarati
 import com.intellij.advancedExpressionFolding.processor.declaration.PsiFieldExt
 import com.intellij.advancedExpressionFolding.processor.declaration.PsiMethodExt
 import com.intellij.advancedExpressionFolding.processor.declaration.PsiVariableExt
-import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiCodeBlock
 import com.intellij.psi.PsiDeclarationStatement
@@ -17,45 +16,32 @@ import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiRecordComponent
 import com.intellij.psi.PsiVariable
 
-class DeclarationStatementBuilder : BuildExpression<PsiDeclarationStatement>(PsiDeclarationStatement::class.java) {
-    override fun buildExpression(element: PsiDeclarationStatement, document: Document, synthetic: Boolean) =
+internal val declarationExpressionBuilders = listOf(
+    registerBuilder<PsiDeclarationStatement> { element, _, _ ->
         PsiDeclarationStatementExt.createExpression(element)
-}
-
-class VariableBuilder : BuildExpression<PsiVariable>(PsiVariable::class.java) {
-    override fun checkConditions(element: PsiVariable) = varExpressionsCollapse &&
-            (element.parent is PsiDeclarationStatement || element.parent is PsiForeachStatement)
-
-    override fun buildExpression(element: PsiVariable, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiVariable>(predicate = {
+        varExpressionsCollapse &&
+            (it.parent is PsiDeclarationStatement || it.parent is PsiForeachStatement)
+    }) { element, _, _ ->
         PsiVariableExt.getVariableDeclaration(element)
-}
-
-class CodeBlockBuilder : BuildExpression<PsiCodeBlock>(PsiCodeBlock::class.java) {
-    override fun buildExpression(element: PsiCodeBlock, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiCodeBlock> { element, _, _ ->
         PsiCodeBlockExt.getCodeBlockExpression(element)
-}
-
-class ClassBuilder : BuildExpression<PsiClass>(PsiClass::class.java) {
-    override fun buildExpression(element: PsiClass, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiClass> { element, _, _ ->
         PsiClassExt.createExpression(element)
-}
-
-class FieldBuilder : BuildExpression<PsiField>(PsiField::class.java) {
-    override fun buildExpression(element: PsiField, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiField> { element, document, _ ->
         PsiFieldExt.createExpression(element, document)
-}
-
-class ParameterBuilder : BuildExpression<PsiParameter>(PsiParameter::class.java) {
-    override fun buildExpression(element: PsiParameter, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiParameter> { element, document, _ ->
         PsiMethodExt.createExpression(element, document)
-}
-
-class RecordComponentBuilder : BuildExpression<PsiRecordComponent>(PsiRecordComponent::class.java) {
-    override fun buildExpression(element: PsiRecordComponent, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiRecordComponent> { element, _, _ ->
         PsiFieldExt.createExpression(element)
-}
-
-class MethodBuilder : BuildExpression<PsiMethod>(PsiMethod::class.java) {
-    override fun buildExpression(element: PsiMethod, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiMethod> { element, document, _ ->
         PsiMethodExt.createExpression(element, document)
-}
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilderManager.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilderManager.kt
@@ -8,7 +8,13 @@ class ExpressionBuilderManager {
       "com.github.advanced-java-folding2.expressionBuilder"
     )
 
+    private val BUILTIN_BUILDERS: List<BuildExpression<*>> =
+      commonExpressionBuilders +
+        controlFlowExpressionBuilders +
+        declarationExpressionBuilders +
+        lexicalExpressionBuilders
+
     val expressionBuilders: List<BuildExpression<*>>
-      get() = EP_NAME.extensionList
+      get() = BUILTIN_BUILDERS + EP_NAME.extensionList
   }
 }

--- a/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt
@@ -1,19 +1,17 @@
 package com.intellij.advancedExpressionFolding.processor.core
 
-import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.operation.basic.TypeCast
 import com.intellij.advancedExpressionFolding.processor.cache.CacheExt
+import com.intellij.advancedExpressionFolding.processor.controlflow.IfExt
 import com.intellij.advancedExpressionFolding.processor.expression.AssignmentExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.BinaryExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.LiteralExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PrefixExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PsiArrayAccessExpressionExt
-import com.intellij.advancedExpressionFolding.processor.reference.ReferenceExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PsiTypeCastExpressionExt
-import com.intellij.advancedExpressionFolding.processor.controlflow.IfExt
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallExpressionExt
 import com.intellij.advancedExpressionFolding.processor.reference.NewExpressionExt
-import com.intellij.openapi.editor.Document
+import com.intellij.advancedExpressionFolding.processor.reference.ReferenceExpressionExt
 import com.intellij.psi.PsiArrayAccessExpression
 import com.intellij.psi.PsiAssignmentExpression
 import com.intellij.psi.PsiBinaryExpression
@@ -27,89 +25,52 @@ import com.intellij.psi.PsiPrefixExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.PsiTypeCastExpression
 
-class ArrayAccessExpressionBuilder : BuildExpression<PsiArrayAccessExpression>(PsiArrayAccessExpression::class.java) {
-    override fun checkConditions(element: PsiArrayAccessExpression) = getExpressionsCollapse
-
-    override fun buildExpression(element: PsiArrayAccessExpression, document: Document, synthetic: Boolean) =
+internal val commonExpressionBuilders = listOf(
+    registerBuilder<PsiArrayAccessExpression>(predicate = { getExpressionsCollapse }) { element, document, _ ->
         PsiArrayAccessExpressionExt.getArrayAccessExpression(element, document)
-}
-
-class MethodCallExpressionBuilder : BuildExpression<PsiMethodCallExpression>(PsiMethodCallExpression::class.java) {
-    override fun buildExpression(element: PsiMethodCallExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiMethodCallExpression> { element, document, _ ->
         MethodCallExpressionExt.getMethodCallExpression(element, document)
-}
-
-class ReferenceExpressionBuilder : BuildExpression<PsiReferenceExpression>(PsiReferenceExpression::class.java) {
-    override fun buildExpression(element: PsiReferenceExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiReferenceExpression> { element, _, _ ->
         ReferenceExpressionExt.getReferenceExpression(element)
-}
-
-class NewExpressionBuilder : BuildExpression<PsiNewExpression>(PsiNewExpression::class.java) {
-    override fun buildExpression(element: PsiNewExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiNewExpression> { element, document, _ ->
         NewExpressionExt.getNewExpression(element, document)
-}
-
-class LiteralExpressionBuilder : BuildExpression<PsiLiteralExpression>(PsiLiteralExpression::class.java) {
-    override fun buildExpression(element: PsiLiteralExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiLiteralExpression> { element, _, _ ->
         LiteralExpressionExt.getLiteralExpression(element)
-}
-
-class AssignmentExpressionBuilder : BuildExpression<PsiAssignmentExpression>(PsiAssignmentExpression::class.java) {
-    override fun buildExpression(element: PsiAssignmentExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiAssignmentExpression> { element, document, _ ->
         AssignmentExpressionExt.getAssignmentExpression(element, document)
-}
-
-class PolyadicExpressionBuilder : BuildExpression<PsiPolyadicExpression>(PsiPolyadicExpression::class.java) {
-    override fun buildExpression(element: PsiPolyadicExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiPolyadicExpression> { element, document, _ ->
         IfExt.getPolyadicExpression(element, document)
-}
-
-class BinaryExpressionBuilder : BuildExpression<PsiBinaryExpression>(PsiBinaryExpression::class.java) {
-    override fun buildExpression(element: PsiBinaryExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiBinaryExpression> { element, document, _ ->
         BinaryExpressionExt.getBinaryExpression(element, document)
-}
-
-class ConditionalExpressionBuilder : BuildExpression<PsiConditionalExpression>(PsiConditionalExpression::class.java) {
-    override fun buildExpression(element: PsiConditionalExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiConditionalExpression> { element, document, _ ->
         IfExt.getConditionalExpression(element, document)
-}
-
-class PrefixExpressionBuilder : BuildExpression<PsiPrefixExpression>(PsiPrefixExpression::class.java) {
-    override fun buildExpression(element: PsiPrefixExpression, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiPrefixExpression> { element, document, _ ->
         PrefixExpressionExt.getPrefixExpression(element, document)
-}
-
-class ParenthesizedExpressionBuilder :
-    BuildExpression<PsiParenthesizedExpression>(PsiParenthesizedExpression::class.java) {
-
-    override fun checkConditions(element: PsiParenthesizedExpression) = castExpressionsCollapse
-
-    override fun buildExpression(
-        element: PsiParenthesizedExpression,
-        document: Document,
-        synthetic: Boolean,
-    ): Expression? {
+    },
+    registerBuilder<PsiParenthesizedExpression>(predicate = { castExpressionsCollapse }) { element, document, synthetic ->
         val expression = element.expression
         if (expression is PsiTypeCastExpression) {
             val typeCast = PsiTypeCastExpressionExt.getTypeCastExpression(expression, document)
             if (typeCast != null) {
-                return TypeCast(
+                return@registerBuilder TypeCast(
                     element,
                     element.textRange,
                     typeCast.getObject()
                 )
             }
         }
-        if (expression != null) {
-            return CacheExt.getExpression(expression, document, synthetic)
-        }
-        return null
-    }
-}
-
-class TypeCastExpressionBuilder : BuildExpression<PsiTypeCastExpression>(PsiTypeCastExpression::class.java) {
-    override fun checkConditions(element: PsiTypeCastExpression) = castExpressionsCollapse
-
-    override fun buildExpression(element: PsiTypeCastExpression, document: Document, synthetic: Boolean) =
+        expression?.let { CacheExt.getExpression(it, document, synthetic) }
+    },
+    registerBuilder<PsiTypeCastExpression>(predicate = { castExpressionsCollapse }) { element, document, _ ->
         PsiTypeCastExpressionExt.getTypeCastExpression(element, document)
-}
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt
@@ -3,33 +3,27 @@ package com.intellij.advancedExpressionFolding.processor.core
 import com.intellij.advancedExpressionFolding.expression.controlflow.SemicolonExpression
 import com.intellij.advancedExpressionFolding.processor.token.PsiJavaTokenExt
 import com.intellij.advancedExpressionFolding.processor.token.PsiKeywordExt
-import com.intellij.openapi.editor.Document
 import com.intellij.psi.JavaTokenType
 import com.intellij.psi.PsiJavaToken
 import com.intellij.psi.PsiKeyword
 
-class SemicolonBuilder : BuildExpression<PsiJavaToken>(PsiJavaToken::class.java) {
-    override fun checkConditions(element: PsiJavaToken) =
-        element.tokenType == JavaTokenType.SEMICOLON &&
-                semicolonsCollapse &&
-                !element.isWritable
-
-    override fun buildExpression(element: PsiJavaToken, document: Document, synthetic: Boolean) =
+internal val lexicalExpressionBuilders = listOf(
+    registerBuilder<PsiJavaToken>(predicate = {
+        it.tokenType == JavaTokenType.SEMICOLON &&
+            semicolonsCollapse &&
+            !it.isWritable
+    }) { element, _, _ ->
         SemicolonExpression(
             element,
             element.textRange
         )
-}
-
-class TokenBuilder : BuildExpression<PsiJavaToken>(PsiJavaToken::class.java) {
-    override fun checkConditions(element: PsiJavaToken) =
-        element.tokenType != JavaTokenType.SEMICOLON || element.isWritable
-
-    override fun buildExpression(element: PsiJavaToken, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiJavaToken>(predicate = {
+        it.tokenType != JavaTokenType.SEMICOLON || it.isWritable
+    }) { element, _, _ ->
         PsiJavaTokenExt.createExpression(element)
-}
-
-class KeywordBuilder : BuildExpression<PsiKeyword>(PsiKeyword::class.java) {
-    override fun buildExpression(element: PsiKeyword, document: Document, synthetic: Boolean) =
+    },
+    registerBuilder<PsiKeyword> { element, _, _ ->
         PsiKeywordExt.createExpression(element)
-}
+    }
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/SimpleBuildExpression.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/SimpleBuildExpression.kt
@@ -1,0 +1,33 @@
+package com.intellij.advancedExpressionFolding.processor.core
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+open class SimpleBuildExpression<T : PsiElement>(
+    elementClass: Class<T>,
+    private val predicate: SimpleBuildExpression<T>.(T) -> Boolean = { true },
+    private val builder: SimpleBuildExpression<T>.(T, Document, Boolean) -> Expression?,
+) : BuildExpression<T>(elementClass) {
+
+    override fun checkConditions(element: T): Boolean = predicate(element)
+
+    override fun buildExpression(element: T, document: Document, synthetic: Boolean): Expression? =
+        builder(element, document, synthetic)
+}
+
+fun <T : PsiElement> simpleBuildExpression(
+    elementClass: Class<T>,
+    predicate: SimpleBuildExpression<T>.(T) -> Boolean = { true },
+    builder: SimpleBuildExpression<T>.(T, Document, Boolean) -> Expression?,
+): SimpleBuildExpression<T> = SimpleBuildExpression(elementClass, predicate, builder)
+
+inline fun <reified T : PsiElement> simpleBuildExpression(
+    noinline predicate: SimpleBuildExpression<T>.(T) -> Boolean = { true },
+    noinline builder: SimpleBuildExpression<T>.(T, Document, Boolean) -> Expression?,
+): SimpleBuildExpression<T> = simpleBuildExpression(T::class.java, predicate, builder)
+
+inline fun <reified T : PsiElement> registerBuilder(
+    noinline predicate: SimpleBuildExpression<T>.(T) -> Boolean = { true },
+    noinline builder: SimpleBuildExpression<T>.(T, Document, Boolean) -> Expression?,
+): SimpleBuildExpression<T> = simpleBuildExpression(predicate, builder)


### PR DESCRIPTION
## Summary
- add a SimpleBuildExpression helper with registerBuilder to define PSI folding builders declaratively
- replace the concrete builder subclasses with helper-based lists and aggregate them in ExpressionBuilderManager
- remove XML registrations for built-in builders now registered programmatically

## Testing
- ./gradlew clean build test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e351cd164832e9e88a2d4129d912d)