### PR TITLE
Fix screenshot labeler workflow run step formatting

### DIFF
--- a/.github/workflows/pr-screenshot-labeler.yml
+++ b/.github/workflows/pr-screenshot-labeler.yml
@@ -127,4 +127,5 @@ jobs:
 
             core.setOutput('labels_added', String(appliedCount));
       - name: Display screenshot labels added
-        run: echo "Screenshot labels added: ${{ steps.apply.outputs.labels_added }}"
+        run: |
+          echo "Screenshot labels added: ${{ steps.apply.outputs.labels_added }}"


### PR DESCRIPTION
## Summary
- adjust the echo step to use a literal block so the workflow parses correctly

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ede77c76c832e892c19e0cba37a69)