### PR TITLE
Refactor expression builders around functional registry

### DIFF
--- a/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilderRegistry.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilderRegistry.kt
@@ -1,0 +1,21 @@
+package com.intellij.advancedExpressionFolding.processor.core
+
+import com.intellij.psi.PsiElement
+
+object ExpressionBuilderRegistry {
+    private val definitions:
+        Map<Class<out BuildExpression<*>>, FunctionalExpressionBuilderDefinition<out PsiElement>> by lazy {
+            expressionBuilderDefinitions +
+                controlFlowExpressionBuilderDefinitions +
+                lexicalExpressionBuilderDefinitions +
+                declarationExpressionBuilderDefinitions
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : PsiElement> definition(
+        builderClass: Class<out BuildExpression<T>>,
+    ): FunctionalExpressionBuilderDefinition<T> {
+        return definitions[builderClass] as? FunctionalExpressionBuilderDefinition<T>
+            ?: error("No expression builder registered for ${'$'}{builderClass.name}")
+    }
+}

--- a/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/ExpressionBuilders.kt
@@ -3,21 +3,22 @@ package com.intellij.advancedExpressionFolding.processor.core
 import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.operation.basic.TypeCast
 import com.intellij.advancedExpressionFolding.processor.cache.CacheExt
+import com.intellij.advancedExpressionFolding.processor.controlflow.IfExt
 import com.intellij.advancedExpressionFolding.processor.expression.AssignmentExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.BinaryExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.LiteralExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PrefixExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PsiArrayAccessExpressionExt
-import com.intellij.advancedExpressionFolding.processor.reference.ReferenceExpressionExt
 import com.intellij.advancedExpressionFolding.processor.expression.PsiTypeCastExpressionExt
-import com.intellij.advancedExpressionFolding.processor.controlflow.IfExt
 import com.intellij.advancedExpressionFolding.processor.methodcall.MethodCallExpressionExt
 import com.intellij.advancedExpressionFolding.processor.reference.NewExpressionExt
+import com.intellij.advancedExpressionFolding.processor.reference.ReferenceExpressionExt
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiArrayAccessExpression
 import com.intellij.psi.PsiAssignmentExpression
 import com.intellij.psi.PsiBinaryExpression
 import com.intellij.psi.PsiConditionalExpression
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLiteralExpression
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiNewExpression
@@ -27,89 +28,125 @@ import com.intellij.psi.PsiPrefixExpression
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.PsiTypeCastExpression
 
-class ArrayAccessExpressionBuilder : BuildExpression<PsiArrayAccessExpression>(PsiArrayAccessExpression::class.java) {
-    override fun checkConditions(element: PsiArrayAccessExpression) = getExpressionsCollapse
-
-    override fun buildExpression(element: PsiArrayAccessExpression, document: Document, synthetic: Boolean) =
+internal val expressionBuilderDefinitions:
+    Map<Class<out BuildExpression<*>>, FunctionalExpressionBuilderDefinition<out PsiElement>> = mapOf(
+    ArrayAccessExpressionBuilder::class.java to builderDefinition<PsiArrayAccessExpression>(
+        checkConditions = { getExpressionsCollapse }
+    ) { element, document, _ ->
         PsiArrayAccessExpressionExt.getArrayAccessExpression(element, document)
-}
-
-class MethodCallExpressionBuilder : BuildExpression<PsiMethodCallExpression>(PsiMethodCallExpression::class.java) {
-    override fun buildExpression(element: PsiMethodCallExpression, document: Document, synthetic: Boolean) =
+    },
+    MethodCallExpressionBuilder::class.java to builderDefinition<PsiMethodCallExpression> { element, document, _ ->
         MethodCallExpressionExt.getMethodCallExpression(element, document)
-}
-
-class ReferenceExpressionBuilder : BuildExpression<PsiReferenceExpression>(PsiReferenceExpression::class.java) {
-    override fun buildExpression(element: PsiReferenceExpression, document: Document, synthetic: Boolean) =
+    },
+    ReferenceExpressionBuilder::class.java to builderDefinition<PsiReferenceExpression> { element, _, _ ->
         ReferenceExpressionExt.getReferenceExpression(element)
-}
-
-class NewExpressionBuilder : BuildExpression<PsiNewExpression>(PsiNewExpression::class.java) {
-    override fun buildExpression(element: PsiNewExpression, document: Document, synthetic: Boolean) =
+    },
+    NewExpressionBuilder::class.java to builderDefinition<PsiNewExpression> { element, document, _ ->
         NewExpressionExt.getNewExpression(element, document)
-}
-
-class LiteralExpressionBuilder : BuildExpression<PsiLiteralExpression>(PsiLiteralExpression::class.java) {
-    override fun buildExpression(element: PsiLiteralExpression, document: Document, synthetic: Boolean) =
+    },
+    LiteralExpressionBuilder::class.java to builderDefinition<PsiLiteralExpression> { element, _, _ ->
         LiteralExpressionExt.getLiteralExpression(element)
-}
-
-class AssignmentExpressionBuilder : BuildExpression<PsiAssignmentExpression>(PsiAssignmentExpression::class.java) {
-    override fun buildExpression(element: PsiAssignmentExpression, document: Document, synthetic: Boolean) =
+    },
+    AssignmentExpressionBuilder::class.java to builderDefinition<PsiAssignmentExpression> { element, document, _ ->
         AssignmentExpressionExt.getAssignmentExpression(element, document)
-}
-
-class PolyadicExpressionBuilder : BuildExpression<PsiPolyadicExpression>(PsiPolyadicExpression::class.java) {
-    override fun buildExpression(element: PsiPolyadicExpression, document: Document, synthetic: Boolean) =
+    },
+    PolyadicExpressionBuilder::class.java to builderDefinition<PsiPolyadicExpression> { element, document, _ ->
         IfExt.getPolyadicExpression(element, document)
-}
-
-class BinaryExpressionBuilder : BuildExpression<PsiBinaryExpression>(PsiBinaryExpression::class.java) {
-    override fun buildExpression(element: PsiBinaryExpression, document: Document, synthetic: Boolean) =
+    },
+    BinaryExpressionBuilder::class.java to builderDefinition<PsiBinaryExpression> { element, document, _ ->
         BinaryExpressionExt.getBinaryExpression(element, document)
-}
-
-class ConditionalExpressionBuilder : BuildExpression<PsiConditionalExpression>(PsiConditionalExpression::class.java) {
-    override fun buildExpression(element: PsiConditionalExpression, document: Document, synthetic: Boolean) =
+    },
+    ConditionalExpressionBuilder::class.java to builderDefinition<PsiConditionalExpression> { element, document, _ ->
         IfExt.getConditionalExpression(element, document)
-}
-
-class PrefixExpressionBuilder : BuildExpression<PsiPrefixExpression>(PsiPrefixExpression::class.java) {
-    override fun buildExpression(element: PsiPrefixExpression, document: Document, synthetic: Boolean) =
+    },
+    PrefixExpressionBuilder::class.java to builderDefinition<PsiPrefixExpression> { element, document, _ ->
         PrefixExpressionExt.getPrefixExpression(element, document)
-}
-
-class ParenthesizedExpressionBuilder :
-    BuildExpression<PsiParenthesizedExpression>(PsiParenthesizedExpression::class.java) {
-
-    override fun checkConditions(element: PsiParenthesizedExpression) = castExpressionsCollapse
-
-    override fun buildExpression(
-        element: PsiParenthesizedExpression,
-        document: Document,
-        synthetic: Boolean,
-    ): Expression? {
+    },
+    ParenthesizedExpressionBuilder::class.java to builderDefinition<PsiParenthesizedExpression>(
+        checkConditions = { castExpressionsCollapse }
+    ) { element, document, synthetic ->
         val expression = element.expression
         if (expression is PsiTypeCastExpression) {
             val typeCast = PsiTypeCastExpressionExt.getTypeCastExpression(expression, document)
             if (typeCast != null) {
-                return TypeCast(
+                return@builderDefinition TypeCast(
                     element,
                     element.textRange,
                     typeCast.getObject()
                 )
             }
         }
-        if (expression != null) {
-            return CacheExt.getExpression(expression, document, synthetic)
-        }
-        return null
-    }
-}
-
-class TypeCastExpressionBuilder : BuildExpression<PsiTypeCastExpression>(PsiTypeCastExpression::class.java) {
-    override fun checkConditions(element: PsiTypeCastExpression) = castExpressionsCollapse
-
-    override fun buildExpression(element: PsiTypeCastExpression, document: Document, synthetic: Boolean) =
+        expression?.let { CacheExt.getExpression(it, document, synthetic) }
+    },
+    TypeCastExpressionBuilder::class.java to builderDefinition<PsiTypeCastExpression>(
+        checkConditions = { castExpressionsCollapse }
+    ) { element, document, _ ->
         PsiTypeCastExpressionExt.getTypeCastExpression(element, document)
-}
+    },
+)
+
+class ArrayAccessExpressionBuilder :
+    FunctionalExpressionBuilder<PsiArrayAccessExpression>(
+        ExpressionBuilderRegistry.definition(ArrayAccessExpressionBuilder::class.java)
+    )
+
+class MethodCallExpressionBuilder :
+    FunctionalExpressionBuilder<PsiMethodCallExpression>(
+        ExpressionBuilderRegistry.definition(MethodCallExpressionBuilder::class.java)
+    )
+
+class ReferenceExpressionBuilder :
+    FunctionalExpressionBuilder<PsiReferenceExpression>(
+        ExpressionBuilderRegistry.definition(ReferenceExpressionBuilder::class.java)
+    )
+
+class NewExpressionBuilder :
+    FunctionalExpressionBuilder<PsiNewExpression>(
+        ExpressionBuilderRegistry.definition(NewExpressionBuilder::class.java)
+    )
+
+class LiteralExpressionBuilder :
+    FunctionalExpressionBuilder<PsiLiteralExpression>(
+        ExpressionBuilderRegistry.definition(LiteralExpressionBuilder::class.java)
+    )
+
+class AssignmentExpressionBuilder :
+    FunctionalExpressionBuilder<PsiAssignmentExpression>(
+        ExpressionBuilderRegistry.definition(AssignmentExpressionBuilder::class.java)
+    )
+
+class PolyadicExpressionBuilder :
+    FunctionalExpressionBuilder<PsiPolyadicExpression>(
+        ExpressionBuilderRegistry.definition(PolyadicExpressionBuilder::class.java)
+    )
+
+class BinaryExpressionBuilder :
+    FunctionalExpressionBuilder<PsiBinaryExpression>(
+        ExpressionBuilderRegistry.definition(BinaryExpressionBuilder::class.java)
+    )
+
+class ConditionalExpressionBuilder :
+    FunctionalExpressionBuilder<PsiConditionalExpression>(
+        ExpressionBuilderRegistry.definition(ConditionalExpressionBuilder::class.java)
+    )
+
+class PrefixExpressionBuilder :
+    FunctionalExpressionBuilder<PsiPrefixExpression>(
+        ExpressionBuilderRegistry.definition(PrefixExpressionBuilder::class.java)
+    )
+
+class ParenthesizedExpressionBuilder :
+    FunctionalExpressionBuilder<PsiParenthesizedExpression>(
+        ExpressionBuilderRegistry.definition(ParenthesizedExpressionBuilder::class.java)
+    )
+
+class TypeCastExpressionBuilder :
+    FunctionalExpressionBuilder<PsiTypeCastExpression>(
+        ExpressionBuilderRegistry.definition(TypeCastExpressionBuilder::class.java)
+    )
+
+private inline fun <reified T : PsiElement> builderDefinition(
+    noinline checkConditions: (FunctionalExpressionBuilder<T>.(T) -> Boolean)? = null,
+    noinline build: FunctionalExpressionBuilder<T>.(T, Document, Boolean) -> Expression?,
+): FunctionalExpressionBuilderDefinition<T> =
+    FunctionalExpressionBuilderDefinition(T::class.java, checkConditions, build)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/FunctionalExpressionBuilder.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/FunctionalExpressionBuilder.kt
@@ -1,0 +1,33 @@
+package com.intellij.advancedExpressionFolding.processor.core
+
+import com.intellij.advancedExpressionFolding.expression.Expression
+import com.intellij.openapi.editor.Document
+import com.intellij.psi.PsiElement
+
+open class FunctionalExpressionBuilder<T : PsiElement>(
+    val elementClass: Class<T>,
+    private val checkConditions: (FunctionalExpressionBuilder<T>.(T) -> Boolean)? = null,
+    private val build: FunctionalExpressionBuilder<T>.(T, Document, Boolean) -> Expression?,
+) : BuildExpression<T>(elementClass) {
+
+    constructor(definition: FunctionalExpressionBuilderDefinition<T>) : this(
+        definition.elementClass,
+        definition.check,
+        definition.build,
+    )
+
+    override fun checkConditions(element: T): Boolean =
+        checkConditions?.invoke(this, element) ?: true
+
+    override fun buildExpression(
+        element: T,
+        document: Document,
+        synthetic: Boolean,
+    ): Expression? = build(this, element, document, synthetic)
+}
+
+data class FunctionalExpressionBuilderDefinition<T : PsiElement>(
+    val elementClass: Class<T>,
+    val check: (FunctionalExpressionBuilder<T>.(T) -> Boolean)? = null,
+    val build: FunctionalExpressionBuilder<T>.(T, Document, Boolean) -> Expression?,
+)

--- a/src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt
+++ b/src/com/intellij/advancedExpressionFolding/processor/core/LexicalExpressionBuilders.kt
@@ -1,35 +1,54 @@
 package com.intellij.advancedExpressionFolding.processor.core
 
+import com.intellij.advancedExpressionFolding.expression.Expression
 import com.intellij.advancedExpressionFolding.expression.controlflow.SemicolonExpression
 import com.intellij.advancedExpressionFolding.processor.token.PsiJavaTokenExt
 import com.intellij.advancedExpressionFolding.processor.token.PsiKeywordExt
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.JavaTokenType
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJavaToken
 import com.intellij.psi.PsiKeyword
 
-class SemicolonBuilder : BuildExpression<PsiJavaToken>(PsiJavaToken::class.java) {
-    override fun checkConditions(element: PsiJavaToken) =
+internal val lexicalExpressionBuilderDefinitions:
+    Map<Class<out BuildExpression<*>>, FunctionalExpressionBuilderDefinition<out PsiElement>> = mapOf(
+    SemicolonBuilder::class.java to builderDefinition<PsiJavaToken>(checkConditions = { element ->
         element.tokenType == JavaTokenType.SEMICOLON &&
-                semicolonsCollapse &&
-                !element.isWritable
-
-    override fun buildExpression(element: PsiJavaToken, document: Document, synthetic: Boolean) =
+            semicolonsCollapse &&
+            !element.isWritable
+    }) { element, _, _ ->
         SemicolonExpression(
             element,
             element.textRange
         )
-}
-
-class TokenBuilder : BuildExpression<PsiJavaToken>(PsiJavaToken::class.java) {
-    override fun checkConditions(element: PsiJavaToken) =
+    },
+    TokenBuilder::class.java to builderDefinition<PsiJavaToken>(checkConditions = { element ->
         element.tokenType != JavaTokenType.SEMICOLON || element.isWritable
-
-    override fun buildExpression(element: PsiJavaToken, document: Document, synthetic: Boolean) =
+    }) { element, _, _ ->
         PsiJavaTokenExt.createExpression(element)
-}
-
-class KeywordBuilder : BuildExpression<PsiKeyword>(PsiKeyword::class.java) {
-    override fun buildExpression(element: PsiKeyword, document: Document, synthetic: Boolean) =
+    },
+    KeywordBuilder::class.java to builderDefinition<PsiKeyword> { element, _, _ ->
         PsiKeywordExt.createExpression(element)
-}
+    },
+)
+
+class SemicolonBuilder :
+    FunctionalExpressionBuilder<PsiJavaToken>(
+        ExpressionBuilderRegistry.definition(SemicolonBuilder::class.java)
+    )
+
+class TokenBuilder :
+    FunctionalExpressionBuilder<PsiJavaToken>(
+        ExpressionBuilderRegistry.definition(TokenBuilder::class.java)
+    )
+
+class KeywordBuilder :
+    FunctionalExpressionBuilder<PsiKeyword>(
+        ExpressionBuilderRegistry.definition(KeywordBuilder::class.java)
+    )
+
+private inline fun <reified T : PsiElement> builderDefinition(
+    noinline checkConditions: (FunctionalExpressionBuilder<T>.(T) -> Boolean)? = null,
+    noinline build: FunctionalExpressionBuilder<T>.(T, Document, Boolean) -> Expression?,
+): FunctionalExpressionBuilderDefinition<T> =
+    FunctionalExpressionBuilderDefinition(T::class.java, checkConditions, build)


### PR DESCRIPTION
## Summary
- introduce a reusable FunctionalExpressionBuilder implementation and registry for reusable builder definitions
- rework the expression, control-flow, lexical, and declaration builders to delegate through the registry indirection
- ensure extension lookups pull definitions from the shared registry to add the extra runtime layer while preserving behavior

## Testing
- ./gradlew clean build test --console=plain --no-configuration-cache

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e35232c04832e94224ad9437e1f43)